### PR TITLE
Make the trust gate configurable: operator, allowlist, project, and domain modes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 
 group :development, :test do
   gem "minitest"
+  gem "minitest-mock"
   gem "rake"
   gem "rubocop", require: false
   gem "rubocop-37signals", bc: "house-style", require: false

--- a/README.md
+++ b/README.md
@@ -149,8 +149,17 @@ The bridge is dumb-and-safe; the driver is smart-and-contextual. You can run
 
 What `bin/connect` has in place, at a glance:
 
-- **Operator-only triggering** — an event acts only when its creator is the
-  operator (the CLI default profile, or `--operator <profile>`), matched by email.
+- **Operator-only triggering by default** — with no trust flags, an event acts
+  only when its creator is the operator (the CLI default profile, or
+  `--operator <profile>`), matched by email. Trust can be **deliberately
+  broadened** per run — see [Trust modes](#trust-modes) below.
+- **Agent-self exclusion** — the agent's own identity never authorizes, in any
+  mode, matched by email *and* Person id. Even when trust is broadened to a
+  domain or project the agent belongs to, its own posts cannot re-trigger it.
+- **Assignments stay operator-only** — assigning the agent a card/todo is
+  higher-privilege (the assigner's identity is not corroborated), so broadened
+  modes apply to mentions only unless `--allow-assignments-from-authorized`
+  explicitly opts assignments in.
 - **Mention gating** — the recording must contain a real Basecamp mention
   *attachment* (`application/vnd.basecamp.mention`) for the agent user, matched by
   the agent's Person id encoded in the mention SGID.
@@ -175,9 +184,14 @@ What `bin/connect` has in place, at a glance:
 A webhook payload is attacker-influenceable text that flows into an agent which
 can run commands. `bin/connect` emits an event only when **all** of these hold:
 
-1. **Authored by the operator.** The event creator must be *you* (the CLI default
-   profile, or `--operator <profile>`), matched by email. A third party who can
-   comment in the project cannot make your agent do anything.
+1. **Authored by an authorized user.** By default that means *you* alone (the
+   CLI default profile, or `--operator <profile>`), matched by email: a third
+   party who can comment in the project cannot make your agent do anything.
+   Trust modes (below) can deliberately extend this to named colleagues, a
+   domain, or the whole project membership — and the check is applied **twice**:
+   once on the claimed webhook payload as a cheap pre-filter, and again on the
+   corroborated event, so authorization binds to the author Basecamp actually
+   recorded, never to forgeable POST text.
 2. **@mentions the agent.** `recording.content` must contain a real Basecamp
    mention of the agent user — a mention *attachment*
    (`application/vnd.basecamp.mention`) naming the agent, not just loose text
@@ -192,9 +206,41 @@ The content acted on is the **authoritative copy fetched from Basecamp**, never
 the raw POST body.
 
 **No reply loop.** Replies are posted *as the agent*, a different user than the
-operator. Because the trust filter requires the *operator* to be the author, the
-agent’s own replies can never re-trigger the connector. (`bin/connect` warns at
-startup if the agent and operator resolve to the same Basecamp user.)
+operator. The agent's own identity **never authorizes, in any mode** — an
+explicit guard, matched by email and Person id, refuses agent-authored events
+before any mode is consulted. So even under `--trust domain` (where the agent's
+email may share the domain) or `--trust project` (where the agent is a member),
+its own replies can never re-trigger the connector. (`bin/connect` warns at
+startup if the agent and operator resolve to the same Basecamp user — a
+configuration in which nothing can trigger.)
+
+### Trust modes
+
+Who may drive the agent is a per-run, explicit choice. The agent acts with the
+operator's full machine authority, so broadening trust means handing that
+authority to more people — the startup log prints the active mode and the
+concrete allowed set so it is never implicit.
+
+| Mode | Who triggers | CLI |
+|------|--------------|-----|
+| `operator` *(default)* | You only. No flags = exactly this. | — |
+| `allowlist` | You + the named emails. | `--allow marie@37signals.com` (repeatable or comma-separated; implies the mode, or `--trust allowlist`) |
+| `domain` | Any author whose email is at a listed domain. | `--allow-domain 37signals.com` (repeatable), or bare `--trust domain` for the 37signals.com default |
+| `project` | Any corroborated member of the watched projects (client users excluded). | `--allow-project` or `--trust project` |
+
+Every mode implicitly includes the operator and excludes the agent itself. In
+`project` mode, membership is proven by corroboration: only project members can
+post in a project, and every event is re-fetched from the Basecamp API before it
+acts — a person who cannot post there cannot produce a corroborated recording.
+Authors Basecamp marks as **client** users are refused; note the check reads the
+`client` flag on the corroborated person, so it is only as strong as that flag's
+presence in the API payload.
+
+**Assignments are operator-only in every mode** unless
+`--allow-assignments-from-authorized` opts the mode's authors in. An assignment
+is corroborated by the agent really being among the card's assignees, but the
+*assigner's* identity is not independently verifiable — bear that in mind before
+opting in.
 
 ---
 
@@ -214,7 +260,12 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
 | `@AGENT` | Agent user / local `basecamp` profile to watch for and reply as. Leading `@` optional; lowercased to the profile name. **Required**, validated at startup. | — |
 | `--project` | Basecamp project name, URL, or ID. **Required**, repeatable. | — |
 | `--operator` | Profile whose user is allowed to trigger. | CLI default profile |
-| `--types` | Comma-separated Basecamp event types to subscribe to. | `Comment,Message,Kanban::Card` |
+| `--trust` | Trust mode: `operator`, `allowlist`, `project`, or `domain`. Usually inferred from the value flags below. | `operator` |
+| `--allow` | Author email to trust (repeatable or comma-separated). Implies `--trust allowlist`. | — |
+| `--allow-domain` | Email domain to trust (repeatable or comma-separated). Implies `--trust domain`. | `37signals.com` under bare `--trust domain` |
+| `--allow-project` | Trust any corroborated member of the watched projects. Implies `--trust project`. | off |
+| `--allow-assignments-from-authorized` | Let any authorized author trigger via assignment, not just the operator. | off — assignments are operator-only |
+| `--types` | Comma-separated Basecamp event types to subscribe to. | `Comment,Message,Kanban::Card,Kanban::Step,Todo` |
 | `--port` | Local port for the webhook server. | an unused high port |
 
 **What it does, in order:**
@@ -234,9 +285,10 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
 4. **Register webhooks.** Creates one webhook per project (with retry on transient
    failures), recording their IDs for cleanup.
 5. **Listen.** For each delivery: respond `200` immediately, then off the hot
-   path — pre-filter (operator-authored + mentions agent + actionable kind),
-   de-duplicate by event id, verify against the Basecamp API, and **print the
-   trusted event as one line of NDJSON** to STDOUT. Dropped/diagnostic lines go
+   path — pre-filter (authorized author + mentions agent + actionable kind),
+   de-duplicate by event id, verify against the Basecamp API, re-check that the
+   **corroborated** author is authorized, and **print the trusted event as one
+   line of NDJSON** to STDOUT. Dropped/diagnostic lines go
    to STDERR.
 
 **Emitted event (STDOUT, one JSON object per line):**
@@ -280,6 +332,8 @@ basecamp comment <recording-url> "…" --profile <agent> # post as the agent
   --profile <agent>`).
 - **Operator** — the user allowed to trigger; defaults to the CLI default
   profile, override with `--operator <profile>`. Must differ from the agent.
+- **Trust mode** — who beyond the operator may trigger; defaults to nobody.
+  See [Trust modes](#trust-modes).
 - **Project → repo mapping** — [`config/project_repos.toml`](config/project_repos.toml)
   maps Basecamp project-name tokens to local repo paths. The skill uses it to
   decide where to run each agent; if nothing matches, it asks you.

--- a/README.md
+++ b/README.md
@@ -232,15 +232,34 @@ Every mode implicitly includes the operator and excludes the agent itself. In
 `project` mode, membership is proven by corroboration: only project members can
 post in a project, and every event is re-fetched from the Basecamp API before it
 acts — a person who cannot post there cannot produce a corroborated recording.
-Authors Basecamp marks as **client** users are refused; note the check reads the
-`client` flag on the corroborated person, so it is only as strong as that flag's
-presence in the API payload.
+
+Three limits of `project` mode are worth stating plainly, because they matter
+only against the forged-POST-with-leaked-secret-path threat (a normal Basecamp
+delivery is unaffected):
+
+- **Corroboration proves the recording exists with that author, not that it
+  lives in a *watched* project.** The API re-fetch follows the URL in the
+  payload, and the operator's CLI can read recordings beyond the watched
+  projects. So `project` mode trusts any corroborated author in *any* project
+  the operator's account can see, not strictly the watched ones. Prefer
+  `allowlist`/`domain` when you need the trust set pinned to specific people.
+- **Client exclusion is only as strong as the `client` flag in the API
+  payload.** Authors Basecamp marks as client users are refused, but the check
+  reads `creator.client` on the corroborated recording; if a recording type
+  omits that field, a client author is not caught. The flag is not
+  attacker-chosen (it comes from Basecamp's authoritative copy), but its absence
+  fails open.
 
 **Assignments are operator-only in every mode** unless
 `--allow-assignments-from-authorized` opts the mode's authors in. An assignment
-is corroborated by the agent really being among the card's assignees, but the
-*assigner's* identity is not independently verifiable — bear that in mind before
-opting in.
+is corroborated by the agent really being among the card's assignees — but the
+*assigner's* identity is **not** independently verifiable: the verifier confirms
+live assignee state and preserves the event's claimed creator. Against a forged
+POST on a leaked secret path, that means the "operator-only" guarantee for the
+assignment trigger rests on the secret path, not on corroboration, in a way the
+mention trigger does not. Bear that in mind before opting assignments in, and
+prefer the mention trigger when the author must be cryptographically pinned to
+the recording.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ What `bin/connect` has in place, at a glance:
   the agent's Person id encoded in the mention SGID.
 - **API corroboration** — every event is re-fetched from the Basecamp API and the
   **authoritative fetched copy is what gets acted on**, never the raw POST body.
+  For a mention the fetched recording carries the authoritative creator *and*
+  content, so both the author and the mention are re-checked against it. An
+  assignment corroborates the agent's live assignee state but keeps the POST's
+  claimed assigner — see the assignment caveat under [Trust modes](#trust-modes).
 - **Secret webhook path** — the server accepts only `POST /bc5/<secret>`, where
   `<secret>` is a fresh 128-bit random token generated per run; every other path
   returns 404.
@@ -188,22 +192,28 @@ can run commands. `bin/connect` emits an event only when **all** of these hold:
    CLI default profile, or `--operator <profile>`), matched by email: a third
    party who can comment in the project cannot make your agent do anything.
    Trust modes (below) can deliberately extend this to named colleagues, a
-   domain, or the whole project membership — and the check is applied **twice**:
-   once on the claimed webhook payload as a cheap pre-filter, and again on the
-   corroborated event, so authorization binds to the author Basecamp actually
-   recorded, never to forgeable POST text.
+   domain, or the whole project membership — and for a **mention** the check is
+   applied **twice**: once on the claimed webhook payload as a cheap pre-filter,
+   and again on the corroborated event, so authorization binds to the author
+   Basecamp actually recorded, never to forgeable POST text. (An **assignment**
+   corroborates the agent's assignee state but not the assigner — see the
+   assignment caveat under [Trust modes](#trust-modes).)
 2. **@mentions the agent.** `recording.content` must contain a real Basecamp
    mention of the agent user — a mention *attachment*
    (`application/vnd.basecamp.mention`) naming the agent, not just loose text
-   that happens to contain the name.
+   that happens to contain the name. This too is re-checked on the corroborated
+   recording, so a forged mention paired with a real un-mentioning recording is
+   dropped.
 3. **Corroborated by Basecamp.** The recording is re-fetched from the Basecamp
-   API and confirmed (it exists, with the claimed creator). The funnel URL is
-   public and Basecamp sends no signature, so a forged POST is possible — but it
-   can’t survive API corroboration. A random secret URL path is a cheap first
-   gate on top.
+   API and confirmed. For a mention that means it exists **with the claimed
+   creator and the claimed mention** — so a forged POST cannot survive. For an
+   assignment it means the agent is really among the recording's current
+   assignees; the assigner's identity is not independently corroborated, so
+   there the secret URL path — a fresh 128-bit token per run — is the gate that
+   stops a forged operator-assignment, not corroboration.
 
-The content acted on is the **authoritative copy fetched from Basecamp**, never
-the raw POST body.
+For a mention, the content acted on is the **authoritative copy fetched from
+Basecamp**, never the raw POST body.
 
 **No reply loop.** Replies are posted *as the agent*, a different user than the
 operator. The agent's own identity **never authorizes, in any mode** — an
@@ -226,29 +236,26 @@ concrete allowed set so it is never implicit.
 | `operator` *(default)* | You only. No flags = exactly this. | — |
 | `allowlist` | You + the named emails. | `--allow marie@37signals.com` (repeatable or comma-separated; implies the mode, or `--trust allowlist`) |
 | `domain` | Any author whose email is at a listed domain. | `--allow-domain 37signals.com` (repeatable), or bare `--trust domain` for the 37signals.com default |
-| `project` | Any corroborated member of the watched projects (client users excluded). | `--allow-project` or `--trust project` |
+| `project` | Any corroborated non-client author of a recording the operator's account can read (client users excluded, fail-closed). | `--allow-project` or `--trust project` |
 
 Every mode implicitly includes the operator and excludes the agent itself. In
 `project` mode, membership is proven by corroboration: only project members can
 post in a project, and every event is re-fetched from the Basecamp API before it
 acts — a person who cannot post there cannot produce a corroborated recording.
+**Client (external) users are excluded fail-closed**: the corroborated recording
+must positively report `creator.client == false`; an absent or non-boolean flag
+is treated as untrusted, so a recording representation that omits it cannot slip
+a client author through.
 
-Three limits of `project` mode are worth stating plainly, because they matter
-only against the forged-POST-with-leaked-secret-path threat (a normal Basecamp
-delivery is unaffected):
-
-- **Corroboration proves the recording exists with that author, not that it
-  lives in a *watched* project.** The API re-fetch follows the URL in the
-  payload, and the operator's CLI can read recordings beyond the watched
-  projects. So `project` mode trusts any corroborated author in *any* project
-  the operator's account can see, not strictly the watched ones. Prefer
-  `allowlist`/`domain` when you need the trust set pinned to specific people.
-- **Client exclusion is only as strong as the `client` flag in the API
-  payload.** Authors Basecamp marks as client users are refused, but the check
-  reads `creator.client` on the corroborated recording; if a recording type
-  omits that field, a client author is not caught. The flag is not
-  attacker-chosen (it comes from Basecamp's authoritative copy), but its absence
-  fails open.
+One limit of `project` mode is worth stating plainly, because it matters only
+against the forged-POST-with-leaked-secret-path threat (a normal Basecamp
+delivery is unaffected): **corroboration proves the recording exists with that
+author, not that it lives in a *watched* project.** The API re-fetch follows the
+URL in the payload, and the operator's CLI can read recordings beyond the
+watched projects. So `project` mode trusts any corroborated non-client author in
+*any* project the operator's account can see, not strictly the watched ones.
+Prefer `allowlist`/`domain` when you need the trust set pinned to specific
+people.
 
 **Assignments are operator-only in every mode** unless
 `--allow-assignments-from-authorized` opts the mode's authors in. An assignment

--- a/README.md
+++ b/README.md
@@ -175,9 +175,12 @@ What `bin/connect` has in place, at a glance:
 - **Localhost binding** — WEBrick listens only on `127.0.0.1`; the sole public
   ingress is the Tailscale Funnel over HTTPS.
 - **Replay de-duplication** — events are de-duplicated by id within a run.
-- **No reply loop** — replies post as the agent (a distinct user), so they fail
-  the operator-author check and can't re-trigger the connector; startup warns if
-  the agent and operator resolve to the same user.
+- **No reply loop** — the agent's own identity never authorizes in any mode (an
+  explicit guard on email and Person id), so replies posted as the agent can't
+  re-trigger the connector even under `domain`/`project` trust where the agent
+  shares the domain or is a project member; in operator mode they also simply
+  fail the author check. Startup warns if the agent and operator resolve to the
+  same user.
 - **Ephemeral exposure** — the funnel and per-project webhooks exist only while
   the process runs and are torn down on exit.
 
@@ -289,7 +292,7 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
 | `--trust` | Trust mode: `operator`, `allowlist`, `project`, or `domain`. Usually inferred from the value flags below. | `operator` |
 | `--allow` | Author email to trust (repeatable or comma-separated). Implies `--trust allowlist`. | — |
 | `--allow-domain` | Email domain to trust (repeatable or comma-separated). Implies `--trust domain`. | `37signals.com` under bare `--trust domain` |
-| `--allow-project` | Trust any corroborated member of the watched projects. Implies `--trust project`. | off |
+| `--allow-project` | Trust any corroborated non-client author of a recording the operator's account can read. Implies `--trust project`. | off |
 | `--allow-assignments-from-authorized` | Let any authorized author trigger via assignment, not just the operator. | off — assignments are operator-only |
 | `--types` | Comma-separated Basecamp event types to subscribe to. | `Comment,Message,Kanban::Card,Kanban::Step,Todo` |
 | `--port` | Local port for the webhook server. | an unused high port |

--- a/lib/basecamp_agent_connector/basecamp/authorizer.rb
+++ b/lib/basecamp_agent_connector/basecamp/authorizer.rb
@@ -1,0 +1,122 @@
+# Decides which Basecamp users may drive the agent. The operator always may;
+# each mode extends trust to a further set of authors. Every mode refuses the
+# agent's own identity outright — matched by email and by Person id — so the
+# agent can never trigger itself no matter how broadly trust is opened (a
+# domain the agent's email shares, a project it is a member of).
+#
+# Assignment events are higher-privilege (assigning the agent a card runs it
+# against that card, and the assigner's identity is not corroborated by the
+# verifier), so broadened modes apply to mentions only: assignments stay
+# operator-only unless `allow_assignments:` opts the mode's authors in.
+#
+# The pipeline consults `authorizes?` twice: on the claimed webhook payload as
+# a cheap pre-filter, and again on the verified event so the decision binds to
+# the authoritative creator fetched from Basecamp, not to forgeable POST text.
+class BasecampAgentConnector::Basecamp::Authorizer
+  DEFAULT_TRUSTED_DOMAIN = "37signals.com"
+
+  def self.build(trust:, operator:, agent:, emails: [], domains: [], allow_assignments: false)
+    case trust
+    when :operator  then Operator.new(operator: operator, agent: agent, allow_assignments: allow_assignments)
+    when :allowlist then Allowlist.new(operator: operator, agent: agent, emails: emails, allow_assignments: allow_assignments)
+    when :project   then Project.new(operator: operator, agent: agent, allow_assignments: allow_assignments)
+    when :domain    then Domain.new(operator: operator, agent: agent, allow_assignments: allow_assignments,
+                       domains: domains.empty? ? [ DEFAULT_TRUSTED_DOMAIN ] : domains)
+    else raise ArgumentError, "unknown trust mode #{trust.inspect}"
+    end
+  end
+
+  def initialize(operator:, agent:, allow_assignments: false)
+    @operator = operator
+    @agent = agent
+    @allow_assignments = allow_assignments
+  end
+
+  def authorizes?(event)
+    if agent_authored?(event)
+      false
+    elsif event.assignment_changed? && !@allow_assignments
+      operator_authored?(event)
+    else
+      operator_authored?(event) || authorized_author?(event)
+    end
+  end
+
+  def description
+    "#{mode_description}; assignments: #{@allow_assignments ? "any authorized author" : "operator only"}"
+  end
+
+  private
+    def operator_authored?(event)
+      event.authored_by?(@operator)
+    end
+
+    def agent_authored?(event)
+      event.authored_by?(@agent) || \
+        (!@agent.person_id.nil? && event.creator_id == @agent.person_id)
+    end
+
+    # Overridden per mode; the operator alone authorizes in the base case.
+    def authorized_author?(event)
+      false
+    end
+end
+
+class BasecampAgentConnector::Basecamp::Authorizer::Operator < BasecampAgentConnector::Basecamp::Authorizer
+  private
+    def mode_description
+      "operator only (#{@operator.email})"
+    end
+end
+
+class BasecampAgentConnector::Basecamp::Authorizer::Allowlist < BasecampAgentConnector::Basecamp::Authorizer
+  def initialize(emails:, **rest)
+    super(**rest)
+    @emails = emails
+  end
+
+  private
+    def authorized_author?(event)
+      !event.creator_email.nil? && \
+        @emails.any? { |email| event.creator_email.casecmp?(email) }
+    end
+
+    def mode_description
+      "allowlist — operator (#{@operator.email}) + #{@emails.join(", ")}"
+    end
+end
+
+# Any corroborated author: only project members can post in a project, and the
+# verifier confirms the recording really exists with that author, so
+# corroboration is the membership proof. Client (external) users are excluded
+# when Basecamp marks the person as one.
+class BasecampAgentConnector::Basecamp::Authorizer::Project < BasecampAgentConnector::Basecamp::Authorizer
+  private
+    def authorized_author?(event)
+      !event.creator_id.nil? && event.creator["client"] != true
+    end
+
+    def mode_description
+      "any corroborated project member (clients excluded)"
+    end
+end
+
+class BasecampAgentConnector::Basecamp::Authorizer::Domain < BasecampAgentConnector::Basecamp::Authorizer
+  def initialize(domains:, **rest)
+    super(**rest)
+    @domains = domains.map { |domain| domain.downcase.delete_prefix("@") }
+  end
+
+  private
+    def authorized_author?(event)
+      @domains.include?(author_domain(event))
+    end
+
+    def author_domain(event)
+      event.creator_email.to_s.downcase[/@([^@\s]+)\z/, 1]
+    end
+
+    def mode_description
+      "any #{@domains.map { |domain| "@#{domain}" }.join(", ")} author"
+    end
+end

--- a/lib/basecamp_agent_connector/basecamp/authorizer.rb
+++ b/lib/basecamp_agent_connector/basecamp/authorizer.rb
@@ -88,12 +88,15 @@ end
 
 # Any corroborated author: only project members can post in a project, and the
 # verifier confirms the recording really exists with that author, so
-# corroboration is the membership proof. Client (external) users are excluded
-# when Basecamp marks the person as one.
+# corroboration is the membership proof. Client (external) users are excluded,
+# and the exclusion fails *closed*: the corroborated recording must positively
+# say the author is not a client (`creator.client == false`). An absent or
+# non-boolean flag is treated as untrusted rather than assumed employee, so a
+# recording representation that omits it cannot slip a client author through.
 class BasecampAgentConnector::Basecamp::Authorizer::Project < BasecampAgentConnector::Basecamp::Authorizer
   private
     def authorized_author?(event)
-      !event.creator_id.nil? && event.creator["client"] != true
+      !event.creator_id.nil? && event.creator["client"] == false
     end
 
     def mode_description

--- a/lib/basecamp_agent_connector/basecamp/bridge.rb
+++ b/lib/basecamp_agent_connector/basecamp/bridge.rb
@@ -5,8 +5,8 @@ require "securerandom"
 # its secret path, registers a webhook per project against the shared funnel, and
 # turns each delivery into a verified, emitted event.
 class BasecampAgentConnector::Basecamp::Bridge
-  def initialize(operator:, agent:, projects:, types:, basecamp_cli:, emitter:, logger: $stderr)
-    @operator = operator
+  def initialize(authorizer:, agent:, projects:, types:, basecamp_cli:, emitter:, logger: $stderr)
+    @authorizer = authorizer
     @agent = agent
     @projects = projects
     @types = types
@@ -25,6 +25,7 @@ class BasecampAgentConnector::Basecamp::Bridge
     url = "#{base_url}#{path}"
     @webhooks.register_all(projects: @projects, url: url, types: @types)
     log "Listening for mentions of @#{@agent.name || @agent.profile} on #{@projects.length} project(s) at #{url}"
+    log "Trust: #{@authorizer.description}"
   end
 
   def handler
@@ -46,7 +47,7 @@ class BasecampAgentConnector::Basecamp::Bridge
   private
     def pipeline
       @pipeline ||= BasecampAgentConnector::Basecamp::Pipeline.new \
-        operator: @operator,
+        authorizer: @authorizer,
         agent: @agent,
         verifier: BasecampAgentConnector::Basecamp::Verifier.new(basecamp_cli: @basecamp_cli, agent: @agent),
         emitter: @emitter

--- a/lib/basecamp_agent_connector/basecamp/pipeline.rb
+++ b/lib/basecamp_agent_connector/basecamp/pipeline.rb
@@ -41,10 +41,10 @@ class BasecampAgentConnector::Basecamp::Pipeline
     # author who must be authorized and the authoritative recording that must
     # target the agent; a forged payload pairing a fake mention with a real
     # recording the agent was never mentioned in is dropped here, not emitted.
-    # For an assignment the verifier corroborates the agent's live assignee
+    # For an assignment the verifier corroborates the agent's current assignee
     # state but keeps the claimed assigner, so this re-check re-tests that same
-    # claimed identity (the verifier, not this method, is what proves the
-    # assignment real).
+    # claimed identity (the verifier confirms the live assignee state, not that
+    # the claimed assigner is who performed the assignment).
     def emit_if_verified(event)
       verified = @verifier.verify(event)
 

--- a/lib/basecamp_agent_connector/basecamp/pipeline.rb
+++ b/lib/basecamp_agent_connector/basecamp/pipeline.rb
@@ -35,12 +35,16 @@ class BasecampAgentConnector::Basecamp::Pipeline
     end
 
     # Both trust predicates are re-checked on the verified event, not just the
-    # claimed payload. Corroboration replaces the pre-filter's forgeable POST
-    # fields with what Basecamp actually recorded — the recording's real creator
-    # and its real content — so it is the authoritative author who must be
-    # authorized and the authoritative recording that must target the agent. A
-    # forged payload that pairs a fake mention with a real recording the agent
-    # was never mentioned in is therefore dropped here, not emitted.
+    # claimed payload. For a mention, corroboration replaces the pre-filter's
+    # forgeable POST fields with what Basecamp actually recorded — the
+    # recording's real creator and its real content — so it is the authoritative
+    # author who must be authorized and the authoritative recording that must
+    # target the agent; a forged payload pairing a fake mention with a real
+    # recording the agent was never mentioned in is dropped here, not emitted.
+    # For an assignment the verifier corroborates the agent's live assignee
+    # state but keeps the claimed assigner, so this re-check re-tests that same
+    # claimed identity (the verifier, not this method, is what proves the
+    # assignment real).
     def emit_if_verified(event)
       verified = @verifier.verify(event)
 

--- a/lib/basecamp_agent_connector/basecamp/pipeline.rb
+++ b/lib/basecamp_agent_connector/basecamp/pipeline.rb
@@ -1,6 +1,6 @@
 class BasecampAgentConnector::Basecamp::Pipeline
-  def initialize(operator:, agent:, verifier:, emitter:, logger: $stderr)
-    @operator = operator
+  def initialize(authorizer:, agent:, verifier:, emitter:, logger: $stderr)
+    @authorizer = authorizer
     @agent = agent
     @verifier = verifier
     @emitter = emitter
@@ -18,7 +18,7 @@ class BasecampAgentConnector::Basecamp::Pipeline
 
   private
     def actionable?(event)
-      event.actionable_kind? && event.authored_by?(@operator) && targets_agent?(event)
+      event.actionable_kind? && @authorizer.authorizes?(event) && targets_agent?(event)
     end
 
     def targets_agent?(event)
@@ -34,13 +34,18 @@ class BasecampAgentConnector::Basecamp::Pipeline
       end
     end
 
+    # Authorization is re-checked on the verified event: corroboration replaces
+    # the claimed creator with the one Basecamp actually recorded, and it is
+    # that authoritative author who must be authorized.
     def emit_if_verified(event)
       verified = @verifier.verify(event)
 
-      if verified
+      if verified.nil?
+        log "dropped event #{event.id}: not corroborated by Basecamp"
+      elsif @authorizer.authorizes?(verified)
         @emitter.emit(verified)
       else
-        log "dropped event #{event.id}: not corroborated by Basecamp"
+        log "dropped event #{event.id}: authoritative author is not authorized"
       end
     end
 

--- a/lib/basecamp_agent_connector/basecamp/pipeline.rb
+++ b/lib/basecamp_agent_connector/basecamp/pipeline.rb
@@ -34,18 +34,24 @@ class BasecampAgentConnector::Basecamp::Pipeline
       end
     end
 
-    # Authorization is re-checked on the verified event: corroboration replaces
-    # the claimed creator with the one Basecamp actually recorded, and it is
-    # that authoritative author who must be authorized.
+    # Both trust predicates are re-checked on the verified event, not just the
+    # claimed payload. Corroboration replaces the pre-filter's forgeable POST
+    # fields with what Basecamp actually recorded — the recording's real creator
+    # and its real content — so it is the authoritative author who must be
+    # authorized and the authoritative recording that must target the agent. A
+    # forged payload that pairs a fake mention with a real recording the agent
+    # was never mentioned in is therefore dropped here, not emitted.
     def emit_if_verified(event)
       verified = @verifier.verify(event)
 
       if verified.nil?
         log "dropped event #{event.id}: not corroborated by Basecamp"
-      elsif @authorizer.authorizes?(verified)
-        @emitter.emit(verified)
-      else
+      elsif !@authorizer.authorizes?(verified)
         log "dropped event #{event.id}: authoritative author is not authorized"
+      elsif !targets_agent?(verified)
+        log "dropped event #{event.id}: authoritative recording does not target the agent"
+      else
+        @emitter.emit(verified)
       end
     end
 

--- a/lib/basecamp_agent_connector/connector.rb
+++ b/lib/basecamp_agent_connector/connector.rb
@@ -44,7 +44,11 @@ class BasecampAgentConnector::Connector
       parser.on("--repo OWNER/REPO", "GitHub repo to watch for reviews (repeatable)") { |value| repos << value }
       parser.on("--operator PROFILE", "Profile whose user is allowed to trigger (default: CLI default profile)") { |value| operator = value }
       parser.on("--trust MODE", TRUST_MODES, "Who may trigger the agent: #{TRUST_MODES.join(", ")} (default: operator only; " \
-        "value flags below imply their mode)") { |value| trust = value.to_sym }
+        "value flags below imply their mode)") do |value|
+        raise ArgumentError, "--trust given twice with different modes (#{trust} then #{value})" if !trust.nil? && trust != value.to_sym
+
+        trust = value.to_sym
+      end
       parser.on("--allow EMAIL", "Also trust this author email (repeatable or comma-separated; implies --trust allowlist)") \
         { |value| allowed_emails.concat(comma_list(value)) }
       parser.on("--allow-domain DOMAIN", "Trust any author whose email is at this domain (repeatable or comma-separated; " \

--- a/lib/basecamp_agent_connector/connector.rb
+++ b/lib/basecamp_agent_connector/connector.rb
@@ -11,8 +11,10 @@ class BasecampAgentConnector::Connector
   # (Kanban::Card already covers card assignments).
   DEFAULT_TYPES = "Comment,Message,Kanban::Card,Kanban::Step,Todo"
   DEFAULT_EVENTS = "pull_request_review"
+  TRUST_MODES = %w[operator allowlist project domain]
 
-  Options = Data.define(:agent, :operator, :projects, :types, :repos, :events, :port)
+  Options = Data.define(:agent, :operator, :projects, :types, :repos, :events, :port,
+    :trust, :allowed_emails, :allowed_domains, :allow_assignments)
 
   def self.start(argv)
     new(parse_options(argv)).start
@@ -28,12 +30,29 @@ class BasecampAgentConnector::Connector
     types = DEFAULT_TYPES
     events = DEFAULT_EVENTS
     port = nil
+    trust = nil
+    allowed_emails = []
+    allowed_domains = []
+    allow_project = false
+    allow_assignments = false
 
     OptionParser.new do |parser|
-      parser.banner = "Usage: connect [@AGENT] [--project PROJECT]... [--repo OWNER/REPO]... [--operator PROFILE] [--types TYPES] [--events EVENTS] [--port PORT]"
+      parser.banner = "Usage: connect [@AGENT] [--project PROJECT]... [--repo OWNER/REPO]... [--operator PROFILE] " \
+        "[--trust MODE] [--allow EMAIL]... [--allow-domain DOMAIN]... [--allow-project] " \
+        "[--allow-assignments-from-authorized] [--types TYPES] [--events EVENTS] [--port PORT]"
       parser.on("--project PROJECT", "Basecamp project name, URL, or ID (repeatable)") { |value| projects << value }
       parser.on("--repo OWNER/REPO", "GitHub repo to watch for reviews (repeatable)") { |value| repos << value }
       parser.on("--operator PROFILE", "Profile whose user is allowed to trigger (default: CLI default profile)") { |value| operator = value }
+      parser.on("--trust MODE", TRUST_MODES, "Who may trigger the agent: #{TRUST_MODES.join(", ")} (default: operator only; " \
+        "value flags below imply their mode)") { |value| trust = value.to_sym }
+      parser.on("--allow EMAIL", "Also trust this author email (repeatable or comma-separated; implies --trust allowlist)") \
+        { |value| allowed_emails.concat(comma_list(value)) }
+      parser.on("--allow-domain DOMAIN", "Trust any author whose email is at this domain (repeatable or comma-separated; " \
+        "implies --trust domain; --trust domain alone defaults to #{BasecampAgentConnector::Basecamp::Authorizer::DEFAULT_TRUSTED_DOMAIN})") \
+        { |value| allowed_domains.concat(comma_list(value)) }
+      parser.on("--allow-project", "Trust any corroborated member of the watched projects (implies --trust project)") { allow_project = true }
+      parser.on("--allow-assignments-from-authorized", "Let any authorized author trigger via assignment too " \
+        "(default: assignments are operator-only in every mode)") { allow_assignments = true }
       parser.on("--types TYPES", "Comma-separated Basecamp event types") { |value| types = value }
       parser.on("--events EVENTS", "Comma-separated GitHub webhook events") { |value| events = value }
       parser.on("--port PORT", Integer, "Local port for the webhook server") { |value| port = value }
@@ -44,7 +63,33 @@ class BasecampAgentConnector::Connector
     raise ArgumentError, "watch something: pass at least one --project or --repo" if projects.empty? && repos.empty?
     raise ArgumentError, "an agent is required to watch Basecamp projects, e.g. `connect @clawdito --project \"My Project\"`" if projects.any? && (agent.nil? || agent.empty?)
 
-    Options.new(agent: normalize_agent(agent), operator: operator, projects: projects, types: types, repos: repos, events: events_list(events), port: port)
+    trust = resolve_trust(trust, emails: allowed_emails, domains: allowed_domains, project: allow_project)
+
+    Options.new(agent: normalize_agent(agent), operator: operator, projects: projects, types: types, repos: repos, events: events_list(events), port: port,
+      trust: trust, allowed_emails: allowed_emails, allowed_domains: allowed_domains, allow_assignments: allow_assignments)
+  end
+
+  # `--trust MODE` picks the mode explicitly; otherwise the value flags imply
+  # it (`--allow` => allowlist, `--allow-domain` => domain, `--allow-project`
+  # => project) and no flags at all means operator-only. Mixing flags that
+  # imply different modes, or a value flag contradicting `--trust`, is refused
+  # rather than guessed at.
+  def self.resolve_trust(explicit, emails:, domains:, project:)
+    implied = []
+    implied << :allowlist if emails.any?
+    implied << :domain if domains.any?
+    implied << :project if project
+
+    raise ArgumentError, "pick one trust mode: --allow, --allow-domain, and --allow-project imply different modes" if implied.length > 1
+    raise ArgumentError, "--trust #{explicit} conflicts with --allow#{"-domain" if implied == [ :domain ]}#{"-project" if implied == [ :project ]}" \
+      if !explicit.nil? && implied.any? && implied != [ explicit ]
+    raise ArgumentError, "--trust allowlist needs at least one --allow EMAIL" if explicit == :allowlist && emails.empty?
+
+    explicit || implied.first || :operator
+  end
+
+  def self.comma_list(value)
+    value.split(",").map(&:strip).reject(&:empty?)
   end
 
   def self.normalize_agent(agent)
@@ -88,9 +133,16 @@ class BasecampAgentConnector::Connector
       warn_if_same_user(agent, operator)
 
       BasecampAgentConnector::Basecamp::Bridge.new \
-        operator: operator, agent: agent,
+        authorizer: authorizer(operator, agent), agent: agent,
         projects: @options.projects, types: @options.types,
         basecamp_cli: basecamp_cli, emitter: emitter
+    end
+
+    def authorizer(operator, agent)
+      BasecampAgentConnector::Basecamp::Authorizer.build \
+        trust: @options.trust, operator: operator, agent: agent,
+        emails: @options.allowed_emails, domains: @options.allowed_domains,
+        allow_assignments: @options.allow_assignments
     end
 
     def github_bridge
@@ -123,7 +175,7 @@ class BasecampAgentConnector::Connector
     def warn_if_same_user(agent, operator)
       if agent.same_user_as?(operator)
         warn "Warning: agent '#{agent.profile}' and the operator are the same Basecamp user (#{agent.email}). " \
-          "Replies posted as the agent would re-trigger the connector — authenticate the agent profile as a distinct bot user."
+          "The agent's own identity never authorizes, so nothing will trigger — authenticate the agent profile as a distinct bot user."
       end
     end
 

--- a/lib/basecamp_agent_connector/connector.rb
+++ b/lib/basecamp_agent_connector/connector.rb
@@ -50,7 +50,7 @@ class BasecampAgentConnector::Connector
       parser.on("--allow-domain DOMAIN", "Trust any author whose email is at this domain (repeatable or comma-separated; " \
         "implies --trust domain; --trust domain alone defaults to #{BasecampAgentConnector::Basecamp::Authorizer::DEFAULT_TRUSTED_DOMAIN})") \
         { |value| allowed_domains.concat(comma_list(value)) }
-      parser.on("--allow-project", "Trust any corroborated member of the watched projects (implies --trust project)") { allow_project = true }
+      parser.on("--allow-project", "Trust any corroborated non-client author of a recording the operator can read (implies --trust project)") { allow_project = true }
       parser.on("--allow-assignments-from-authorized", "Let any authorized author trigger via assignment too " \
         "(default: assignments are operator-only in every mode)") { allow_assignments = true }
       parser.on("--types TYPES", "Comma-separated Basecamp event types") { |value| types = value }

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -75,6 +75,8 @@ run `bin/setup` (see the repo README).
 /basecamp-connect @Clawdito --project "BC5 Calendar"                 # one project
 /basecamp-connect @Clawdito --project "BC5 Calendar" --project HEY    # several
 /basecamp-connect @Clawdito --project "BC5 Calendar" --operator jorge # explicit operator
+/basecamp-connect @Clawdito --project "BC5 Calendar" --allow marie@37signals.com  # + a named coworker
+/basecamp-connect @Clawdito --project "BC5 Calendar" --allow-domain 37signals.com # any 37signals author
 ```
 
 `<agent>` is a real Basecamp user backed by a local CLI profile (the leading `@`
@@ -82,6 +84,13 @@ is optional; it's lowercased to the profile name). `--project` is **required**
 (Basecamp has no global webhook) — pass a name, URL, or ID. The connector
 **validates the agent profile exists locally at startup** and aborts with setup
 guidance if not.
+
+**Who may trigger** defaults to the operator alone. Broaden it deliberately with
+the trust flags — `--allow <email>`, `--allow-domain <domain>`, `--allow-project`,
+or explicit `--trust <mode>` — and pass them straight through to `bin/connect`;
+the bridge enforces them and logs the active set. See the connector README's
+"Trust modes" for the full semantics and the agent-self / assignments-operator-only
+safeguards.
 
 ### Stored connection params (no-args invocation)
 
@@ -93,21 +102,31 @@ The skill remembers the last successful connection in
   "agent": "clawdito",
   "operator": null,
   "projects": [ { "id": 27, "name": "On Call" }, { "id": 41746046, "name": "BC5.1" } ],
+  "trust": { "mode": "domain", "allow": [], "allow_domain": [ "37signals.com" ], "allow_assignments": false },
   "saved_at": "2026-07-01T15:00:00Z"
 }
 ```
 
 - **Invoked without arguments:** read that file and **confirm the stored params
-  with the user before starting** — show the agent and the project list and ask
-  whether to go with them, adjust them (add/drop projects, different agent), or
+  with the user before starting** — show the agent, the project list, **and the
+  trust configuration (mode + the concrete allowed set)** and ask whether to go
+  with them, adjust them (add/drop projects, different agent, change trust), or
   start fresh. Never launch on stored params silently. If the file doesn't
   exist, ask for the agent and projects as usual.
 - **Invoked with arguments:** arguments win; the store is not consulted.
 - **After every successful registration** (the `Listening for mentions of …`
   line), write the params that were actually used back to the file — agent
-  profile, operator override (or null), and the projects with their resolved
-  ids and names — so the store always reflects the last working connection.
-  Create the directory if needed. Launch failures must not overwrite it.
+  profile, operator override (or null), the projects with their resolved ids and
+  names, **and the trust configuration** (the mode and its value flags, so a
+  later no-argument launch reconstructs the same trust boundary rather than
+  silently falling back to operator-only) — so the store always reflects the
+  last working connection. Create the directory if needed. Launch failures must
+  not overwrite it.
+- **Reconstructing the command from the store:** translate `trust` back into the
+  same flags (`allow` → `--allow`, `allow_domain` → `--allow-domain`, mode
+  `project` → `--allow-project`, `allow_assignments` → the assignment opt-in). A
+  missing `trust` block means operator-only (older stores) — do not invent a
+  broader mode.
 
 Project ids are stored (not just names) because name lookup is exact-match;
 launching from the store passes ids.
@@ -128,9 +147,11 @@ agent/bot account):
 basecamp auth login --profile clawdito
 ```
 
-If the agent profile resolves to the **same** user as the operator, replies would
-re-trigger the connector — `bin/connect` warns about this at startup. Use a
-distinct bot account for the agent.
+If the agent profile resolves to the **same** user as the operator, **nothing
+will trigger**: the connector refuses the agent's own identity in every trust
+mode, so if the agent *is* the operator, the operator's own mentions are dropped
+too. `bin/connect` warns about this at startup. Use a distinct bot account for
+the agent.
 
 ## Procedure
 
@@ -179,8 +200,12 @@ Each STDOUT line is one trusted event as NDJSON:
    "parent":{...},"bucket":{"id":222,"name":"BC5 Calendar"}}}
 ```
 
-`creator` is the operator (you). The mention of the agent lives in
-`recording.content` as a mention attachment. STDERR carries diagnostics
+`creator` is the **triggering author** — the person whose mention/assignment
+drove this event. In the default operator-only mode that is always you; under a
+broadened trust mode (`--allow`, `--allow-domain`, `--allow-project`) it may be
+an authorized coworker instead. Treat `creator` as *the requester* — that is who
+to @mention on failure — not as "the operator." The mention of the agent lives
+in `recording.content` as a mention attachment. STDERR carries diagnostics
 (dropped/uncorroborated events, registration notices) — surface them but don't
 act on them.
 
@@ -211,7 +236,9 @@ everything it needs to finish **without the front thread**:
   rest of the raw HTML (links, other mentions) intact;
 - the **recording** URL/id and its parent URL;
 - the **agent profile name** (its reply identity);
-- the **operator's** name/id (to @mention on failure).
+- the **requester's** name/id — i.e. the event `creator` (to @mention on
+  failure). This is the triggering author, who under a broadened trust mode is
+  not necessarily the operator.
 
 Instruct that background agent to, in order:
 
