### PR TITLE
Match agent mention by first name within full display-name alt

### DIFF
--- a/lib/basecamp_agent_connector/event.rb
+++ b/lib/basecamp_agent_connector/event.rb
@@ -67,8 +67,11 @@ class BasecampAgentConnector::Event
   def mentions?(agent)
     return false if agent.name.nil?
 
+    # Basecamp renders the mention avatar's alt as the full display name
+    # ("Marie Chef (Agent)"), while agent.name is the first name ("Marie"), so
+    # match the name as the leading token of alt rather than the whole value.
     body = content.to_s
-    body.include?(MENTION_CONTENT_TYPE) && body.match?(/<img[^>]*\balt="#{Regexp.escape(agent.name)}"/i)
+    body.include?(MENTION_CONTENT_TYPE) && body.match?(/<img[^>]*\balt="#{Regexp.escape(agent.name)}(?: |")/i)
   end
 
   def to_emitted_hash

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -19,7 +19,9 @@ class EventTest < Minitest::Test
     agent = agent_identity(name: "Clawdito")
 
     assert with_content("<p>Hey #{mention_html('Clawdito')} please</p>").mentions?(agent)
+    assert with_content("<p>Hey #{mention_html('Clawdito', display_name: 'Clawdito')} please</p>").mentions?(agent)
     refute with_content("<p>Hey #{mention_html('Someone')} please</p>").mentions?(agent)
+    refute with_content("<p>Hey #{mention_html('Clawdito', display_name: 'Clawditolina')} please</p>").mentions?(agent)
     refute with_content("<p>plain text saying Clawdito without a mention</p>").mentions?(agent)
     refute with_content(nil).mentions?(agent)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -68,9 +68,12 @@ module PayloadHelpers
     }.merge(overrides)
   end
 
-  def mention_html(name, person_id: 51177542)
+  # Basecamp renders the avatar alt/title with the person's full display name
+  # while the visible figcaption shows the first name, so default display_name to
+  # a full name distinct from the first name the agent is matched on.
+  def mention_html(name, person_id: 51177542, display_name: "#{name} Bot (Agent)")
     %(<bc-attachment sgid="SGID" content-type="application/vnd.basecamp.mention"><figure>) +
-      %(<img data-avatar-for-person-id="#{person_id}" alt="#{name}" title="#{name}, Agent" class="avatar">) +
+      %(<img data-avatar-for-person-id="#{person_id}" alt="#{display_name}" title="#{display_name}, Agent" class="avatar">) +
       %(<figcaption>#{name}</figcaption></figure></bc-attachment>)
   end
 


### PR DESCRIPTION
## Problem

`bin/connect` silently dropped legitimate `@mentions`. A message that met every trust condition (authored by the operator, real mention of the agent, subscribed recording type, posted after registration) never reached STDOUT, and no STDERR diagnostic was emitted.

The cause is in `Event#mentions?`:

```ruby
body.match?(/<img[^>]*\balt="#{Regexp.escape(agent.name)}"/i)
```

`agent.name` is the **first name** (`identity["first_name"]`, e.g. `"Marie"`), but Basecamp renders the mention avatar with the **full display name** (`alt="Marie Chef (Agent)"`). The regex required the alt value to equal the first name exactly, so it never matched — and the drop happens at the `actionable?` stage, which isn't logged (only failed corroboration is), hence the silence.

The test suite missed this because the `mention_html` fixture rendered `alt="#{name}"` with the same surname-less name everywhere — an avatar shape that never occurs in real Basecamp.

## Fix

- `event.rb`: match the first name as the **leading token** of the alt value (`#{name}(?: |")`), so it matches both the full display name and a bare first name, while still rejecting partial-word collisions (e.g. `"Clawditolina"`).
- `test_helper.rb`: `mention_html` now renders a realistic full display name in alt/title with the first name in the figcaption.
- `event_test.rb`: added assertions for the exact-first-name alt and a partial-word non-match.

Verified the patched matcher returns `true` against the real HTML of a live `@mention` message.