### PR TITLE
Share the Tailscale Funnel: mount only our own paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,14 @@ the agent runs and replies.
 
 **Watch several projects at once** — repeat `--project` (name, URL, or ID).
 A single connector run registers one webhook per project and multiplexes them all
-onto one funnel, so the same `@agent` watches every listed project simultaneously:
+onto one funnel path, so the same `@agent` watches every listed project simultaneously:
 
 ```
 /basecamp-connect @Clawdito --project "BC5.1" --project "On Call" --project 20361308
 ```
 
 - `--project` takes a **name, URL, or ID** — the CLI resolves it.
-- Watch GitHub PR reviews too, over the **same** funnel: add `--repo <owner>/<repo>`
+- Watch GitHub PR reviews too, over the **same** server: add `--repo <owner>/<repo>`
   (repeatable). You need at least one `--project` or `--repo`; `--project` also
   needs an `@agent`.
 
@@ -104,7 +104,7 @@ onto one funnel, so the same `@agent` watches every listed project simultaneousl
 
 While running, the connector exposes a **public URL** (via Tailscale Funnel) and
 registers a **real webhook** on each watched project. **Always stop it when
-you’re done** — stopping deletes every webhook and closes the funnel
+you’re done** — stopping deletes every webhook and unmounts its funnel paths
 automatically. In Claude Code, ending the skill does this; from a terminal, press
 **Ctrl-C**. Nothing is left running or exposed.
 
@@ -225,9 +225,12 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
    (refreshing an expired token once). Warns if agent == operator.
 2. **Open the endpoint.** Starts a WEBrick server on `127.0.0.1:<port>` that only
    accepts `POST /hook/<random-secret>`; everything else is 404. One server + one
-   funnel + one secret path serves every watched project.
-3. **Expose it.** `tailscale funnel` publishes the server at a public
-   `https://<host>.ts.net` URL.
+   secret path serves every watched project.
+3. **Expose it.** `tailscale funnel --set-path` mounts each of the connector's
+   paths (`/hook/<secret>`, plus `/gh/<secret>` when watching repos) on this
+   host's funnel, publishing the server at a public `https://<host>.ts.net` URL.
+   Only those paths are touched, so funnel paths other tools mounted keep
+   working.
 4. **Register webhooks.** Creates one webhook per project (with retry on transient
    failures), recording their IDs for cleanup.
 5. **Listen.** For each delivery: respond `200` immediately, then off the hot
@@ -247,14 +250,17 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
 ```
 
 **Teardown.** On `SIGINT`/`SIGTERM` it deletes **every** registered webhook
-(best-effort, reporting any it couldn’t) and resets the funnel, then stops the
-server. The funnel and webhooks live only for the lifetime of the process. If it
+(best-effort, reporting any it couldn’t) and unmounts its own funnel paths
+(`tailscale funnel --set-path <path> off` — never `funnel reset`, which would
+also tear down other tools' paths), then stops the server. The mounted paths and
+webhooks live only for the lifetime of the process. If it
 is ever `SIGKILL`ed, clean up manually:
 
 ```bash
 basecamp webhooks list   --project "<project>"        # find leftovers
 basecamp webhooks delete <id> --project "<project>"
-tailscale funnel reset
+tailscale funnel status                              # find leftover /hook/… and /gh/… paths
+tailscale funnel --set-path /hook/<secret> off
 ```
 
 ### Useful `basecamp` CLI commands
@@ -300,10 +306,10 @@ boundary rather than mocking the gem’s own classes.
 ```
 bin/connect                          # shim → Connector.start(ARGV) — Basecamp and/or GitHub
 lib/basecamp_agent_connector/
-  connector        # unified: one funnel + one multi-route server, mounts each transport's bridge
+  connector        # unified: one multi-route server on shared-funnel paths, mounts each transport's bridge
   command_runner   # shared: runs subprocesses; the seam tests stub
   server           # shared: WEBrick server, path→handler routes; 200-fast, raw body + headers