@@ -250,7 +277,9 @@ Instruct that background agent to, in order:
    ```
    - **Success** — post the results where the mention was written.
    - **Failure** (it errored or couldn't finish) — post a short error summary and
-     **@mention the operator** so it surfaces as a notification.
+     **@mention the requester** (the event `creator`) so it surfaces as a
+     notification for whoever asked — the operator in the default mode, or the
+     authorized coworker who triggered it under a broadened mode.
    - **Never put the agent mention in a reply body.**
 
 Because the background agent gathers its own context and posts its own reply, the
@@ -323,8 +352,8 @@ green** — getting CI green is part of finishing the task, not a follow-up:
    what local passed).
 5. **Only now reply "done"** on Basecamp, with the PR link. Never communicate
    success on a red or unchecked branch. If you cannot get it green after a
-   reasonable effort, reply with **what is failing** and @mention the operator —
-   not a false "done."
+   reasonable effort, reply with **what is failing** and @mention the requester
+   (the event `creator`) — not a false "done."
 
 #### Review / approval loop (GitHub webhook)
 

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -302,9 +302,11 @@ depth.
 
 ### When the agent is assigned a card/todo
 
-If the event `kind` ends in `_assignment_changed`, the operator assigned the
-agent to the recording (a card/todo/step) — there's no mention to strip; **the
-recording itself is the task**. The dispatched background agent should, in order:
+If the event `kind` ends in `_assignment_changed`, the requester (the event
+`creator` — the operator by default, or an authorized coworker when `bin/connect`
+runs with `--allow-assignments-from-authorized`) assigned the agent to the
+recording (a card/todo/step) — there's no mention to strip; **the recording
+itself is the task**. The dispatched background agent should, in order:
 
 1. **Acknowledge first with a boost** — same as for a mention: boost the
    recording with `On it!` as the agent (`basecamp boost create <recording.url|id>
