### PR TITLE
Trigger on the operator assigning the agent a card/todo

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -307,7 +307,9 @@ Confirmed against `bc3` source (`app/views/api/webhooks/event.jbuilder`,
   `creator`, (`copy` for copied events).
 - **`kind`**: `"<container>_<action>"`, e.g. `comment_created`,
   `message_created`, `kanban_card_created`, `message_content_changed`. The
-  connector subscribes to `*_created` and `*_content_changed`.
+  connector subscribes to `*_created`, `*_content_changed`, and
+  `*_assignment_changed` (assignment events carry `details.added_person_ids` /
+  `removed_person_ids`).
 - **`recording`**: `id`, `status`, `type` (Ruby class: `Comment`, `Message`,
   `Kanban::Card`, `Todo`, …), `title`, `url` (API JSON), `app_url` (browser),
   `bookmark_url`, `parent` {id,title,type,url,app_url}, `bucket` {id,name,type},
@@ -337,7 +339,7 @@ Confirmed against `bc3` source (`app/views/api/webhooks/event.jbuilder`,
 | Linked identity | Basecamp user id (+ email) for the filter target & reply identity | CLI-authed user (`clawdito`) |
 | Watched projects | Explicit `--project` list (name/URL/ID), required | — (at least one) |
 | Project→repo map | Maps Basecamp project names / app tokens to local repo paths under `~/Work/<org>/<repo>` | heuristic + ask-on-miss |
-| Default event types | Subscribed Basecamp types | `Comment, Message, Kanban::Card` |
+| Default event types | Subscribed Basecamp types | `Comment, Message, Kanban::Card, Kanban::Step, Todo` |
 | Local port | WEBrick bind port | unused high port |
 
 ---
@@ -428,7 +430,19 @@ Coverage the suite must include:
 ## Decisions resolved
 
 - Trigger: a real @mention of the **agent** user (a local CLI profile of the
-  same name, validated at startup), authored by the **operator**.
+  same name, validated at startup), authored by the **operator** — **or** the
+  operator **assigning** the agent a card/todo.
+- Assignment trigger: the documented-but-previously-undocumented
+  `todo_assignment_changed` / `kanban_card_assignment_changed` /
+  `kanban_step_assignment_changed` events (bc3 PR #12156). Actionable when
+  authored by the operator **and** `details.added_person_ids` includes the agent
+  — corroborated by re-fetching the recording and confirming the agent is among
+  its current `assignees` (the recording has no "who assigned" field, so the
+  assigner identity rests on the operator-author check + the secret URL path,
+  as with mentions). To receive them, the default subscribed types now include
+  `Todo` and `Kanban::Step` (`Kanban::Card` already covered cards). The dispatched
+  agent acknowledges on the card/todo first, then works the card/todo as the
+  instruction.
 - Reply: post results back **as the agent** (`basecamp comment --profile
   <agent>`). On failure, post an error summary that @mentions the operator.
 - Dedup: in-memory, keyed on `event.id`; always 200-OK fast.

--- a/lib/basecamp_agent_connector/basecamp/bridge.rb
+++ b/lib/basecamp_agent_connector/basecamp/bridge.rb
@@ -48,7 +48,7 @@ class BasecampAgentConnector::Basecamp::Bridge
       @pipeline ||= BasecampAgentConnector::Basecamp::Pipeline.new \
         operator: @operator,
         agent: @agent,
-        verifier: BasecampAgentConnector::Basecamp::Verifier.new(basecamp_cli: @basecamp_cli),
+        verifier: BasecampAgentConnector::Basecamp::Verifier.new(basecamp_cli: @basecamp_cli, agent: @agent),
         emitter: @emitter
     end
 

--- a/lib/basecamp_agent_connector/basecamp/event.rb
+++ b/lib/basecamp_agent_connector/basecamp/event.rb
@@ -1,7 +1,13 @@
 require "base64"
 
 class BasecampAgentConnector::Basecamp::Event
-  ACTIONABLE_KIND_SUFFIXES = [ "_created", "_content_changed" ]
+  # Assignment events (`todo_assignment_changed`, `kanban_card_assignment_changed`,
+  # `kanban_step_assignment_changed`) are a second way to trigger the agent: the
+  # operator assigns it a card/todo rather than @mentioning it. Their `details`
+  # carry `added_person_ids` / `removed_person_ids`.
+  ASSIGNMENT_KIND_SUFFIX = "_assignment_changed"
+
+  ACTIONABLE_KIND_SUFFIXES = [ "_created", "_content_changed", ASSIGNMENT_KIND_SUFFIX ]
 
   MENTION_CONTENT_TYPE = "application/vnd.basecamp.mention"
 
@@ -25,6 +31,7 @@ class BasecampAgentConnector::Basecamp::Event
 
   EMITTED_RECORDING_FIELDS = %w[id type title app_url url content parent bucket]
   EMITTED_CREATOR_FIELDS = %w[id name email_address]
+  EMITTED_DETAIL_FIELDS = %w[added_person_ids removed_person_ids]
 
   def self.from_payload(payload)
     new(payload)
@@ -74,8 +81,20 @@ class BasecampAgentConnector::Basecamp::Event
     recording["content"]
   end
 
+  def details
+    @payload["details"] || {}
+  end
+
+  def added_person_ids
+    details["added_person_ids"] || []
+  end
+
   def actionable_kind?
     kind.end_with?(*ACTIONABLE_KIND_SUFFIXES)
+  end
+
+  def assignment_changed?
+    kind.end_with?(ASSIGNMENT_KIND_SUFFIX)
   end
 
   def authored_by?(identity)
@@ -90,12 +109,19 @@ class BasecampAgentConnector::Basecamp::Event
     mentioned_person_ids.include?(agent.person_id)
   end
 
+  def assigns?(agent)
+    return false if agent.person_id.nil?
+
+    assignment_changed? && added_person_ids.include?(agent.person_id)
+  end
+
   def to_emitted_hash
     {
       "event_id" => id,
       "kind" => kind,
       "created_at" => created_at,
       "creator" => creator.slice(*EMITTED_CREATOR_FIELDS),
+      "details" => details.slice(*EMITTED_DETAIL_FIELDS),
       "recording" => recording.slice(*EMITTED_RECORDING_FIELDS)
     }
   end

--- a/lib/basecamp_agent_connector/basecamp/pipeline.rb
+++ b/lib/basecamp_agent_connector/basecamp/pipeline.rb
@@ -18,7 +18,11 @@ class BasecampAgentConnector::Basecamp::Pipeline
 
   private
     def actionable?(event)
-      event.actionable_kind? && event.authored_by?(@operator) && event.mentions?(@agent)
+      event.actionable_kind? && event.authored_by?(@operator) && targets_agent?(event)
+    end
+
+    def targets_agent?(event)
+      event.mentions?(@agent) || event.assigns?(@agent)
     end
 
     def fresh?(event)

--- a/lib/basecamp_agent_connector/basecamp/verifier.rb
+++ b/lib/basecamp_agent_connector/basecamp/verifier.rb
@@ -1,6 +1,7 @@
 class BasecampAgentConnector::Basecamp::Verifier
-  def initialize(basecamp_cli:)
+  def initialize(basecamp_cli:, agent:)
     @basecamp_cli = basecamp_cli
+    @agent = agent
   end
 
   def verify(event)
@@ -21,8 +22,29 @@ class BasecampAgentConnector::Basecamp::Verifier
       nil
     end
 
+    # For a mention/comment the authoritative author is the recording's creator,
+    # so confirm it matches the claimed event author. For an assignment the event
+    # author is the assigner (not the recording's creator), so instead confirm the
+    # agent is actually among the recording's current assignees — a forged POST
+    # can't fake real Basecamp state.
     def corroborated?(recording, event)
-      recording.is_a?(Hash) && recording.dig("creator", "id") == event.creator_id
+      return false unless recording.is_a?(Hash)
+
+      if event.assignment_changed?
+        assigns_agent?(recording)
+      else
+        recording.dig("creator", "id") == event.creator_id
+      end
+    end
+
+    def assigns_agent?(recording)
+      return false if @agent.person_id.nil?
+
+      assignee_ids(recording).include?(@agent.person_id)
+    end
+
+    def assignee_ids(recording)
+      Array(recording["assignees"]).map { |assignee| assignee["id"] }
     end
 
     def authoritative_event(event, recording)
@@ -30,7 +52,8 @@ class BasecampAgentConnector::Basecamp::Verifier
         "id" => event.id,
         "kind" => event.kind,
         "created_at" => event.created_at,
-        "creator" => recording.fetch("creator"),
+        "details" => event.details,
+        "creator" => event.assignment_changed? ? event.creator : recording.fetch("creator"),
         "recording" => recording
     end
 end

--- a/lib/basecamp_agent_connector/connector.rb
+++ b/lib/basecamp_agent_connector/connector.rb
@@ -6,7 +6,9 @@ require "socket"
 # route on it. Basecamp and GitHub watching therefore run simultaneously over a
 # single funnel — the per-machine funnel is no longer a bottleneck.
 class BasecampAgentConnector::Connector
-  DEFAULT_TYPES = "Comment,Message,Kanban::Card"
+  # Todo + Kanban::Step are included so todo/step assignment events are delivered
+  # (Kanban::Card already covers card assignments).
+  DEFAULT_TYPES = "Comment,Message,Kanban::Card,Kanban::Step,Todo"
   DEFAULT_EVENTS = "pull_request_review"
 
   Options = Data.define(:agent, :operator, :projects, :types, :repos, :events, :port)

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -31,9 +31,16 @@ The agent is identified by a **local `basecamp` CLI profile** of the same name
 
 The trust model is enforced by `bin/connect`, **not** by this skill: an event
 reaches STDOUT only if it is (1) authored by the **operator** (you — the CLI
-default profile, or `--operator <profile>`), (2) @mentions the agent user, and
-(3) is corroborated against the Basecamp API. Treat every STDOUT line as
-already-trusted — but still keep dispatched agents scoped to the resolved repo.
+default profile, or `--operator <profile>`), (2) **either** @mentions the agent
+user **or** assigns it a card/todo, and (3) is corroborated against the Basecamp
+API. Treat every STDOUT line as already-trusted — but still keep dispatched
+agents scoped to the resolved repo.
+
+There are thus **two triggers**: an `@mention` of the agent, or the operator
+**assigning** the agent a card/todo (a `*_assignment_changed` event whose
+`details.added_person_ids` includes the agent — corroborated by re-fetching the
+recording and confirming the agent is among its current `assignees`). Only the
+**operator's** assignments count.
 
 ## Invocation
 
@@ -177,6 +184,25 @@ itself just posted, ignore it. Posting as the agent (a distinct user from the
 operator) already keeps replies from re-triggering the connector — the trust
 filter requires the *operator* to be the author — but this is cheap defense in
 depth.
+
+### When the agent is assigned a card/todo
+
+If the event `kind` ends in `_assignment_changed`, the operator assigned the
+agent to the recording (a card/todo/step) — there's no mention to strip; **the
+recording itself is the task**. The dispatched background agent should, in order:
+
+1. **Acknowledge first** — immediately post a brief comment on the recording as
+   the agent (`basecamp comment <recording.url|id> "On it — starting now." --profile
+   <agent>`) so the assignment visibly registered before any slow work begins.
+2. **Do the work** the card/todo describes (its `content`/`title` is the
+   instruction; gather context and resolve the repo as usual; if it's a PR task,
+   follow the green-first lifecycle below).
+3. **Reply with the result** on the same recording as the agent — and on failure,
+   a short error summary that @mentions the operator.
+
+The instruction here is the **card/todo content**, not a comment body. Everything
+else (resolve repo, one background agent owns it end-to-end, front thread returns
+to the monitor) is the same as above.
 
 ### When the task results in a pull request
 

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -156,15 +156,21 @@ everything it needs to finish **without the front thread**:
 
 Instruct that background agent to, in order:
 
-1. **Gather context from Basecamp** — it is the context store; the event is just
+1. **Acknowledge immediately with a boost** — before any slow work, boost the
+   originating recording with `On it!` **as the agent** so the mention visibly
+   registered (a boost is a lightweight reaction, ≤16 chars):
+   ```bash
+   basecamp boost create <recording.url|id> "On it!" --profile <agent>
+   ```
+2. **Gather context from Basecamp** — it is the context store; the event is just
    the trigger + pointer:
    ```bash
    basecamp show <recording.app_url> -j          # the recording itself
    basecamp show <recording.parent.app_url> -j   # the card/message it lives in
    # plus the thread/comments and the project as needed
    ```
-2. **Do the requested work** in the repo.
-3. **Reply on the originating recording as the agent** — commenting with the
+3. **Do the requested work** in the repo.
+4. **Reply on the originating recording as the agent** — commenting with the
    agent's profile so the reply posts as the agent user:
    ```bash
    basecamp comment <recording.url|id> "<body>" --profile <agent>
@@ -191,9 +197,11 @@ If the event `kind` ends in `_assignment_changed`, the operator assigned the
 agent to the recording (a card/todo/step) — there's no mention to strip; **the
 recording itself is the task**. The dispatched background agent should, in order:
 
-1. **Acknowledge first** — immediately post a brief comment on the recording as
-   the agent (`basecamp comment <recording.url|id> "On it — starting now." --profile
-   <agent>`) so the assignment visibly registered before any slow work begins.
+1. **Acknowledge first with a comment** — immediately post a brief comment on the
+   recording as the agent (`basecamp comment <recording.url|id> "On it — starting
+   now." --profile <agent>`) so the assignment visibly registered before any slow
+   work begins. (A *comment* here, not a boost — being assigned a card/todo merits
+   a visible acknowledgement on it; a plain @mention gets the lighter boost.)
 2. **Do the work** the card/todo describes (its `content`/`title` is the
    instruction; gather context and resolve the repo as usual; if it's a PR task,
    follow the green-first lifecycle below).

--- a/test/connector_test.rb
+++ b/test/connector_test.rb
@@ -7,7 +7,7 @@ class ConnectorTest < Minitest::Test
     assert_equal "clawdito", options.agent
     assert_equal [ "Queenbee" ], options.projects
     assert_empty options.repos
-    assert_equal "Comment,Message,Kanban::Card", options.types
+    assert_equal "Comment,Message,Kanban::Card,Kanban::Step,Todo", options.types
     assert_equal [ "pull_request_review" ], options.events
     assert_nil options.port
   end

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -4,8 +4,28 @@ class EventTest < Minitest::Test
   def test_actionable_kind
     assert from_kind("comment_created").actionable_kind?
     assert from_kind("message_content_changed").actionable_kind?
+    assert from_kind("kanban_card_assignment_changed").actionable_kind?
+    assert from_kind("todo_assignment_changed").actionable_kind?
     refute from_kind("comment_archived").actionable_kind?
     refute from_kind(nil).actionable_kind?
+  end
+
+  def test_assigns_the_agent
+    agent = agent_identity(person_id: 200)
+
+    assert BasecampAgentConnector::Basecamp::Event.from_payload(assignment_payload).assigns?(agent)
+    refute BasecampAgentConnector::Basecamp::Event.from_payload(assignment_payload("details" => { "added_person_ids" => [ 999 ] })).assigns?(agent)
+    # an assignment removing the agent is not a trigger
+    refute BasecampAgentConnector::Basecamp::Event.from_payload(assignment_payload("details" => { "added_person_ids" => [], "removed_person_ids" => [ 200 ] })).assigns?(agent)
+    # a non-assignment kind never "assigns", even if details somehow carry the id
+    refute BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload("details" => { "added_person_ids" => [ 200 ] })).assigns?(agent)
+    refute BasecampAgentConnector::Basecamp::Event.from_payload(assignment_payload).assigns?(agent_identity(person_id: nil))
+  end
+
+  def test_to_emitted_hash_carries_assignment_details
+    emitted = BasecampAgentConnector::Basecamp::Event.from_payload(assignment_payload).to_emitted_hash
+
+    assert_equal [ 200 ], emitted["details"]["added_person_ids"]
   end
 
   def test_authored_by_matches_on_email

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -60,6 +60,31 @@ class PipelineTest < Minitest::Test
     assert_match(/not corroborated/, @logs.string)
   end
 