-  tunnel           # shared: Tailscale Funnel lifecycle (start / reset)
+  tunnel           # shared: mounts/unmounts our own paths on the host's Tailscale Funnel
   emitter          # shared: NDJSON writer
   basecamp/        # Basecamp:: — the Basecamp webhook transport
     bridge         #   one route: secret path, register webhooks, handler, teardown

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ What `bin/connect` has in place, at a glance:
   the agent's Person id encoded in the mention SGID.
 - **API corroboration** — every event is re-fetched from the Basecamp API and the
   **authoritative fetched copy is what gets acted on**, never the raw POST body.
-- **Secret webhook path** — the server accepts only `POST /hook/<secret>`, where
+- **Secret webhook path** — the server accepts only `POST /bc5/<secret>`, where
   `<secret>` is a fresh 128-bit random token generated per run; every other path
   returns 404.
 - **Localhost binding** — WEBrick listens only on `127.0.0.1`; the sole public
@@ -224,10 +224,10 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
    `Run basecamp auth login --profile <agent>…`. Resolves the operator identity
    (refreshing an expired token once). Warns if agent == operator.
 2. **Open the endpoint.** Starts a WEBrick server on `127.0.0.1:<port>` that only
-   accepts `POST /hook/<random-secret>`; everything else is 404. One server + one
+   accepts `POST /bc5/<random-secret>`; everything else is 404. One server + one
    secret path serves every watched project.
 3. **Expose it.** `tailscale funnel --set-path` mounts each of the connector's
-   paths (`/hook/<secret>`, plus `/gh/<secret>` when watching repos) on this
+   paths (`/bc5/<secret>`, plus `/gh/<secret>` when watching repos) on this
    host's funnel, publishing the server at a public `https://<host>.ts.net` URL.
    Only those paths are touched, so funnel paths other tools mounted keep
    working.
@@ -259,8 +259,8 @@ is ever `SIGKILL`ed, clean up manually:
 ```bash
 basecamp webhooks list   --project "<project>"        # find leftovers
 basecamp webhooks delete <id> --project "<project>"
-tailscale funnel status                              # find leftover /hook/… and /gh/… paths
-tailscale funnel --set-path /hook/<secret> off
+tailscale funnel status                              # find leftover /bc5/… and /gh/… paths
+tailscale funnel --set-path /bc5/<secret> off
 ```
 
 ### Useful `basecamp` CLI commands

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -161,7 +161,7 @@ bin/connect @AGENT --project <project>... [--operator <profile>] [--types <types
    are resolved to IDs by the `basecamp` CLI when registering. This is the
    project set to subscribe.
 3. **Start the local HTTP server** — a minimal **WEBrick** (Ruby stdlib, zero
-   dependencies) server on `127.0.0.1:<port>` accepting `POST /hook/<secret>`.
+   dependencies) server on `127.0.0.1:<port>` accepting `POST /bc5/<secret>`.
    A random unguessable path segment is generated per run (defense-in-depth; see
    Security). All other paths return 404. **One server + one funnel + one secret
    path serve every project**; the payload's `recording.bucket.id` identifies