@@ -317,7 +319,7 @@ recording itself is the task**. The dispatched background agent should, in order
    instruction; gather context and resolve the repo as usual; if it's a PR task,
    follow the green-first lifecycle below).
 4. **Reply with the result** on the same recording as the agent — and on failure,
-   a short error summary that @mentions the operator.
+   a short error summary that @mentions the requester (the event `creator`).
 
 The instruction here is the **card/todo content**, not a comment body. Everything
 else (resolve repo, one background agent owns it end-to-end, front thread returns

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -122,11 +122,18 @@ The skill remembers the last successful connection in
   silently falling back to operator-only) — so the store always reflects the
   last working connection. Create the directory if needed. Launch failures must
   not overwrite it.
-- **Reconstructing the command from the store:** translate `trust` back into the
-  same flags (`allow` → `--allow`, `allow_domain` → `--allow-domain`, mode
-  `project` → `--allow-project`, `allow_assignments` → the assignment opt-in). A
-  missing `trust` block means operator-only (older stores) — do not invent a
-  broader mode.
+- **Reconstructing the command from the store:** always emit **exactly one
+  `--trust <mode>`** for the stored mode, followed by its value flags (`allow` →
+  `--allow`, `allow_domain` → `--allow-domain`, `allow_assignments` → the
+  assignment opt-in; `--trust project` needs no value flag). Emitting the mode
+  explicitly makes `bare --trust domain` (empty `allow_domain`) reconstruct as
+  `domain` — using the built-in default domain — rather than silently dropping
+  to operator, and makes a value flag that disagrees with the stored mode (e.g.
+  `mode:"operator"` with a stray `allow_domain`) get **rejected by the parser**
+  rather than silently broadening trust. A missing `trust` block means
+  operator-only (older stores). If the stored block is internally inconsistent
+  and the parser rejects it, **stop and confirm with the user** — never infer a
+  mode to make it launch.
 
 Project ids are stored (not just names) because name lookup is exact-match;
 launching from the store passes ids.

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -2,8 +2,9 @@
 name: basecamp-connect
 description: |
   Manage local Claude Code agents from Basecamp. Runs the connector bridge
