### PR TITLE
Match mentions when webhook orders content before content-type

### DIFF
--- a/lib/basecamp_agent_connector/event.rb
+++ b/lib/basecamp_agent_connector/event.rb
@@ -8,7 +8,18 @@ class BasecampAgentConnector::Event
   # The webhook delivers a mention as an unexpanded attachment carrying only an
   # SGID and content-type — no rendered name. The agent's account-scoped Person
   # id is encoded inside the SGID, so match on that id rather than a display name.
-  MENTION_ATTACHMENT = /<bc-attachment\b[^>]*content-type="#{Regexp.escape(MENTION_CONTENT_TYPE)}"[^>]*>/i
+  #
+  # Match the whole opening tag quote-aware: a mention attachment also carries a
+  # `content="…"` attribute whose value is embedded markup full of `>` characters,
+  # and webhooks order the attributes sgid, content, content-type (the API renders
+  # them sgid, content-type, content). A `[^>]*` matcher would stop at the first
+  # `>` inside that content value and miss a trailing content-type, so consume
+  # quoted values whole and test the attributes against the captured tag instead.
+  BC_ATTACHMENT_TAG = /<bc-attachment\b(?:"[^"]*"|'[^']*'|[^"'>])*>/i
+
+  MENTION_CONTENT_TYPE_ATTRIBUTE = /content-type="#{Regexp.escape(MENTION_CONTENT_TYPE)}"/i
+
+  SGID_ATTRIBUTE = /\bsgid="([^"]+)"/
 
   PERSON_GID = %r{gid://bc3/Person/(\d+)}
 
@@ -95,7 +106,10 @@ class BasecampAgentConnector::Event
     end
 
     def mention_attachment_sgids
-      content.to_s.scan(MENTION_ATTACHMENT).map { |attachment| attachment[/\bsgid="([^"]+)"/, 1] }.compact
+      content.to_s.scan(BC_ATTACHMENT_TAG)
+        .select { |tag| tag.match?(MENTION_CONTENT_TYPE_ATTRIBUTE) }
+        .map { |tag| tag[SGID_ATTRIBUTE, 1] }
+        .compact
     end
 
     def person_ids_in(sgid)

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -26,6 +26,13 @@ class EventTest < Minitest::Test
     refute with_content("<p>#{mention_html(person_id: 200)}</p>").mentions?(agent_identity(person_id: nil))
   end
 
+  def test_mentions_the_agent_in_a_real_webhook_payload
+    agent = agent_identity(person_id: 200)
+
+    assert with_content("<p>are you listening #{webhook_mention_html(person_id: 200)} ?</p>").mentions?(agent)
+    refute with_content("<p>are you listening #{webhook_mention_html(person_id: 999)} ?</p>").mentions?(agent)
+  end
+
   def test_to_emitted_hash_keeps_only_known_fields
     recording = sample_recording("status" => "active", "bookmark_url" => "https://example.org/b")
     event = BasecampAgentConnector::Event.from_payload(sample_payload("recording" => recording))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -76,6 +76,14 @@ module PayloadHelpers
     %(<bc-attachment sgid="#{sgid}" content-type="application/vnd.basecamp.mention"></bc-attachment>)
   end
 
+  # The real webhook payload orders the attributes sgid, content, content-type and
+  # carries embedded mention markup (full of `>` characters) in the content value.
+  def webhook_mention_html(person_id:)
+    sgid = "#{Base64.strict_encode64("gid://bc3/Person/#{person_id}")}--signature"
+    embedded = %(<bc-mention class=&quot;mentionable-person&quot; gid=&quot;gid://bc3/Person/#{person_id}&quot;><span><img data-avatar-for-person-id=&quot;#{person_id}&quot;>Marie</span></bc-mention>)
+    %(<bc-attachment sgid="#{sgid}" content="#{embedded}" content-type="application/vnd.basecamp.mention"></bc-attachment>)
+  end
+
   def operator_identity
     BasecampAgentConnector::Identity.new(id: 100, email: "operator@example.com")
   end


### PR DESCRIPTION
## Problem

The connector received mentions fine (webhooks delivered, server replied `200`) but **silently dropped** them. They never reached STDOUT, so no agent was ever dispatched.

The mention matcher used:

```ruby
/<bc-attachment\b[^>]*content-type="...mention"[^>]*>/i
```

Basecamp's **webhook** payload orders the attachment attributes as `sgid`, `content`, `content-type`, and the `content` value is embedded mention markup full of literal `>` characters. The `[^>]*` before `content-type` can't cross those `>`, so the regex never matched a real delivery → `mentions?` returned `false` → `actionable?` was `false` → dropped with no diagnostic (non-actionable events aren't logged).

Tests passed only because their fixtures used the **API** attribute order (`sgid`, `content-type`, `content`) with empty `content`, never exercising this case.

## Fix

Match the whole `<bc-attachment>` opening tag **quote-aware** so a `content="…"` value with embedded `>` is consumed whole, then test content-type and extract the sgid against the captured tag — order-independent:

```ruby
BC_ATTACHMENT_TAG = /<bc-attachment\b(?:"[^"]*"|'[^']*'|[^"'>])*>/i
```

Added a regression test (`test_mentions_the_agent_in_a_real_webhook_payload`) and a `webhook_mention_html` helper reproducing the real webhook attribute order. Verified against the actual captured payload. All 41 tests pass.