@@ -171,7 +171,7 @@ bin/connect @AGENT --project <project>... [--operator <profile>] [--types <types
    (tailnet-only) is insufficient — Basecamp's servers must reach the endpoint,
    so `funnel` (public) is required.
 5. **Register webhooks** — for **each** project in the set, `basecamp webhooks
-   create <funnel-url>/hook/<secret> --project <project> --types <types>`. Capture
+   create <funnel-url>/bc5/<secret> --project <project> --types <types>`. Capture
    every created webhook ID for cleanup. Surface per-project registration
    failures without aborting the rest.
 6. **Listen** — for each incoming POST, run the pipeline below. Always respond
@@ -420,7 +420,7 @@ Coverage the suite must include:
   @mentioning the agent) are acted on, and (2) the content is re-fetched from
   Basecamp (not taken from the POST body). Treat all content as untrusted
   regardless; keep agents scoped to the resolved repo.
-- **Public endpoint hygiene** — the server only honors `POST /hook/<secret>` and
+- **Public endpoint hygiene** — the server only honors `POST /bc5/<secret>` and
   ignores everything else.
 - **Teardown** — webhook + funnel are removed on exit, minimizing the window in
   which a public endpoint exists.

--- a/lib/basecamp_agent_connector/basecamp/bridge.rb
+++ b/lib/basecamp_agent_connector/basecamp/bridge.rb
@@ -18,7 +18,7 @@ class BasecampAgentConnector::Basecamp::Bridge
   end
 
   def path
-    "/hook/#{@secret}"
+    "/bc5/#{@secret}"
   end
 
   def register(base_url:)

--- a/lib/basecamp_agent_connector/connector.rb
+++ b/lib/basecamp_agent_connector/connector.rb
@@ -1,10 +1,11 @@
 require "optparse"
 require "socket"
 
-# The unified entry point. Opens ONE Tailscale Funnel and ONE local server, and
-# mounts each requested transport (Basecamp projects and/or GitHub repos) as a
-# route on it. Basecamp and GitHub watching therefore run simultaneously over a
-# single funnel — the per-machine funnel is no longer a bottleneck.
+# The unified entry point. Opens ONE local server and mounts each requested
+# transport (Basecamp projects and/or GitHub repos) as a route on it, exposing
+# each route as its own path on this host's Tailscale Funnel. Basecamp and GitHub
+# watching therefore run simultaneously — the per-machine funnel is no longer a
+# bottleneck, and paths other tools mounted are left alone.
 class BasecampAgentConnector::Connector
   # Todo + Kanban::Step are included so todo/step assignment events are delivered
   # (Kanban::Card already covers card assignments).
@@ -62,7 +63,7 @@ class BasecampAgentConnector::Connector
     @bridges = build_bridges
     port = @options.port || free_port
 
-    @tunnel = BasecampAgentConnector::Tunnel.new(port: port, command_runner: command_runner)
+    @tunnel = BasecampAgentConnector::Tunnel.new(port: port, paths: @bridges.map(&:path), command_runner: command_runner)
     base_url = @tunnel.start
     @bridges.each { |bridge| bridge.register(base_url: base_url) }
 

--- a/lib/basecamp_agent_connector/tunnel.rb
+++ b/lib/basecamp_agent_connector/tunnel.rb
@@ -3,24 +3,32 @@ require "json"
 class BasecampAgentConnector::Tunnel
   class Error < StandardError; end
 
-  def initialize(port:, command_runner: BasecampAgentConnector::CommandRunner.new, executable: "tailscale")
+  def initialize(port:, paths:, command_runner: BasecampAgentConnector::CommandRunner.new, executable: "tailscale")
     @port = port
+    @paths = paths
     @command_runner = command_runner
     @executable = executable
   end
 
   def start
-    result = run("funnel", "--bg", @port.to_s)
-    raise Error, "`tailscale funnel` failed: #{result.stderr.strip}" unless result.success?
-
+    @paths.each { |path| mount(path) }
     public_url
   end
 
+  # Unmounts only our own paths: `tailscale funnel reset` would tear down paths
+  # other tools mounted on this host's funnel too.
   def stop
-    run("funnel", "reset")
+    @paths.each { |path| run("funnel", "--set-path", path, "off") }
   end
 
   private
+    # The funnel strips the mount prefix before proxying, so the target has to
+    # carry the path or the local server sees every delivery at "/".
+    def mount(path)
+      result = run("funnel", "--bg", "--set-path", path, "http://127.0.0.1:#{@port}#{path}")
+      raise Error, "`tailscale funnel` failed: #{result.stderr.strip}" unless result.success?
+    end
+
     def public_url
       result = run("status", "--json")
       raise Error, "`tailscale status` failed: #{result.stderr.strip}" unless result.success?

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -367,13 +367,13 @@ After stopping, **verify nothing leaked**:
 
 ```bash
 basecamp webhooks list --project "<project>" -j   # expect zero from this run
-tailscale funnel status                            # expect no /hook/… or /gh/… path
+tailscale funnel status                            # expect no /bc5/… or /gh/… path
 ```
 
 If the process was killed un-gracefully (e.g. `SIGKILL`) and teardown didn't run,
 delete the leftover webhook(s) manually with `basecamp webhooks delete <id>
 --project "<project>"` and unmount each leftover path with `tailscale funnel
---set-path /hook/<secret> off`. Never run `tailscale funnel reset` — it tears
+--set-path /bc5/<secret> off`. Never run `tailscale funnel reset` — it tears
 down every path on this host's funnel, including ones other tools mounted. Never
 leave a registered webhook or a mounted path behind.
 

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -358,8 +358,8 @@ signature, parse `pull_request_review`, emit) is specced in
 
 `bin/connect` opens a **public** Tailscale Funnel URL and registers a **real
 Basecamp webhook per project**. These must not outlive the session. The