-  (bin/connect), watches its STDOUT for trusted events — authored by the operator
-  and @mentioning a real Basecamp agent user — and hands each off to a background
+  (bin/connect), watches its STDOUT for trusted events — authored by an authorized
+  user (the operator alone, by default) and @mentioning a real Basecamp agent
+  user — and hands each off to a background
   agent that gathers context, does the work, and replies as that agent user, so the
   watcher thread stays free to keep taking new mentions.
   Invoked without arguments it recalls the last-used agent and projects from
@@ -32,17 +33,22 @@ The agent is identified by a **local `basecamp` CLI profile** of the same name
 - the **mention target** — the connector only fires when that user is @mentioned.
 
 The trust model is enforced by `bin/connect`, **not** by this skill: an event
-reaches STDOUT only if it is (1) authored by the **operator** (you — the CLI
-default profile, or `--operator <profile>`), (2) **either** @mentions the agent
+reaches STDOUT only if it is (1) authored by an **authorized user** — by default
+the operator alone (you — the CLI default profile, or `--operator <profile>`);
+`bin/connect`'s trust flags (`--trust`, `--allow`, `--allow-domain`,
+`--allow-project`) can deliberately broaden this to named colleagues, an email
+domain, or the whole project membership — (2) **either** @mentions the agent
 user **or** assigns it a card/todo, and (3) is corroborated against the Basecamp