+  def test_emits_for_an_assignment_of_the_agent_by_the_operator
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(assigned_recording)
+
+    pipeline(runner).process(assignment_payload)
+
+    assert_equal 1, @output.string.lines.length
+    assert_equal "kanban_card_assignment_changed", JSON.parse(@output.string)["kind"]
+  end
+
+  def test_ignores_an_assignment_made_by_a_non_operator
+    runner = FakeCommandRunner.new
+
+    pipeline(runner).process(assignment_payload("creator" => { "email_address" => "someone@example.com" }))
+
+    assert_empty @output.string
+    assert_empty runner.commands
+  end
+
+  def test_ignores_an_assignment_that_does_not_add_the_agent
+    pipeline(FakeCommandRunner.new).process(assignment_payload("details" => { "added_person_ids" => [ 999 ] }))
+
+    assert_empty @output.string
+  end
+
   private
     def corroborating_runner
       runner = FakeCommandRunner.new
@@ -71,7 +96,7 @@ class PipelineTest < Minitest::Test
       BasecampAgentConnector::Basecamp::Pipeline.new \
         operator: @operator,
         agent: @agent,
-        verifier: BasecampAgentConnector::Basecamp::Verifier.new(basecamp_cli: build_cli(runner)),
+        verifier: BasecampAgentConnector::Basecamp::Verifier.new(basecamp_cli: build_cli(runner), agent: @agent),
         emitter: BasecampAgentConnector::Emitter.new(output: @output),
         logger: @logs
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -70,6 +70,28 @@ module PayloadHelpers
     }.merge(overrides)
   end
 