-connector deletes every webhook and resets the funnel on `SIGINT`/`SIGTERM`, so
-the rule is simple: **whenever you stop watching — normal end, user interrupt, an
+connector deletes every webhook and unmounts its own funnel paths on
+`SIGINT`/`SIGTERM`, so the rule is simple: **whenever you stop watching — normal end, user interrupt, an
 error, or the skill aborting — stop the `bin/connect` process** (TaskStop / send
 SIGTERM). Its teardown does the rest.
 
@@ -367,18 +367,21 @@ After stopping, **verify nothing leaked**:
 
 ```bash
 basecamp webhooks list --project "<project>" -j   # expect zero from this run
-tailscale funnel status                            # expect no funnel for our port
+tailscale funnel status                            # expect no /hook/… or /gh/… path
 ```
 
 If the process was killed un-gracefully (e.g. `SIGKILL`) and teardown didn't run,
 delete the leftover webhook(s) manually with `basecamp webhooks delete <id>
---project "<project>"` and `tailscale funnel reset`. Never leave a registered
-webhook or an open funnel behind.
+--project "<project>"` and unmount each leftover path with `tailscale funnel
+--set-path /hook/<secret> off`. Never run `tailscale funnel reset` — it tears
+down every path on this host's funnel, including ones other tools mounted. Never
+leave a registered webhook or a mounted path behind.
 
 ## Notes
 
-- One `bin/connect` run = one funnel + one server + one webhook per watched
-  project. Re-running re-registers fresh; exiting cleans up.
+- One `bin/connect` run = one or two paths on the host's shared funnel + one
+  server + one webhook per watched project. Re-running re-registers fresh;
+  exiting cleans up.
 - The connector never trusts the POST body's content — it re-fetches the
   recording from Basecamp before emitting. The content you see on STDOUT is the
   authoritative copy.

--- a/test/basecamp_bridge_test.rb
+++ b/test/basecamp_bridge_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class BasecampBridgeTest < Minitest::Test
   def test_path_is_a_secret_hook_path
-    assert_match(%r{\A/hook/[0-9a-f]{32}\z}, bridge(FakeCommandRunner.new).path)
+    assert_match(%r{\A/bc5/[0-9a-f]{32}\z}, bridge(FakeCommandRunner.new).path)
   end
 
   def test_register_creates_a_webhook_at_the_funnel_url_for_each_project

--- a/test/connector_test.rb
+++ b/test/connector_test.rb
@@ -48,4 +48,35 @@ class ConnectorTest < Minitest::Test
       BasecampAgentConnector::Connector.parse_options([ "--project", "Queenbee" ])
     end
   end
+
+  class FakeServer
+    def start; end
+    def stop; end
+  end
+
+  def test_start_mounts_only_its_own_bridge_paths_on_the_shared_funnel
+    runner = FakeCommandRunner.new
+    runner.stub "tailscale funnel", exit_status: 0
+    runner.stub "tailscale status --json", stdout: JSON.generate("Self" => { "DNSName" => "desktop.example.ts.net." })
+    runner.stub "/hooks", stdout: '{"id":888}'
+    runner.stub "-X DELETE", exit_status: 0
+
+    start_connector [ "--repo", "acme/a", "--port", "4567" ], runner
+
+    mounted = runner.commands_matching(/funnel --bg/)
+    assert_equal 1, mounted.length
+    path = mounted.first[4]
+    assert_match %r{\A/gh/[0-9a-f]+\z}, path
+    assert_equal [ "tailscale", "funnel", "--bg", "--set-path", path, "http://127.0.0.1:4567#{path}" ], mounted.first
+    assert_equal [ [ "tailscale", "funnel", "--set-path", path, "off" ] ], runner.commands_matching(/funnel --set-path/)
+    assert_empty runner.commands_matching(/reset/)
+  end
+
+  private
+    def start_connector(argv, runner)
+      connector = BasecampAgentConnector::Connector.new(BasecampAgentConnector::Connector.parse_options(argv))
+      connector.instance_variable_set(:@command_runner, runner)
+
+      BasecampAgentConnector::Server.stub(:new, FakeServer.new) { capture_io { connector.start } }
+    end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
 require "basecamp_agent_connector"
 require "minitest/autorun"
+require "minitest/mock"
 require "base64"
 require "json"
 require "openssl"

--- a/test/tunnel_test.rb
+++ b/test/tunnel_test.rb
@@ -6,11 +6,11 @@ class TunnelTest < Minitest::Test
     runner.stub "tailscale funnel", exit_status: 0
     runner.stub "tailscale status --json", stdout: JSON.generate("Self" => { "DNSName" => "desktop.example.ts.net." })
 
-    url = BasecampAgentConnector::Tunnel.new(port: 4567, paths: [ "/hook/abc", "/gh/def" ], command_runner: runner).start
+    url = BasecampAgentConnector::Tunnel.new(port: 4567, paths: [ "/bc5/abc", "/gh/def" ], command_runner: runner).start
 
     assert_equal "https://desktop.example.ts.net", url
     assert_equal [
-      [ "tailscale", "funnel", "--bg", "--set-path", "/hook/abc", "http://127.0.0.1:4567/hook/abc" ],
+      [ "tailscale", "funnel", "--bg", "--set-path", "/bc5/abc", "http://127.0.0.1:4567/bc5/abc" ],
       [ "tailscale", "funnel", "--bg", "--set-path", "/gh/def", "http://127.0.0.1:4567/gh/def" ]
     ], runner.commands_matching(/funnel/)
   end
@@ -20,7 +20,7 @@ class TunnelTest < Minitest::Test
     runner.stub "tailscale funnel", exit_status: 1, stderr: "Funnel is not enabled"
 
     assert_raises BasecampAgentConnector::Tunnel::Error do
-      BasecampAgentConnector::Tunnel.new(port: 4567, paths: [ "/hook/abc" ], command_runner: runner).start
+      BasecampAgentConnector::Tunnel.new(port: 4567, paths: [ "/bc5/abc" ], command_runner: runner).start
     end
   end
 
@@ -28,10 +28,10 @@ class TunnelTest < Minitest::Test
     runner = FakeCommandRunner.new
     runner.stub "tailscale funnel", exit_status: 0
 
-    BasecampAgentConnector::Tunnel.new(port: 4567, paths: [ "/hook/abc", "/gh/def" ], command_runner: runner).stop
+    BasecampAgentConnector::Tunnel.new(port: 4567, paths: [ "/bc5/abc", "/gh/def" ], command_runner: runner).stop
 
     assert_equal [
-      [ "tailscale", "funnel", "--set-path", "/hook/abc", "off" ],
+      [ "tailscale", "funnel", "--set-path", "/bc5/abc", "off" ],
       [ "tailscale", "funnel", "--set-path", "/gh/def", "off" ]
     ], runner.commands_matching(/funnel/)
     assert_empty runner.commands_matching(/reset/)

--- a/test/tunnel_test.rb
+++ b/test/tunnel_test.rb
@@ -1,14 +1,18 @@
 require "test_helper"
 
 class TunnelTest < Minitest::Test
-  def test_start_returns_the_public_url
+  def test_start_mounts_each_path_with_a_path_carrying_proxy_target
     runner = FakeCommandRunner.new
-    runner.stub "tailscale funnel --bg", exit_status: 0
+    runner.stub "tailscale funnel", exit_status: 0
     runner.stub "tailscale status --json", stdout: JSON.generate("Self" => { "DNSName" => "desktop.example.ts.net." })
 
-    url = BasecampAgentConnector::Tunnel.new(port: 4567, command_runner: runner).start
+    url = BasecampAgentConnector::Tunnel.new(port: 4567, paths: [ "/hook/abc", "/gh/def" ], command_runner: runner).start
 
     assert_equal "https://desktop.example.ts.net", url
+    assert_equal [
+      [ "tailscale", "funnel", "--bg", "--set-path", "/hook/abc", "http://127.0.0.1:4567/hook/abc" ],
+      [ "tailscale", "funnel", "--bg", "--set-path", "/gh/def", "http://127.0.0.1:4567/gh/def" ]
+    ], runner.commands_matching(/funnel/)
   end
 
   def test_start_raises_when_funnel_fails
@@ -16,16 +20,20 @@ class TunnelTest < Minitest::Test
     runner.stub "tailscale funnel", exit_status: 1, stderr: "Funnel is not enabled"
 
     assert_raises BasecampAgentConnector::Tunnel::Error do
-      BasecampAgentConnector::Tunnel.new(port: 4567, command_runner: runner).start
+      BasecampAgentConnector::Tunnel.new(port: 4567, paths: [ "/hook/abc" ], command_runner: runner).start
     end
   end
 
-  def test_stop_resets_the_funnel
+  def test_stop_unmounts_each_path_and_never_resets_the_funnel
     runner = FakeCommandRunner.new
-    runner.stub "tailscale funnel reset", exit_status: 0
+    runner.stub "tailscale funnel", exit_status: 0
 
-    BasecampAgentConnector::Tunnel.new(port: 4567, command_runner: runner).stop
+    BasecampAgentConnector::Tunnel.new(port: 4567, paths: [ "/hook/abc", "/gh/def" ], command_runner: runner).stop
 
-    assert_equal 1, runner.commands_matching(/funnel reset/).length
+    assert_equal [
+      [ "tailscale", "funnel", "--set-path", "/hook/abc", "off" ],
+      [ "tailscale", "funnel", "--set-path", "/gh/def", "off" ]
+    ], runner.commands_matching(/funnel/)
+    assert_empty runner.commands_matching(/reset/)
   end
 end


### PR DESCRIPTION
## Why

`Tunnel#start` ran `tailscale funnel --bg PORT`, which mounts our server at `/` on
the host's funnel, and `Tunnel#stop` ran `tailscale funnel reset`, which removes
**every** path on that funnel — not just ours. That was fine while `bin/connect`
was the machine's only funnel user. It no longer is: a second tool now mounts its
own path on this host, so starting the connector would replace any existing `/`
mapping and stopping it would silently tear the other tool's path down.