-API. Treat every STDOUT line as already-trusted — but still keep dispatched
-agents scoped to the resolved repo.
+API. The agent's own identity never authorizes, in any mode. Treat every STDOUT
+line as already-trusted — but still keep dispatched agents scoped to the
+resolved repo.
 
 There are thus **two triggers**: an `@mention` of the agent, or the operator
 **assigning** the agent a card/todo (a `*_assignment_changed` event whose
 `details.added_person_ids` includes the agent — corroborated by re-fetching the
 recording and confirming the agent is among its current `assignees`). Only the
-**operator's** assignments count.
+**operator's** assignments count, in every trust mode, unless `bin/connect` was
+started with `--allow-assignments-from-authorized`.
 
 ## Runs from any project — the runtime lives in the connector clone
 
@@ -253,9 +259,9 @@ monitor, ready for the next mention while any number of events are in flight.
 There is **no concurrency cap**; dispatch every event as it arrives.
 
 **c. Drop self-authored events.** If an event's recording is a comment the agent
-itself just posted, ignore it. Posting as the agent (a distinct user from the
-operator) already keeps replies from re-triggering the connector — the trust
-filter requires the *operator* to be the author — but this is cheap defense in
+itself just posted, ignore it. `bin/connect` already refuses agent-authored
+events in every trust mode, and posting as the agent (a distinct user from the
+operator) keeps replies from authorizing anyway — but this is cheap defense in
 depth.
 
 ### When the agent is assigned a card/todo
