### PR TITLE
Fire on new comments on subscribed recordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ What `bin/connect` has in place, at a glance:
 - **Mention gating** — the recording must contain a real Basecamp mention
   *attachment* (`application/vnd.basecamp.mention`) for the agent user, matched by
   the agent's Person id encoded in the mention SGID.
+- **Subscription gating** — a new comment with *no* mention still triggers when
+  the agent subscribes to the commented-on recording (a card/thread it
+  participates in). Subscription is a live API fact, so it is confirmed by
+  re-fetching the parent's subscribers and matching the agent's Person id — never
+  taken from the payload. The comment author is gated exactly like a mention
+  (operator by default, or the active trust mode's authors).
 - **API corroboration** — every event is re-fetched from the Basecamp API and the
   **authoritative fetched copy is what gets acted on**, never the raw POST body.
   For a mention the fetched recording carries the authoritative creator *and*
@@ -201,12 +207,15 @@ can run commands. `bin/connect` emits an event only when **all** of these hold:
    Basecamp actually recorded, never to forgeable POST text. (An **assignment**
    corroborates the agent's assignee state but not the assigner — see the
    assignment caveat under [Trust modes](#trust-modes).)
-2. **@mentions the agent.** `recording.content` must contain a real Basecamp
-   mention of the agent user — a mention *attachment*
-   (`application/vnd.basecamp.mention`) naming the agent, not just loose text
-   that happens to contain the name. This too is re-checked on the corroborated
-   recording, so a forged mention paired with a real un-mentioning recording is
-   dropped.
+2. **Targets the agent.** The recording must reach the agent one of three ways:
+   a real Basecamp mention *attachment* (`application/vnd.basecamp.mention`)
+   naming it (not loose text that happens to contain the name); an assignment
+   adding it to a card/todo; or a **new comment on a recording the agent
+   subscribes to**. Mentions are re-checked on the corroborated recording, so a
+   forged mention paired with a real un-mentioning recording is dropped;
+   subscription is re-fetched from the live subscribers API and stamped by the
+   verifier, so a comment the agent doesn't actually subscribe to is dropped the
+   same way.
 3. **Corroborated by Basecamp.** The recording is re-fetched from the Basecamp
    API and confirmed. For a mention that means it exists **with the claimed
    creator and the claimed mention** — so a forged POST cannot survive. For an

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -464,6 +464,9 @@ Coverage the suite must include:
   matching the agent's Person id; the author is gated exactly as a mention is
   (operator by default, else the active trust mode's authors), and the agent's
   own comments never re-trigger because its identity never authorizes.
+- Boosts on the agent's own recordings can't arrive this way — a boost never
+  fires a webhook — so boost coverage arrives separately, via a poll of the
+  agent's notifications feed (follow-up PR).
 - Assignment trigger: the documented-but-previously-undocumented
   `todo_assignment_changed` / `kanban_card_assignment_changed` /
   `kanban_step_assignment_changed` events (bc3 PR #12156). Actionable when

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -205,10 +205,11 @@ For each delivered event:
    - `creator.email_address` matches the **operator** (case-insensitive). Email,
      not id — a webhook's `creator.id` is an account-scoped Person id while
      `basecamp me` returns a global identity id; the email bridges them.
-   - `recording.content` **@mentions the agent** — it contains a mention
-     attachment (`application/vnd.basecamp.mention`) whose rendered name matches
-     the agent. (A real Basecamp mention is an attachment carrying the person's
-     SGID, not literal `@name` text, so a plain text match would miss it.)
+   - The event **targets the agent** — its content `@mentions` the agent (a
+     mention attachment carrying the person's SGID, not literal `@name` text), or
+     it assigns the agent, or it is a `comment_created` (which may target the
+     agent by subscription; that can't be judged from the payload, so comments
+     are admitted here and decided at verification).
 2. **Dedup** — drop the event if its `event.id` has already been seen (in-memory
    set; at-least-once delivery means duplicates are expected). An id counts as
    seen once it reaches a verdict; an event Basecamp could not corroborate is
@@ -220,7 +221,11 @@ For each delivered event:
    and content. A forged POST (the funnel URL is public, Basecamp sends no
    signature) cannot survive this — if Basecamp doesn't corroborate the event, it
    is discarded. The payload's content field is never trusted directly; the
-   fetched content is authoritative.
+   fetched content is authoritative. For a **comment on a subscribed recording**,
+   verification additionally re-fetches the parent's subscribers
+   (`basecamp subscriptions show`) and stamps the agent's membership onto the
+   authoritative event, so the subscription that triggers is the live one
+   Basecamp reports, not a claim in the POST.
 4. **Emit** — print one NDJSON line to STDOUT with the verified event (see
    format below). Non-matching / unverified events are dropped (logged to
    STDERR).
@@ -450,7 +455,15 @@ Coverage the suite must include:
 
 - Trigger: a real @mention of the **agent** user (a local CLI profile of the
   same name, validated at startup), authored by the **operator** — **or** the
-  operator **assigning** the agent a card/todo.
+  operator **assigning** the agent a card/todo — **or** a new comment (authored
+  by an authorized user) on a recording the agent **subscribes** to.
+- Subscription trigger: a `comment_created` with no mention, when the agent is a
+  subscriber of the comment's parent (the commented-on card/todo/message —
+  subscriptions live on the container, not the comment). Corroborated by
+  re-fetching the parent's subscribers (`basecamp subscriptions show`) and
+  matching the agent's Person id; the author is gated exactly as a mention is
+  (operator by default, else the active trust mode's authors), and the agent's
+  own comments never re-trigger because its identity never authorizes.
 - Assignment trigger: the documented-but-previously-undocumented
   `todo_assignment_changed` / `kanban_card_assignment_changed` /
   `kanban_step_assignment_changed` events (bc3 PR #12156). Actionable when

--- a/lib/basecamp_agent_connector/basecamp/client.rb
+++ b/lib/basecamp_agent_connector/basecamp/client.rb
@@ -36,6 +36,10 @@ class BasecampAgentConnector::Basecamp::Client
     json "chat", "line", url_or_id
   end
 
+  def subscription(url_or_id)
+    json "subscriptions", "show", url_or_id
+  end
+
   def create_webhook(url:, project:, types:)
     json "webhooks", "create", url, "--project", project.to_s, "--types", types
   end

--- a/lib/basecamp_agent_connector/basecamp/event.rb
+++ b/lib/basecamp_agent_connector/basecamp/event.rb
@@ -16,6 +16,14 @@ class BasecampAgentConnector::Basecamp::Event
   # payload arriving on the webhook route is by definition not from Basecamp.
   CHAT_KIND_PREFIX = "chat_"
 
+  # A third way to trigger the agent: a new comment on a recording it subscribes
+  # to, with no @mention. A new comment always hangs off a subscribable parent
+  # (the commented-on todo/card/message), so `comment_created` is the one kind
+  # that can trigger by subscription. Whether the agent actually subscribes is a
+  # live API fact the Verifier corroborates and stamps onto the authoritative
+  # event under `agent_subscribed`; a raw webhook payload never carries it.
+  COMMENT_CREATED_KIND = "comment_created"
+
   MENTION_CONTENT_TYPE = "application/vnd.basecamp.mention"
 
   # The webhook delivers a mention as an unexpanded attachment carrying only an
@@ -126,6 +134,10 @@ class BasecampAgentConnector::Basecamp::Event
     kind.start_with?(CHAT_KIND_PREFIX)
   end
 
+  def subscribable_comment?
+    kind == COMMENT_CREATED_KIND
+  end
+
   def authored_by?(identity)
     return false if creator_email.nil? || identity.email.nil?
 
@@ -142,6 +154,13 @@ class BasecampAgentConnector::Basecamp::Event
     return false if agent.person_id.nil?
 
     assignment_changed? && added_person_ids.include?(agent.person_id)
+  end
+
+  # True only on an authoritative event the Verifier stamped after confirming,
+  # against the live subscribers API, that the agent subscribes to the comment's
+  # parent. Reads nothing from the forgeable webhook payload.
+  def subscribed?
+    @payload["agent_subscribed"] == true
   end
 
   def to_emitted_hash

--- a/lib/basecamp_agent_connector/basecamp/pipeline.rb
+++ b/lib/basecamp_agent_connector/basecamp/pipeline.rb
@@ -24,11 +24,20 @@ class BasecampAgentConnector::Basecamp::Pipeline
 
   private
     def actionable?(event)
-      event.actionable_kind? && @authorizer.authorizes?(event) && targets_agent?(event)
+      event.actionable_kind? && @authorizer.authorizes?(event) && worth_verifying?(event)
+    end
+
+    # The pre-filter is deliberately looser than the authoritative target check:
+    # a comment carries no subscription flag in its payload, so it can't prove it
+    # targets the agent until the Verifier re-fetches subscribers. Admit every
+    # comment here (author is already gated) so subscription can be corroborated;
+    # `targets_agent?` on the verified event makes the real decision.
+    def worth_verifying?(event)
+      targets_agent?(event) || event.subscribable_comment?
     end
 
     def targets_agent?(event)
-      event.mentions?(@agent) || event.assigns?(@agent)
+      event.mentions?(@agent) || event.assigns?(@agent) || event.subscribed?
     end
 
     def fresh?(event)
@@ -50,7 +59,11 @@ class BasecampAgentConnector::Basecamp::Pipeline
     # For an assignment the verifier corroborates the agent's current assignee
     # state but keeps the claimed assigner, so this re-check re-tests that same
     # claimed identity (the verifier confirms the live assignee state, not that
-    # the claimed assigner is who performed the assignment).
+    # the claimed assigner is who performed the assignment). For a comment on a
+    # subscribed recording there is no mention to re-check; the verifier stamps
+    # the subscription it confirmed against the live subscribers API, and
+    # `targets_agent?` reads only that stamp — so a comment the agent doesn't
+    # actually subscribe to is dropped here too.
     def emit_if_verified(event)
       verified = @verifier.verify(event)
 

--- a/lib/basecamp_agent_connector/basecamp/verifier.rb
+++ b/lib/basecamp_agent_connector/basecamp/verifier.rb
@@ -1,4 +1,6 @@
 class BasecampAgentConnector::Basecamp::Verifier
+  COMMENT_RECORDING_TYPE = "Comment"
+
   def initialize(basecamp_cli:, agent:)
     @basecamp_cli = basecamp_cli
     @agent = agent
@@ -75,8 +77,14 @@ class BasecampAgentConnector::Basecamp::Verifier
     # stamp binds to what Basecamp reports now, not to anything in the POST. A
     # failed or missing lookup stamps false: never emit on an unconfirmed
     # subscription.
+    #
+    # The recording's authoritative `type` must be a Comment, not just the
+    # claimed `comment_created` kind: otherwise a forged POST naming that kind
+    # but pointing at an existing subscribed Message/Card would corroborate on
+    # creator and pass the subscriber check, emitting though no comment exists.
     def agent_subscribed?(event, recording)
       event.subscribable_comment? && \
+        recording["type"] == COMMENT_RECORDING_TYPE && \
         !mentions_agent?(recording) && \
         agent_subscribes_to_parent?(recording)
     end

--- a/lib/basecamp_agent_connector/basecamp/verifier.rb
+++ b/lib/basecamp_agent_connector/basecamp/verifier.rb
@@ -64,6 +64,47 @@ class BasecampAgentConnector::Basecamp::Verifier
         "created_at" => event.created_at,
         "details" => event.details,
         "creator" => event.assignment_changed? ? event.creator : recording.fetch("creator"),
-        "recording" => recording
+        "recording" => recording,
+        "agent_subscribed" => agent_subscribed?(event, recording)
+    end
+
+    # A comment can trigger by subscription instead of by a mention: confirm,
+    # against the live subscribers API, that the agent subscribes to the
+    # comment's parent (the commented-on recording — subscriptions live on the
+    # container, not the comment). This is the connector's own re-fetch, so the
+    # stamp binds to what Basecamp reports now, not to anything in the POST. A
+    # failed or missing lookup stamps false: never emit on an unconfirmed
+    # subscription.
+    def agent_subscribed?(event, recording)
+      event.subscribable_comment? && \
+        !mentions_agent?(recording) && \
+        agent_subscribes_to_parent?(recording)
+    end
+
+    # A mention triggers on its own, so a mentioning comment needs no subscribers
+    # lookup. Reuse the canonical mention matcher on the authoritative recording.
+    def mentions_agent?(recording)
+      BasecampAgentConnector::Basecamp::Event.from_payload("recording" => recording).mentions?(@agent)
+    end
+
+    def agent_subscribes_to_parent?(recording)
+      locator = subscription_locator(recording)
+
+      if @agent.person_id.nil? || locator.nil?
+        false
+      else
+        subscriber_ids(locator).include?(@agent.person_id)
+      end
+    end
+
+    def subscription_locator(recording)
+      parent = recording["parent"] || {}
+      parent["url"] || parent["app_url"] || recording["url"] || recording["app_url"]
+    end
+
+    def subscriber_ids(locator)
+      Array(@basecamp_cli.subscription(locator)["subscribers"]).map { |subscriber| subscriber["id"] }
+    rescue BasecampAgentConnector::Basecamp::Client::Error
+      []
     end
 end

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -277,8 +277,10 @@ Instruct that background agent to, in order:
 1. **Acknowledge immediately with a boost** — before any slow work, boost the
    originating recording (comment, message, card, **or** todo) with `On it!` **as
    the agent** so the trigger visibly registered (a boost is a lightweight
-   reaction, ≤16 chars). This is the ack for **every** trigger — mentions and
-   assignments alike:
+   reaction, ≤16 chars). This is the ack for both **directive** triggers —
+   mentions and assignments alike. Subscribed-thread comments are the one
+   exception: they get **no** boost (see *When a comment lands on a thread the
+   agent follows*):
    ```bash
    basecamp boost create <recording.url|id> "On it!" --profile <agent>
    ```
@@ -391,7 +393,8 @@ addressed. Treat this as *activity on a followed thread*, not a directive:
    problem it can act on, a change it should make. Reply on the same recording as
    the agent, exactly like a mention reply. **Default to staying silent**: a
    followed thread is not an instruction, and replying to every comment is noise.
-3. **No boost, no card moves** — a followed-thread comment is not an ack-worthy
+3. **No boost, no card moves** — this **overrides** the generic
+   acknowledge-first step above: a followed-thread comment is not an ack-worthy
    assignment; skip the `On it!` boost and the Triage move unless the agent
    actually takes the thread on.
 

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -37,18 +37,25 @@ reaches STDOUT only if it is (1) authored by an **authorized user** — by defau
 the operator alone (you — the CLI default profile, or `--operator <profile>`);
 `bin/connect`'s trust flags (`--trust`, `--allow`, `--allow-domain`,
 `--allow-project`) can deliberately broaden this to named colleagues, an email
-domain, or the whole project membership — (2) **either** @mentions the agent
-user **or** assigns it a card/todo, and (3) is corroborated against the Basecamp
-API. The agent's own identity never authorizes, in any mode. Treat every STDOUT
-line as already-trusted — but still keep dispatched agents scoped to the
-resolved repo.
+domain, or the whole project membership — (2) **@mentions the agent user**,
+**assigns** it a card/todo, **or** is a new comment on a recording the agent
+**subscribes** to, and (3) is corroborated against the Basecamp API. The agent's
+own identity never authorizes, in any mode. Treat every STDOUT line as
+already-trusted — but still keep dispatched agents scoped to the resolved repo.
 
-There are thus **two triggers**: an `@mention` of the agent, or the operator
-**assigning** the agent a card/todo (a `*_assignment_changed` event whose
-`details.added_person_ids` includes the agent — corroborated by re-fetching the
-recording and confirming the agent is among its current `assignees`). Only the
-**operator's** assignments count, in every trust mode, unless `bin/connect` was
-started with `--allow-assignments-from-authorized`.
+There are thus **three triggers**:
+
+1. an `@mention` of the agent;
+2. the operator **assigning** the agent a card/todo (a `*_assignment_changed`
+   event whose `details.added_person_ids` includes the agent — corroborated by
+   re-fetching the recording and confirming the agent is among its current
+   `assignees`). Only the **operator's** assignments count, in every trust mode,
+   unless `bin/connect` was started with `--allow-assignments-from-authorized`;
+3. a new comment (`comment_created`) with no mention, on a recording the agent
+   **subscribes** to — corroborated by re-fetching the parent's subscribers and
+   matching the agent's Person id. The comment author is gated exactly like a
+   mention (operator by default, else the active trust mode's authors). See
+   [When a comment lands on a thread the agent follows](#when-a-comment-lands-on-a-thread-the-agent-follows).
 
 ## Runs from any project — the runtime lives in the connector clone
 
@@ -369,6 +376,29 @@ with these differences:
   chat-sized; spill long results into a Basecamp doc or comment and link
   them. On failure, @mention the requester so it notifies:
   `[@Name](person:<creator.id>)`.
+
+### When a comment lands on a thread the agent follows
+
+If the event `kind` is `comment_created` and `recording.content` carries **no
+mention of the agent**, the connector fired because the agent **subscribes** to
+the commented-on recording (a card/thread it participates in), not because it was
+addressed. Treat this as *activity on a followed thread*, not a directive:
+
+1. **Read for context** — the comment (`recording.content`) and, as needed, its
+   parent (`recording.parent`) and neighbours. This is the same non-blocking
+   dispatch as a mention: the front thread returns to the monitor immediately.
+2. **Respond only if a response adds value** — a question the agent can answer, a
+   problem it can act on, a change it should make. Reply on the same recording as
+   the agent, exactly like a mention reply. **Default to staying silent**: a
+   followed thread is not an instruction, and replying to every comment is noise.
+3. **No boost, no card moves** — a followed-thread comment is not an ack-worthy
+   assignment; skip the `On it!` boost and the Triage move unless the agent
+   actually takes the thread on.
+
+> This response policy is **provisional** — the connector now *fires* on
+> subscribed-thread comments; how aggressively the agent should engage (answer
+> vs. stay silent, and on which threads) is an operator-tunable judgment worth
+> revisiting once there's real traffic.
 
 ### Validate a finished body of work with `bin/ci` (in the background)
 

--- a/test/basecamp_client_test.rb
+++ b/test/basecamp_client_test.rb
@@ -44,6 +44,17 @@ class BasecampClientTest < Minitest::Test
     assert build_cli(runner).delete_webhook(id: 555, project: 222)
   end
 
+  def test_subscription_shows_the_subscribers_of_an_item
+    runner = FakeCommandRunner.new
+    runner.stub "subscriptions show", stdout: subscribers_envelope(200)
+
+    subscription = build_cli(runner).subscription("https://example.org/buckets/1/recordings/789")
+
+    assert_equal 200, subscription["subscribers"].first.fetch("id")
+    assert_includes runner.commands.first.join(" "),
+      "subscriptions show https://example.org/buckets/1/recordings/789"
+  end
+
   def test_raises_on_command_failure
     runner = FakeCommandRunner.new
     runner.stub "basecamp me", exit_status: 1, stderr: "boom"

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -22,6 +22,21 @@ class EventTest < Minitest::Test
     refute BasecampAgentConnector::Basecamp::Event.from_payload(assignment_payload).assigns?(agent_identity(person_id: nil))
   end
 
+  def test_subscribable_comment
+    assert from_kind("comment_created").subscribable_comment?
+    refute from_kind("comment_content_changed").subscribable_comment?
+    refute from_kind("message_created").subscribable_comment?
+    refute from_kind("kanban_card_assignment_changed").subscribable_comment?
+    refute from_kind(nil).subscribable_comment?
+  end
+
+  def test_subscribed_reflects_only_the_verifier_stamp
+    refute BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload).subscribed?
+    assert BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload("agent_subscribed" => true)).subscribed?
+    # strictly boolean true — a truthy stand-in must not read as subscribed
+    refute BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload("agent_subscribed" => "true")).subscribed?
+  end
+
   def test_to_emitted_hash_carries_assignment_details
     emitted = BasecampAgentConnector::Basecamp::Event.from_payload(assignment_payload).to_emitted_hash
 

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -87,6 +87,22 @@ class PipelineTest < Minitest::Test
     assert_empty runner.commands
   end
 
+  def test_a_forged_comment_kind_pointing_at_a_subscribed_message_cannot_emit
+    # The POST claims comment_created but names an existing subscribed Message
+    # the operator authored. Creator corroborates and the agent even subscribes,
+    # but the authoritative recording is not a Comment, so nothing is emitted.
+    message = sample_recording("type" => "Message", "content" => "<p>an old message, no mention</p>")
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(message)
+    runner.stub "subscriptions show", stdout: subscribers_envelope(200)
+
+    pipeline(runner).process(sample_payload("recording" => message))
+
+    assert_empty @output.string
+    assert_match(/does not target the agent/, @logs.string)
+    assert_empty runner.commands_matching(/subscriptions show/)
+  end
+
   def test_a_forged_subscribed_flag_in_the_payload_cannot_emit
     # The POST claims agent_subscribed=true, but the agent is not really a
     # subscriber. The verifier discards the claimed flag and stamps its own from

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -41,13 +41,65 @@ class PipelineTest < Minitest::Test
     assert_empty @output.string
   end
 
-  def test_ignores_event_that_does_not_mention_the_agent
-    payload = sample_payload
-    payload["recording"]["content"] = "<p>just a normal comment, no mention</p>"
+  def test_ignores_a_comment_that_neither_mentions_nor_subscribes_the_agent
+    recording = sample_recording("content" => "<p>just a normal comment, no mention</p>")
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(recording)
+    runner.stub "subscriptions show", stdout: subscribers_envelope(999)
 
-    pipeline(FakeCommandRunner.new).process(payload)
+    pipeline(runner).process(sample_payload("recording" => recording))
 
     assert_empty @output.string
+    assert_match(/does not target the agent/, @logs.string)
+  end
+
+  def test_emits_for_a_comment_on_a_recording_the_agent_subscribes_to
+    recording = sample_recording("content" => "<p>no mention, just an update</p>")
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(recording)
+    runner.stub "subscriptions show", stdout: subscribers_envelope(200)
+
+    pipeline(runner).process(sample_payload("recording" => recording))
+
+    assert_equal 1, @output.string.lines.length
+    assert_equal "comment_created", JSON.parse(@output.string)["kind"]
+  end
+
+  def test_ignores_the_agents_own_comment_on_a_subscribed_recording
+    author = { "id" => 200, "name" => "Clawdito", "email_address" => "clawdito@example.com" }
+    recording = sample_recording("content" => "<p>my own reply</p>", "creator" => author)
+    runner = FakeCommandRunner.new
+
+    pipeline(runner).process(sample_payload("creator" => author, "recording" => recording))
+
+    assert_empty @output.string
+    assert_empty runner.commands
+  end
+
+  def test_ignores_a_third_partys_comment_on_a_subscribed_recording
+    author = { "id" => 400, "email_address" => "sam@elsewhere.net" }
+    recording = sample_recording("content" => "<p>hi</p>", "creator" => author)
+    runner = FakeCommandRunner.new
+
+    pipeline(runner).process(sample_payload("creator" => author, "recording" => recording))
+
+    assert_empty @output.string
+    assert_empty runner.commands
+  end
+
+  def test_a_forged_subscribed_flag_in_the_payload_cannot_emit
+    # The POST claims agent_subscribed=true, but the agent is not really a
+    # subscriber. The verifier discards the claimed flag and stamps its own from
+    # the live subscribers API, so the event is dropped, not emitted.
+    recording = sample_recording("content" => "<p>no mention</p>")
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(recording)
+    runner.stub "subscriptions show", stdout: subscribers_envelope(999)
+
+    pipeline(runner).process(sample_payload("agent_subscribed" => true, "recording" => recording))
+
+    assert_empty @output.string
+    assert_match(/does not target the agent/, @logs.string)
   end
 
   def test_drops_uncorroborated_event
@@ -125,6 +177,7 @@ class PipelineTest < Minitest::Test
     # recording is authoritative and carries no mention, so it must not emit.
     runner = FakeCommandRunner.new
     runner.stub "basecamp show", stdout: envelope(sample_recording("content" => "<p>a plain operator note, no mention</p>"))
+    runner.stub "subscriptions show", stdout: subscribers_envelope(999)
 
     pipeline(runner).process(sample_payload)
 

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -283,6 +283,38 @@ class PipelineTest < Minitest::Test
     assert_empty runner.commands
   end
 
+  def test_allowlist_emits_for_an_allowed_authors_comment_on_a_subscribed_recording
+    # The subscription trigger passes the same trust gate as a mention: a
+    # broadened mode's authors can drive the agent through a followed thread.
+    recording = sample_recording("content" => "<p>no mention, just an update</p>", "creator" => colleague)
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(recording)
+    runner.stub "subscriptions show", stdout: subscribers_envelope(200)
+
+    pipeline(runner, authorizer: authorizer(trust: :allowlist, emails: [ "marie@example.com" ]))
+      .process(sample_payload("creator" => colleague, "recording" => recording))
+
+    assert_equal 1, @output.string.lines.length
+    assert_equal "marie@example.com", JSON.parse(@output.string)["creator"]["email_address"]
+  end
+
+  def test_project_trust_drops_a_client_authors_comment_on_a_subscribed_recording
+    # Subscription targeting never bypasses the authorizer: even when the agent
+    # really subscribes, the corroborated author must still be authorized. The
+    # claimed payload denies client status (passing the pre-filter); Basecamp's
+    # authoritative copy marks the author a client, and that copy decides.
+    recording = sample_recording("content" => "<p>no mention</p>", "creator" => colleague.merge("client" => true))
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(recording)
+    runner.stub "subscriptions show", stdout: subscribers_envelope(200)
+
+    pipeline(runner, authorizer: authorizer(trust: :project))
+      .process(sample_payload("creator" => colleague, "recording" => recording))
+
+    assert_empty @output.string
+    assert_match(/authoritative author is not authorized/, @logs.string)
+  end
+
   def test_broadened_trust_keeps_assignments_operator_only
     runner = FakeCommandRunner.new
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -134,6 +134,12 @@ module PayloadHelpers
     BasecampAgentConnector::Basecamp::Event.chat_line_payload(line)
   end
 
+  # The `basecamp subscriptions show` envelope: the subscribers of a recording,
+  # each a person with an id. The connector matches the agent's Person id here.
+  def subscribers_envelope(*person_ids)
+    envelope("subscribers" => person_ids.map { |id| { "id" => id, "name" => "Someone" } })
+  end
+
   def operator_identity
     BasecampAgentConnector::Basecamp::Identity.new(id: 100, email: "operator@example.com")
   end

--- a/test/verifier_test.rb
+++ b/test/verifier_test.rb
@@ -107,6 +107,20 @@ class VerifierTest < Minitest::Test
     assert_empty runner.commands_matching(/subscriptions show/)
   end
 
+  def test_does_not_stamp_subscribed_when_the_recording_is_not_a_comment
+    # A forged comment_created pointing at a subscribed Message/Card: creator
+    # corroborates, but the authoritative recording is not a Comment, so it is
+    # not treated as a subscribed comment and no subscribers lookup is made.
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(sample_recording("type" => "Message", "content" => "<p>an old message</p>"))
+
+    verified = verifier(runner).verify(event(sample_payload))
+
+    refute_nil verified
+    refute verified.subscribed?
+    assert_empty runner.commands_matching(/subscriptions show/)
+  end
+
   def test_a_failed_subscribers_lookup_stamps_not_subscribed
     runner = FakeCommandRunner.new
     runner.stub "basecamp show", stdout: envelope(sample_recording("content" => "<p>no mention</p>"))

--- a/test/verifier_test.rb
+++ b/test/verifier_test.rb
@@ -72,6 +72,52 @@ class VerifierTest < Minitest::Test
     assert_nil verifier(runner).verify(event(chat_line_payload))
   end
 
+  def test_stamps_subscribed_after_confirming_the_agent_subscribes_to_the_comments_parent
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(sample_recording("content" => "<p>no mention, just a note</p>"))
+    runner.stub "subscriptions show", stdout: subscribers_envelope(200)
+
+    verified = verifier(runner).verify(event(sample_payload))
+
+    refute_nil verified
+    assert verified.subscribed?
+    # subscription is checked on the comment's parent recording, not the comment
+    assert_includes runner.commands_matching(/subscriptions show/).first.join(" "), "cards/789"
+  end
+
+  def test_does_not_stamp_subscribed_when_the_agent_is_not_a_subscriber
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(sample_recording("content" => "<p>no mention</p>"))
+    runner.stub "subscriptions show", stdout: subscribers_envelope(999)
+
+    verified = verifier(runner).verify(event(sample_payload))
+
+    refute_nil verified
+    refute verified.subscribed?
+  end
+
+  def test_a_mentioning_comment_needs_no_subscribers_lookup
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(sample_recording)
+
+    verified = verifier(runner).verify(event(sample_payload))
+
+    refute_nil verified
+    refute verified.subscribed?
+    assert_empty runner.commands_matching(/subscriptions show/)
+  end
+
+  def test_a_failed_subscribers_lookup_stamps_not_subscribed
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(sample_recording("content" => "<p>no mention</p>"))
+    runner.stub "subscriptions show", exit_status: 1, stderr: "boom"
+
+    verified = verifier(runner).verify(event(sample_payload))
+
+    refute_nil verified
+    refute verified.subscribed?
+  end
+
   private
     def verifier(runner)
       BasecampAgentConnector::Basecamp::Verifier.new(basecamp_cli: build_cli(runner), agent: agent_identity)


### PR DESCRIPTION
Adds the **comment-on-subscribed-recording** trigger: a new comment with no @mention fires when the agent **subscribes** to the commented-on recording (a card/thread it participates in). Mechanism is webhook — no new poller.

> Boost-on-own-recording coverage is **not** in this PR. Boosts never fire webhooks, so it arrives separately via a poll of the agent's notifications feed — split into its own PR.

## What fires now

**Was it supported?** No. Every `comment_created` for a watched project already arrives (the `Comment` type is subscribed), but a comment with no mention was dropped at the targeting gate: `targets_agent? = mentions? || assigns?` (`pipeline.rb`). There was no subscription path.

**Trust-gate decision.** The comment author is gated **exactly like a mention** — operator by default, or the active trust mode's authors (`Authorizer#authorizes?`, unchanged). The new predicate *replaces* the mention predicate for this path; it does **not** relax the author gate. Rationale: a subscribed recording is a broad surface, so letting *anyone's* comment trigger would hand drive-authority to any project member; keeping the author gate makes the subscribed trigger no more permissive than mentions already are. Assignments stay operator-only as before.

**How subscription is corroborated (not trusted from the POST).** Subscription is a live fact, so the verifier re-fetches the parent's subscribers (`basecamp subscriptions show`) and **stamps** the agent's Person-id membership onto the authoritative event under an internal `agent_subscribed` flag; `targets_agent?` reads only that stamp. A forged `agent_subscribed:true` in the payload is discarded — the verifier overwrites it from its own fetch. Subscriptions live on the **container**, not the comment, so the lookup targets `recording.parent` (confirmed in bc3: `comment.rb:43-44`, `subscribable.rb`, subscriptions `show.json.jbuilder`).

**Self-trigger loop closed.** The agent's own comments never re-trigger — its identity never authorizes (`Authorizer` agent-self guard), so a self-authored comment is dropped at the pre-filter before any API call. A mentioning comment skips the subscribers lookup entirely.

**Tests (all new/updated, mutation-checked):**
- `pipeline_test`: `test_emits_for_a_comment_on_a_recording_the_agent_subscribes_to` (positive), `test_ignores_a_comment_that_neither_mentions_nor_subscribes_the_agent` (negative — not subscribed), `test_ignores_the_agents_own_comment_on_a_subscribed_recording` (self-drop, asserts zero API calls), `test_ignores_a_third_partys_comment_on_a_subscribed_recording` (author gate), `test_a_forged_subscribed_flag_in_the_payload_cannot_emit` (forgery), `test_a_forged_comment_kind_pointing_at_a_subscribed_message_cannot_emit` (kind forgery), plus the existing `test_drops_a_forged_mention_when_the_authoritative_recording_has_none` still holds.
- `verifier_test`: stamps subscribed / not-a-subscriber / mentioning-comment-skips-lookup / not-a-Comment-recording / failed-lookup-stamps-false.
- `event_test`: `subscribable_comment?`, `subscribed?` reads only the strict-boolean stamp.
- `basecamp_client_test`: `subscription` maps to `subscriptions show`.

## Base-branch decision — stacked on #9 (`configurable-trust-modes`)

Based on **#9**, not `main`. This trigger's forgery defense relies on the post-verify `targets_agent?(verified)` re-check and the `authorizes?` gate that **#9 introduces**; on `main` those hooks don't exist (main's `emit_if_verified` only checks corroboration) and I'd have to reimplement them, fighting #9's imminent merge. Basing on #9 keeps the diff minimal and lets the subscribed trigger inherit configurable trust coherently (a subscribed comment follows the same mode as a mention). **Merge order: after #9.** Sibling of #10 (chat poller); the two only overlap where both touch the shared pipeline/verifier/event files, kept minimal here.

No PII or credentials in code, tests, or docs (all fixtures use `example.com`/`example.org`).