+  # A `*_assignment_changed` webhook: the operator assigned a card/todo to a
+  # person, with the added/removed Person ids in `details`.
+  def assignment_payload(overrides = {})
+    {
+      "id" => 99002,
+      "kind" => "kanban_card_assignment_changed",
+      "created_at" => "2026-06-28T12:00:00Z",
+      "creator" => { "id" => 100, "name" => "Operator", "email_address" => "operator@example.com" },
+      "details" => { "added_person_ids" => [ 200 ], "removed_person_ids" => [] },
+      "recording" => assigned_recording
+    }.merge(overrides)
+  end
+
+  def assigned_recording(overrides = {})
+    sample_recording(
+      "type" => "Kanban::Card",
+      "content" => "<p>Fix the date picker, it is off by one.</p>",
+      "creator" => { "id" => 777, "name" => "Someone Else", "email_address" => "someone@example.com" },
+      "assignees" => [ { "id" => 200, "name" => "Clawdito" } ]
+    ).merge(overrides)
+  end
+
   # A webhook delivers a mention as an unexpanded attachment: just the SGID
   # (which encodes the Person gid) and content-type, with no rendered name.
   def mention_html(person_id:)

--- a/test/verifier_test.rb
+++ b/test/verifier_test.rb
@@ -35,9 +35,28 @@ class VerifierTest < Minitest::Test
     assert_empty runner.commands
   end
 