@@ -385,9 +391,8 @@ leave a registered webhook or a mounted path behind.
 - The connector never trusts the POST body's content — it re-fetches the
   recording from Basecamp before emitting. The content you see on STDOUT is the
   authoritative copy.
-- **Reply loop (defense in depth):** trust is "authored by the operator AND
-  mentions the agent." Replying as the agent profile (a distinct user) means
-  agent replies fail the operator-author check and are never re-ingested. The
-  durable belt-and-suspenders fix still belongs in `bin/connect` (don't emit
-  recordings the agent authored); until then, reply as the agent and keep the
-  agent mention out of reply bodies.
+- **Reply loop (defense in depth):** trust is "authored by an authorized user
+  AND mentions the agent," and `bin/connect` refuses agent-authored events
+  outright in every trust mode (matched by email and Person id). Replying as
+  the agent profile (a distinct user) means agent replies are never
+  re-ingested; still keep the agent mention out of reply bodies as a courtesy.

--- a/test/authorizer_test.rb
+++ b/test/authorizer_test.rb
@@ -1,10 +1,10 @@
 require "test_helper"
 
 class AuthorizerTest < Minitest::Test
-  OPERATOR = { "id" => 100, "name" => "Operator", "email_address" => "operator@example.com" }
-  COLLEAGUE = { "id" => 300, "name" => "Marie", "email_address" => "marie@example.com" }
-  STRANGER = { "id" => 400, "name" => "Sam", "email_address" => "sam@elsewhere.net" }
-  AGENT = { "id" => 200, "name" => "Clawdito", "email_address" => "clawdito@example.com" }
+  OPERATOR = { "id" => 100, "name" => "Operator", "email_address" => "operator@example.com", "client" => false }
+  COLLEAGUE = { "id" => 300, "name" => "Marie", "email_address" => "marie@example.com", "client" => false }
+  STRANGER = { "id" => 400, "name" => "Sam", "email_address" => "sam@elsewhere.net", "client" => false }
+  AGENT = { "id" => 200, "name" => "Clawdito", "email_address" => "clawdito@example.com", "client" => false }
 
   def test_operator_mode_authorizes_only_the_operator
     assert authorizer.authorizes?(mention_by(OPERATOR))
@@ -45,6 +45,16 @@ class AuthorizerTest < Minitest::Test
 
     refute project.authorizes?(mention_by(COLLEAGUE.merge("client" => true)))
     refute project.authorizes?(mention_by({}))
+  end
+
+  def test_project_mode_fails_closed_when_the_client_flag_is_absent
+    project = authorizer(trust: :project)
+
+    # No leaked secret path needed: if the corroborated recording omits the
+    # client flag, the author is untrusted rather than assumed an employee.
+    refute project.authorizes?(mention_by("id" => 300, "email_address" => "marie@example.com"))
+    refute project.authorizes?(mention_by(COLLEAGUE.merge("client" => nil)))
+    refute project.authorizes?(mention_by(COLLEAGUE.merge("client" => "false")))
   end
 
   def test_project_mode_never_authorizes_the_agent

--- a/test/authorizer_test.rb
+++ b/test/authorizer_test.rb
@@ -1,0 +1,132 @@
+require "test_helper"
+
+class AuthorizerTest < Minitest::Test
+  OPERATOR = { "id" => 100, "name" => "Operator", "email_address" => "operator@example.com" }
+  COLLEAGUE = { "id" => 300, "name" => "Marie", "email_address" => "marie@example.com" }
+  STRANGER = { "id" => 400, "name" => "Sam", "email_address" => "sam@elsewhere.net" }
+  AGENT = { "id" => 200, "name" => "Clawdito", "email_address" => "clawdito@example.com" }
+
+  def test_operator_mode_authorizes_only_the_operator
+    assert authorizer.authorizes?(mention_by(OPERATOR))
+    refute authorizer.authorizes?(mention_by(COLLEAGUE))
+    refute authorizer.authorizes?(mention_by(AGENT))
+  end
+
+  def test_allowlist_authorizes_the_operator_and_each_allowed_email
+    allowlist = authorizer(trust: :allowlist, emails: [ "marie@example.com", "sam@elsewhere.net" ])
+
+    assert allowlist.authorizes?(mention_by(OPERATOR))
+    assert allowlist.authorizes?(mention_by(COLLEAGUE))
+    assert allowlist.authorizes?(mention_by(STRANGER))
+    refute allowlist.authorizes?(mention_by("id" => 500, "email_address" => "other@example.com"))
+  end
+
+  def test_allowlist_matches_emails_case_insensitively
+    allowlist = authorizer(trust: :allowlist, emails: [ "Marie@Example.com" ])
+
+    assert allowlist.authorizes?(mention_by(COLLEAGUE))
+  end
+
+  def test_allowlist_never_authorizes_the_agent_even_when_listed
+    allowlist = authorizer(trust: :allowlist, emails: [ "clawdito@example.com" ])
+
+    refute allowlist.authorizes?(mention_by(AGENT))
+  end
+
+  def test_project_mode_authorizes_any_corroborated_author
+    project = authorizer(trust: :project)
+
+    assert project.authorizes?(mention_by(COLLEAGUE))
+    assert project.authorizes?(mention_by(STRANGER))
+  end
+
+  def test_project_mode_refuses_client_users_and_missing_creators
+    project = authorizer(trust: :project)
+
+    refute project.authorizes?(mention_by(COLLEAGUE.merge("client" => true)))
+    refute project.authorizes?(mention_by({}))
+  end
+
+  def test_project_mode_never_authorizes_the_agent
+    project = authorizer(trust: :project)
+
+    refute project.authorizes?(mention_by(AGENT))
+    # matched by Person id even when the email claims someone else
+    refute project.authorizes?(mention_by("id" => 200, "email_address" => "someone@example.com"))
+  end
+
+  def test_domain_mode_authorizes_matching_domains_only
+    domain = authorizer(trust: :domain, domains: [ "example.com" ])
+
+    assert domain.authorizes?(mention_by(COLLEAGUE))
+    assert domain.authorizes?(mention_by(COLLEAGUE.merge("email_address" => "Marie@EXAMPLE.COM")))
+    refute domain.authorizes?(mention_by(STRANGER))
+    refute domain.authorizes?(mention_by(COLLEAGUE.merge("email_address" => nil)))
+  end
+
+  def test_domain_mode_matches_the_domain_part_exactly
+    domain = authorizer(trust: :domain, domains: [ "example.com" ])
+
+    refute domain.authorizes?(mention_by("id" => 500, "email_address" => "sam@notexample.com"))
+    refute domain.authorizes?(mention_by("id" => 500, "email_address" => "sam@mail.example.com"))
+  end
+
+  def test_domain_mode_tolerates_a_leading_at_sign_in_the_configured_domain
+    domain = authorizer(trust: :domain, domains: [ "@example.com" ])
+
+    assert domain.authorizes?(mention_by(COLLEAGUE))
+  end
+
+  def test_domain_mode_never_authorizes_the_agent_on_a_shared_domain
+    domain = authorizer(trust: :domain, domains: [ "example.com" ])
+
+    refute domain.authorizes?(mention_by(AGENT))
+  end
+
+  def test_domain_mode_defaults_to_37signals
+    domain = authorizer(trust: :domain)
+
+    assert domain.authorizes?(mention_by("id" => 500, "email_address" => "andrea@37signals.com"))
+    refute domain.authorizes?(mention_by(COLLEAGUE))
+  end
+
+  def test_assignments_stay_operator_only_in_broadened_modes
+    allowlist = authorizer(trust: :allowlist, emails: [ "marie@example.com" ])
+
+    assert allowlist.authorizes?(assignment_by(OPERATOR))
+    refute allowlist.authorizes?(assignment_by(COLLEAGUE))
+  end
+
+  def test_assignments_open_to_authorized_authors_only_by_explicit_opt_in
+    allowlist = authorizer(trust: :allowlist, emails: [ "marie@example.com" ], allow_assignments: true)
+
+    assert allowlist.authorizes?(assignment_by(COLLEAGUE))
+    refute allowlist.authorizes?(assignment_by(STRANGER))
+    refute allowlist.authorizes?(assignment_by(AGENT))
+  end
+
+  def test_describes_the_active_trust_configuration
+    assert_equal "operator only (operator@example.com); assignments: operator only", authorizer.description
+    assert_equal "allowlist — operator (operator@example.com) + marie@example.com; assignments: operator only",
+      authorizer(trust: :allowlist, emails: [ "marie@example.com" ]).description
+    assert_equal "any corroborated project member (clients excluded); assignments: operator only",
+      authorizer(trust: :project).description
+    assert_equal "any @37signals.com author; assignments: any authorized author",
+      authorizer(trust: :domain, allow_assignments: true).description
+  end
+
+  def test_refuses_an_unknown_trust_mode
+    assert_raises ArgumentError do
+      authorizer(trust: :everyone)
+    end
+  end
+
+  private
+    def mention_by(creator)
+      BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload("creator" => creator))
+    end
+
+    def assignment_by(creator)
+      BasecampAgentConnector::Basecamp::Event.from_payload(assignment_payload("creator" => creator))
+    end
+end