## What

**Mount and unmount only our own paths.**

- **`Tunnel`** now takes `paths:` and mounts one path per bridge:
  ```
  tailscale funnel --bg --set-path /bc5/<secret> http://127.0.0.1:PORT/bc5/<secret>
  ```
  and unmounts with `tailscale funnel --set-path /bc5/<secret> off`. `funnel reset`
  is gone for good.
- **The proxy target has to carry the path.** The funnel strips the mount prefix
  before proxying, so a bare `http://127.0.0.1:PORT` target makes WEBrick see
  every delivery at `/` and return 404. Verified on tailscale 1.98.10.
- **`Connector#start`** builds the bridges first, then starts the tunnel with
  their paths. Bridge paths are known before the tunnel exists (each is a secret
  chosen at construction), so ordering is the only change — the public URL each
  bridge registers is unchanged in shape.
- **The Basecamp bridge path is now `/bc5/<secret>`,** not `/hook/<secret>`
  (second commit). `/hook/` said nothing about which transport it served now that
  the funnel carries a path per bridge alongside `/gh/`.

## Tests

**85 runs, 220 assertions, 0 failures.** `tunnel_test` asserts start issues one
`--set-path` per path with the path-carrying target, and that stop issues one
`off` per path and never `reset`; `connector_test` covers the wiring end to end
(bridge paths reach the tunnel, and teardown unmounts them). All through the
existing `CommandRunner` seam — no shelling out. `test_helper` now requires
`minitest/mock` for the `Server` stub.

Also exercised live against the real funnel with another tool's path already
mounted: registered a Basecamp webhook, took a real delivery through
`/bc5/<secret>`, and confirmed teardown removed our path and webhook while the
other tool's path survived untouched. The old code would have wiped it.

## Docs

README architecture/lifecycle (the connector opens one or two paths on the shared
funnel, not "one funnel"), `docs/spec.md` endpoint paths, and the
`basecamp-connect` skill's cleanup section — which now says to unmount per-path
and states explicitly that `funnel reset` tears down other tools' paths.

**After merge:** the installed skill copy still carries the `funnel reset` advice,
so it needs `npx skills update -g`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