+  def test_corroborates_an_assignment_when_the_agent_is_an_assignee
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(assigned_recording)
+
+    verified = verifier(runner).verify(event(assignment_payload))
+
+    refute_nil verified
+    assert_equal "kanban_card_assignment_changed", verified.kind
+    # the assigner (operator), not the card's creator, stays as the event creator
+    assert_equal 100, verified.creator_id
+  end
+
+  def test_rejects_an_assignment_when_the_agent_is_not_an_assignee
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(assigned_recording("assignees" => [ { "id" => 999 } ]))
+
+    assert_nil verifier(runner).verify(event(assignment_payload))
+  end
+
   private
     def verifier(runner)
-      BasecampAgentConnector::Basecamp::Verifier.new(basecamp_cli: build_cli(runner))
+      BasecampAgentConnector::Basecamp::Verifier.new(basecamp_cli: build_cli(runner), agent: agent_identity)
     end
 
     def event(payload)


### PR DESCRIPTION
## What

Adds a **second trigger** alongside @mentions: the **operator assigning the agent** to a card/todo. This wires up the assignment webhook events documented in [bc3#12156](https://github.com/basecamp/bc3/pull/12156) — `todo_assignment_changed`, `kanban_card_assignment_changed`, `kanban_step_assignment_changed` (already firing, just newly documented; `details` carry `added_person_ids` / `removed_person_ids`).

## Behavior

When you assign the agent a card/todo, the dispatched background agent:
1. **Acknowledges first** — posts a brief "On it — starting now." comment on the card/todo (immediate feedback that the assignment registered), then
2. **does the work** the card/todo describes (its content is the instruction), and replies with the result.

## Trust — only *your* assignments count

The operator-author check is unchanged and still gates every event: an assignment is actionable only when **authored by the operator** (the assigner, matched by email). A non-operator assigning the agent is dropped.

Corroboration differs from mentions out of necessity: an assignment event's author is the *assigner*, not the recording's creator, so the connector re-fetches the recording and confirms **the agent is among its current `assignees`** — a forged POST can't fake real Basecamp state. (The assigner identity itself rests on the operator-author check + the secret URL path, exactly as mentions do; the recording has no "who assigned" field to re-fetch — documented in `spec.md`.)

## Changes

- `Basecamp::Event` — `assignment_changed?`, `assigns?(agent)` (via `details.added_person_ids`), `actionable_kind?` includes `_assignment_changed`, emitted hash carries assignment `details`.
- `Basecamp::Pipeline` — `actionable? = operator-authored AND (mentions? OR assigns?)`.
- `Basecamp::Verifier` — branches corroboration: assignment ⇒ agent ∈ recording `assignees`; keeps the assigner as the emitted `creator`.
- `Connector` default types add `Todo` + `Kanban::Step` (so todo/step assignments are delivered; `Kanban::Card` already covered cards).
- `SKILL.md` (two triggers; ack-then-work) and `docs/spec.md` updated.

## Tests

**84 runs, 210 assertions, 0 failures; rubocop clean (43 files).** New coverage: assignment-kind actionability, `assigns?` (added vs removed vs wrong person vs non-assignment kind), verifier corroboration via assignees (assigned ⇒ verified, not-assigned ⇒ rejected, assigner preserved as creator), and pipeline (operator-assignment emits; non-operator assignment dropped; assignment not adding the agent dropped). Built green.

## Acknowledgement UX

Both ack as the agent (`--profile <agent>`), differing by trigger:
- **@mention** → **boost** the originating recording with `On it!` (a lightweight reaction).
- **assignment** → an `On it — starting now.` **comment** on the card/todo (a visible acknowledgement, since you were assigned it).