--- a/test/authorizer_test.rb
+++ b/test/authorizer_test.rb
@@ -61,8 +61,9 @@ class AuthorizerTest < Minitest::Test
     project = authorizer(trust: :project)
 
     refute project.authorizes?(mention_by(AGENT))
-    # matched by Person id even when the email claims someone else
-    refute project.authorizes?(mention_by("id" => 200, "email_address" => "someone@example.com"))
+    # matched by Person id even when the email claims someone else; client=>false
+    # so it is the self-exclusion guard, not the fail-closed client check, that drops it
+    refute project.authorizes?(mention_by("id" => 200, "email_address" => "someone@example.com", "client" => false))
   end
 
   def test_domain_mode_authorizes_matching_domains_only

--- a/test/basecamp_bridge_test.rb
+++ b/test/basecamp_bridge_test.rb
@@ -29,15 +29,25 @@ class BasecampBridgeTest < Minitest::Test
     assert_equal 1, runner.commands_matching(/webhooks delete/).length
   end
 
+  def test_register_logs_the_active_trust_mode
+    runner = FakeCommandRunner.new
+    runner.stub "webhooks create", stdout: envelope("id" => 555)
+    logs = StringIO.new
+
+    bridge(runner, logger: logs).register(base_url: "https://host.ts.net")
+
+    assert_match(/Trust: operator only \(operator@example\.com\); assignments: operator only/, logs.string)
+  end
+
   private
-    def bridge(runner, projects: [ "A" ])
+    def bridge(runner, projects: [ "A" ], logger: StringIO.new)
       BasecampAgentConnector::Basecamp::Bridge.new \
-        operator: operator_identity,
+        authorizer: authorizer,
         agent: agent_identity,
         projects: projects,
         types: "Comment",
         basecamp_cli: build_cli(runner),
         emitter: BasecampAgentConnector::Emitter.new(output: StringIO.new),
-        logger: StringIO.new
+        logger: logger
     end
 end

--- a/test/connector_test.rb
+++ b/test/connector_test.rb
@@ -10,6 +10,61 @@ class ConnectorTest < Minitest::Test
     assert_equal "Comment,Message,Kanban::Card,Kanban::Step,Todo", options.types
     assert_equal [ "pull_request_review" ], options.events
     assert_nil options.port
+    assert_equal :operator, options.trust
+    assert_empty options.allowed_emails
+    assert_empty options.allowed_domains
+    refute options.allow_assignments
+  end
+
+  def test_allow_implies_allowlist_trust
+    options = parse "@clawdito", "--project", "A", "--allow", "marie@example.com", "--allow", "sam@example.com, ana@example.com"
+
+    assert_equal :allowlist, options.trust
+    assert_equal [ "marie@example.com", "sam@example.com", "ana@example.com" ], options.allowed_emails
+  end
+
+  def test_allow_domain_implies_domain_trust
+    options = parse "@clawdito", "--project", "A", "--allow-domain", "example.com"
+
+    assert_equal :domain, options.trust
+    assert_equal [ "example.com" ], options.allowed_domains
+  end
+
+  def test_trust_domain_alone_uses_the_default_domain
+    options = parse "@clawdito", "--project", "A", "--trust", "domain"
+
+    assert_equal :domain, options.trust
+    assert_empty options.allowed_domains
+  end
+
+  def test_allow_project_implies_project_trust
+    options = parse "@clawdito", "--project", "A", "--allow-project"
+
+    assert_equal :project, options.trust
+  end
+
+  def test_parses_the_assignment_opt_in
+    options = parse "@clawdito", "--project", "A", "--allow-project", "--allow-assignments-from-authorized"
+
+    assert options.allow_assignments
+  end
+
+  def test_refuses_value_flags_that_imply_different_trust_modes
+    assert_raises ArgumentError do
+      parse "@clawdito", "--project", "A", "--allow", "marie@example.com", "--allow-domain", "example.com"
+    end
+  end
+
+  def test_refuses_an_explicit_trust_mode_contradicted_by_a_value_flag
+    assert_raises ArgumentError do
+      parse "@clawdito", "--project", "A", "--trust", "operator", "--allow", "marie@example.com"
+    end
+  end
+
+  def test_refuses_an_allowlist_with_no_allowed_emails
+    assert_raises ArgumentError do
+      parse "@clawdito", "--project", "A", "--trust", "allowlist"
+    end
   end
 
   def test_parses_github_only_without_an_agent
@@ -73,6 +128,10 @@ class ConnectorTest < Minitest::Test
   end
 
   private
+    def parse(*argv)
+      BasecampAgentConnector::Connector.parse_options(argv)
+    end
+
     def start_connector(argv, runner)
       connector = BasecampAgentConnector::Connector.new(BasecampAgentConnector::Connector.parse_options(argv))
       connector.instance_variable_set(:@command_runner, runner)

--- a/test/connector_test.rb
+++ b/test/connector_test.rb
@@ -67,6 +67,18 @@ class ConnectorTest < Minitest::Test
     end
   end
 
+  def test_refuses_a_repeated_trust_flag_with_different_modes
+    assert_raises ArgumentError do
+      parse "@clawdito", "--project", "A", "--trust", "operator", "--trust", "project"
+    end
+  end
+
+  def test_allows_a_repeated_trust_flag_with_the_same_mode
+    options = parse "@clawdito", "--project", "A", "--trust", "project", "--trust", "project"
+
+    assert_equal :project, options.trust
+  end
+
   def test_parses_github_only_without_an_agent
     options = BasecampAgentConnector::Connector.parse_options([ "--repo", "basecamp/bc3" ])
 

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -95,6 +95,19 @@ class PipelineTest < Minitest::Test
     assert_match(/authoritative author is not authorized/, @logs.string)
   end
 
+  def test_drops_a_forged_mention_when_the_authoritative_recording_has_none
+    # The POST claims a mention of the agent (passing the pre-filter) but points
+    # at a real operator recording that never mentioned the agent. The verified
+    # recording is authoritative and carries no mention, so it must not emit.
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(sample_recording("content" => "<p>a plain operator note, no mention</p>"))
+
+    pipeline(runner).process(sample_payload)
+
+    assert_empty @output.string
+    assert_match(/does not target the agent/, @logs.string)
+  end
+
   def test_allowlist_emits_for_an_allowed_author
     runner = FakeCommandRunner.new
     runner.stub "basecamp show", stdout: envelope(sample_recording("creator" => colleague))

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -151,8 +151,10 @@ class PipelineTest < Minitest::Test
   def test_project_trust_ignores_an_event_authored_by_the_agent_itself
     runner = FakeCommandRunner.new
 
+    # client=>false so the drop is the Person-id self-exclusion guard, not the
+    # fail-closed client check masking a regression in it.
     pipeline(runner, authorizer: authorizer(trust: :project))
-      .process(sample_payload("creator" => { "id" => 200, "name" => "Clawdito", "email_address" => "clawdito@example.com" }))
+      .process(sample_payload("creator" => { "id" => 200, "name" => "Clawdito", "email_address" => "clawdito@example.com", "client" => false }))
 
     assert_empty @output.string
     assert_empty runner.commands

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -210,7 +210,7 @@ class PipelineTest < Minitest::Test
 
   private
     def colleague
-      { "id" => 300, "name" => "Marie", "email_address" => "marie@example.com" }
+      { "id" => 300, "name" => "Marie", "email_address" => "marie@example.com", "client" => false }
     end
 
     def corroborating_runner

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -85,16 +85,130 @@ class PipelineTest < Minitest::Test
     assert_empty @output.string
   end
 
+  def test_drops_event_whose_claimed_author_is_not_the_authoritative_one
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(sample_recording("creator" => { "id" => 100, "name" => "Sam", "email_address" => "sam@elsewhere.net" }))
+
+    pipeline(runner).process(sample_payload)
+
+    assert_empty @output.string
+    assert_match(/authoritative author is not authorized/, @logs.string)
+  end
+
+  def test_allowlist_emits_for_an_allowed_author
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(sample_recording("creator" => colleague))
+
+    pipeline(runner, authorizer: authorizer(trust: :allowlist, emails: [ "marie@example.com" ]))
+      .process(sample_payload("creator" => colleague))
+
+    assert_equal 1, @output.string.lines.length
+    assert_equal "marie@example.com", JSON.parse(@output.string)["creator"]["email_address"]
+  end
+
+  def test_allowlist_ignores_an_author_not_on_the_list
+    runner = FakeCommandRunner.new
+
+    pipeline(runner, authorizer: authorizer(trust: :allowlist, emails: [ "marie@example.com" ]))
+      .process(sample_payload("creator" => { "id" => 400, "email_address" => "sam@elsewhere.net" }))
+
+    assert_empty @output.string
+    assert_empty runner.commands
+  end
+
+  def test_project_trust_emits_for_any_corroborated_author
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(sample_recording("creator" => colleague))
+
+    pipeline(runner, authorizer: authorizer(trust: :project)).process(sample_payload("creator" => colleague))
+
+    assert_equal 1, @output.string.lines.length
+  end
+
+  def test_project_trust_drops_an_author_basecamp_marks_as_a_client
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(sample_recording("creator" => colleague.merge("client" => true)))
+
+    pipeline(runner, authorizer: authorizer(trust: :project)).process(sample_payload("creator" => colleague))
+
+    assert_empty @output.string
+    assert_match(/authoritative author is not authorized/, @logs.string)
+  end
+
+  def test_project_trust_ignores_an_event_authored_by_the_agent_itself
+    runner = FakeCommandRunner.new
+
+    pipeline(runner, authorizer: authorizer(trust: :project))
+      .process(sample_payload("creator" => { "id" => 200, "name" => "Clawdito", "email_address" => "clawdito@example.com" }))
+
+    assert_empty @output.string
+    assert_empty runner.commands
+  end
+
+  def test_domain_trust_emits_for_a_matching_domain
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(sample_recording("creator" => colleague))
+
+    pipeline(runner, authorizer: authorizer(trust: :domain, domains: [ "example.com" ]))
+      .process(sample_payload("creator" => colleague))
+
+    assert_equal 1, @output.string.lines.length
+  end
+
+  def test_domain_trust_ignores_other_domains
+    runner = FakeCommandRunner.new
+
+    pipeline(runner, authorizer: authorizer(trust: :domain, domains: [ "example.com" ]))
+      .process(sample_payload("creator" => { "id" => 400, "email_address" => "sam@elsewhere.net" }))
+
+    assert_empty @output.string
+    assert_empty runner.commands
+  end
+
+  def test_domain_trust_ignores_the_agent_itself_on_a_shared_domain
+    runner = FakeCommandRunner.new
+
+    pipeline(runner, authorizer: authorizer(trust: :domain, domains: [ "example.com" ]))
+      .process(sample_payload("creator" => { "id" => 200, "name" => "Clawdito", "email_address" => "clawdito@example.com" }))
+
+    assert_empty @output.string
+    assert_empty runner.commands
+  end
+
+  def test_broadened_trust_keeps_assignments_operator_only
+    runner = FakeCommandRunner.new
+
+    pipeline(runner, authorizer: authorizer(trust: :allowlist, emails: [ "marie@example.com" ]))
+      .process(assignment_payload("creator" => colleague))
+
+    assert_empty @output.string
+    assert_empty runner.commands
+  end
+
+  def test_assignment_opt_in_lets_an_authorized_author_assign
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(assigned_recording)
+
+    pipeline(runner, authorizer: authorizer(trust: :allowlist, emails: [ "marie@example.com" ], allow_assignments: true))
+      .process(assignment_payload("creator" => colleague))
+
+    assert_equal 1, @output.string.lines.length
+  end
+
   private
+    def colleague
+      { "id" => 300, "name" => "Marie", "email_address" => "marie@example.com" }
+    end
+
     def corroborating_runner
       runner = FakeCommandRunner.new
       runner.stub "basecamp show", stdout: envelope(sample_recording)
       runner
     end
 
-    def pipeline(runner)
+    def pipeline(runner, authorizer: authorizer())
       BasecampAgentConnector::Basecamp::Pipeline.new \
-        operator: @operator,
+        authorizer: authorizer,
         agent: @agent,
         verifier: BasecampAgentConnector::Basecamp::Verifier.new(basecamp_cli: build_cli(runner), agent: @agent),
         emitter: BasecampAgentConnector::Emitter.new(output: @output),

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -112,6 +112,12 @@ module PayloadHelpers
     BasecampAgentConnector::Basecamp::Identity.new(id: 100, email: "operator@example.com")
   end
 
+  def authorizer(trust: :operator, emails: [], domains: [], allow_assignments: false, operator: operator_identity, agent: agent_identity)
+    BasecampAgentConnector::Basecamp::Authorizer.build \
+      trust: trust, operator: operator, agent: agent,
+      emails: emails, domains: domains, allow_assignments: allow_assignments
+  end
+
   def agent_identity(name: "Clawdito", person_id: 200)
     BasecampAgentConnector::Basecamp::Identity.new(id: 200, profile: "clawdito", email: "clawdito@example.com", name: name, person_id: person_id)
   end


### PR DESCRIPTION
## What & why

The connector's trust gate is one line — an event acts only when its author is the operator. That is the right default, but there are legitimate reasons to let a small, deliberately chosen set of coworkers drive an agent too. This makes the gate **configurable across four modes** while keeping the operator-only default byte-for-byte: **no flags = today's behavior exactly.**

These agents run locally with the operator's full machine authority, so *who may drive them* is a security decision, not a convenience toggle. The change is built to be conservative by default and explicit when broadened.

## The four modes

| Mode | Who may trigger | CLI |
|------|-----------------|-----|
| `operator` *(default)* | Operator only. No flags selects this. | — |
| `allowlist` | Operator + named emails. | `--allow a@x.com` (repeatable / comma-separated) |
| `project` | Operator + any corroborated non-client project author. | `--allow-project` |
| `domain` | Operator + any author at a listed domain. | `--allow-domain 37signals.com`; bare `--trust domain` defaults to 37signals.com |

Mode is inferred from the value flags (`--allow` ⇒ allowlist, `--allow-domain` ⇒ domain, `--allow-project` ⇒ project) or set explicitly with `--trust MODE`; contradictory combinations are refused rather than guessed. The gate is a small `Authorizer` strategy (`authorizes?(event)`) that the pipeline consults, not a pile of conditionals: `actionable?` is now `actionable_kind? && authorizer.authorizes?(event) && targets_agent?(event)`.

## Safety guarantees (implemented + tested)

- **Default preserves current behavior exactly** — no flags means operator-only, matched by email as before.
- **The agent's own identity never authorizes, in any mode** — an explicit guard, matched by *both* email and Person id, refuses agent-authored events before any mode is consulted. This is the belt to `targets_agent?`'s suspenders for the `domain`/`project` reply-loop case, where the agent's email may share the domain or it may be a project member.
- **Assignments stay operator-only in every broadened mode** unless `--allow-assignments-from-authorized` opts them in. Assigning the agent a card is higher-privilege and the assigner's identity is not corroborated, so broadened trust applies to *mentions* only by default.
- **Authorization is checked twice** — as a cheap pre-filter on the claimed payload, then again on the **corroborated** event, so the decision binds to the author Basecamp actually recorded, never to forgeable POST text.
- **Targeting is also re-checked on the corroborated event** (last commit) — closes a forgery where a fabricated mention is paired with a real recording that never mentioned the agent.
- **Startup logs the active trust mode and the concrete allowed set** next to the listening line — visibility is a feature for a trust boundary.

## Adversarial review

Driven through Codex at xhigh as a trust-boundary change. Its findings are addressed or documented in the PR: the corroborated-targeting gap is fixed here; project mode's forged-POST limits (trust not pinned to a *watched* project; client-flag fail-open) and the assignment trigger's unverified-assigner caveat are stated plainly in the README, as they sit in the pre-existing verifier and only bite the leaked-secret-path threat.

## Open decisions for the operator

- **Mode B client exclusion** relies on `creator.client` being present in the API payload; absent, it fails open. Kept permissive per the mode's "corroboration is the membership proof" framing — flag if you want it to fail closed.
- **Assignment opt-in** exists but is off by default; the assigner is not cryptographically pinned to the recording the way a mention is.

## Tests

Minitest, mirroring the existing style: every mode (operator/allowlist/project/domain), stranger-dropped, agent-self-dropped (including agent-self on a matching domain), assignments-operator-only-unless-opted-in, the corroborated-targeting forgery, and the CLI mode resolution + conflicts. Full suite green (`bundle exec rake test`), rubocop clean.

*(First commit restores `minitest/mock` via the extracted `minitest-mock` gem — a fresh bundle resolves minitest 6, which moved it out, and the suite would not otherwise load.)*
