### PR TITLE
Fire on boosts of the agent's work via a received-boosts poll

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,13 @@ What `bin/connect` has in place, at a glance:
   re-fetching the parent's subscribers and matching the agent's Person id — never
   taken from the payload. The comment author is gated exactly like a mention
   (operator by default, or the active trust mode's authors).
+- **Boost gating** — a boost on the agent's work triggers only when a fresh
+  fetch of the **agent's own received-boosts feed** contains it: boosts never
+  arrive by webhook (polling that feed is the delivery mechanism), and the feed
+  files a boost under the person it was aimed at, so membership is both the
+  existence proof and the targeting proof. The booster is gated exactly like a
+  mention author, and the emitted booster/content come from the fetch, never
+  from a payload.
 - **API corroboration** — every event is re-fetched from the Basecamp API and the
   **authoritative fetched copy is what gets acted on**, never the raw POST body.
   For a mention the fetched recording carries the authoritative creator *and*
@@ -207,15 +214,18 @@ can run commands. `bin/connect` emits an event only when **all** of these hold:
    Basecamp actually recorded, never to forgeable POST text. (An **assignment**
    corroborates the agent's assignee state but not the assigner — see the
    assignment caveat under [Trust modes](#trust-modes).)
-2. **Targets the agent.** The recording must reach the agent one of three ways:
+2. **Targets the agent.** The event must reach the agent one of four ways:
    a real Basecamp mention *attachment* (`application/vnd.basecamp.mention`)
    naming it (not loose text that happens to contain the name); an assignment
-   adding it to a card/todo; or a **new comment on a recording the agent
-   subscribes to**. Mentions are re-checked on the corroborated recording, so a
-   forged mention paired with a real un-mentioning recording is dropped;
-   subscription is re-fetched from the live subscribers API and stamped by the
-   verifier, so a comment the agent doesn't actually subscribe to is dropped the
-   same way.
+   adding it to a card/todo; a **new comment on a recording the agent
+   subscribes to**; or a **boost on the agent's work**. Mentions are re-checked
+   on the corroborated recording, so a forged mention paired with a real
+   un-mentioning recording is dropped; subscription is re-fetched from the live
+   subscribers API and stamped by the verifier, so a comment the agent doesn't
+   actually subscribe to is dropped the same way; a boost is stamped only when
+   the verifier finds it in a fresh fetch of the agent's own received-boosts
+   feed — the feed files a boost under the person it was aimed at, so
+   membership is the targeting fact.
 3. **Corroborated by Basecamp.** The recording is re-fetched from the Basecamp
    API and confirmed. For a mention that means it exists **with the claimed
    creator and the claimed mention** — so a forged POST cannot survive. For an
@@ -305,6 +315,8 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
 | `--allow-assignments-from-authorized` | Let any authorized author trigger via assignment, not just the operator. | off — assignments are operator-only |
 | `--types` | Comma-separated Basecamp event types to subscribe to. `Chat::Line` selects Campfire coverage — chat has no webhooks, so the connector polls each watched project's chats for it. | `Comment,Message,Kanban::Card,Kanban::Step,Todo,Chat::Line` |
 | `--chat-poll` | Campfire poll interval, in seconds. | `15` |
+| `--boost-poll` | Received-boosts poll interval, in seconds. Boosts have no webhooks, so the connector polls the agent's own received-boosts feed for them. | `60` |
+| `--no-boosts` | Don't poll the agent's received-boosts feed (no boost trigger). | polling on |
 | `--port` | Local port for the webhook server. | an unused high port |
 
 **What it does, in order:**
@@ -322,7 +334,11 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
    Only those paths are touched, so funnel paths other tools mounted keep
    working.
 4. **Register webhooks.** Creates one webhook per project (with retry on transient
-   failures), recording their IDs for cleanup.
+   failures), recording their IDs for cleanup. Also starts the **boost poller**
+   (unless `--no-boosts`): boosts have no webhooks, so the agent's own
+   received-boosts feed is fetched every `--boost-poll` seconds and each new
+   boost runs the same pipeline as a webhook delivery. The first fetch is a
+   baseline — history is never dispatched.
 5. **Listen.** For each delivery: respond `200` immediately, then off the hot
    path — pre-filter (authorized author + mentions agent + actionable kind),
    de-duplicate by event id, verify against the Basecamp API, re-check that the
@@ -380,6 +396,11 @@ basecamp comment <recording-url> "…" --profile <agent> # post as the agent
   `Chat::Line` is Campfire coverage: Basecamp delivers no chat webhooks, so the
   connector polls each watched project's chats and runs new lines through the
   same trust gate as webhook events.
+- **Boost polling** — `--boost-poll` interval in seconds (default 60), or
+  `--no-boosts` to disable the boost trigger. Boosts have no webhooks, so the
+  connector polls the agent's own received-boosts feed — an account-wide,
+  agent-scoped surface (a boost triggers wherever the agent's boosted work
+  lives, not only in watched projects).
 - **Port** — `--port` (default: an unused high port).
 
 ---

--- a/README.md
+++ b/README.md
@@ -151,8 +151,10 @@ What `bin/connect` has in place, at a glance:
 
 - **Operator-only triggering by default** — with no trust flags, an event acts
   only when its creator is the operator (the CLI default profile, or
-  `--operator <profile>`), matched by email. Trust can be **deliberately
-  broadened** per run — see [Trust modes](#trust-modes) below.
+  `--operator <profile>`), matched by email or account Person id (bc3 redacts
+  other users' emails from non-admin viewers, so the id is the key that always
+  works). Trust can be **deliberately broadened** per run — see
+  [Trust modes](#trust-modes) below.
 - **Agent-self exclusion** — the agent's own identity never authorizes, in any
   mode, matched by email *and* Person id. Even when trust is broadened to a
   domain or project the agent belongs to, its own posts cannot re-trigger it.
@@ -174,8 +176,11 @@ What `bin/connect` has in place, at a glance:
   arrive by webhook (polling that feed is the delivery mechanism), and the feed
   files a boost under the person it was aimed at, so membership is both the
   existence proof and the targeting proof. The booster is gated exactly like a
-  mention author, and the emitted booster/content come from the fetch, never
-  from a payload.
+  mention author — matched by Person id, since the agent's view of the feed
+  redacts other users' emails — and the emitted booster/content come from the
+  fetch, never from a payload. Email-keyed trust modes (`allowlist`, `domain`)
+  can't see through that redaction, so under them boosts effectively stay
+  operator-only; `project` mode broadens boosts fine.
 - **API corroboration** — every event is re-fetched from the Basecamp API and the
   **authoritative fetched copy is what gets acted on**, never the raw POST body.
   For a mention the fetched recording carries the authoritative creator *and*
@@ -205,8 +210,9 @@ A webhook payload is attacker-influenceable text that flows into an agent which
 can run commands. `bin/connect` emits an event only when **all** of these hold:
 
 1. **Authored by an authorized user.** By default that means *you* alone (the
-   CLI default profile, or `--operator <profile>`), matched by email: a third
-   party who can comment in the project cannot make your agent do anything.
+   CLI default profile, or `--operator <profile>`), matched by email or account
+   Person id: a third party who can comment in the project cannot make your
+   agent do anything.
    Trust modes (below) can deliberately extend this to named colleagues, a
    domain, or the whole project membership — and for a **mention** the check is
    applied **twice**: once on the claimed webhook payload as a cheap pre-filter,

--- a/docs/built-in-support.md
+++ b/docs/built-in-support.md
@@ -31,7 +31,7 @@ Every mechanism in the connector maps to a gap in Basecamp:
 | 4 | **Public inbound endpoint** — Tailscale Funnel publishes the laptop | Webhooks push to a URL; nothing lets a consumer connect *out* and receive events |
 | 5 | **Forgeable deliveries** — every event re-fetched and corroborated | Webhook deliveries carry no signature |
 | 6 | **Manual lifecycle, orphan risk** — teardown required; SIGKILL leaves stale webhooks and a live funnel; silent deactivation after 10 failures | Webhooks are durable registrations with no lease, TTL, or self-expiry |
-| 7 | **No conversation** — a plain reply to the agent's question never reaches it | Mentions already auto-subscribe the mentionee, and subscribers are notified of every comment — but no machine consumer can read a person's notification stream |
+| 7 | **No conversation** — a plain reply to the agent's question never reaches it | Mentions already auto-subscribe the mentionee, and subscribers are notified of every comment — but no machine consumer can read a person's notification stream (the received-boosts report is the one API-readable slice, which is what makes the boost trigger possible — by polling) |
 | 8 | **Client-side filtering of a project firehose** — operator and mention checks happen on the laptop | Webhooks filter by recording type only, not addressee or author |
 | 9 | **No structural events** — card-moved-to-column / todo-added means client-side diffing | Those events exist internally but aren't subscribable per-container |
 | 10 | **Two id spaces joined by email** — account Person id vs. global identity id | No stable common key surfaced in both places |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -88,7 +88,8 @@ basecamp-local-agent-connector/
 │       │   ├── webhooks.rb            #   register/delete webhooks across all projects
 │       │   ├── event.rb               #   payload value object (kind, creator, recording)
 │       │   ├── verifier.rb            #   authoritative Basecamp API verification
-│       │   └── pipeline.rb            #   pre-filter → dedup → verify → emit orchestration
+│       │   ├── pipeline.rb            #   pre-filter → dedup → verify → emit orchestration
+│       │   └── boost_poller.rb        #   received-boosts feed poll (boosts have no webhooks)
 │       └── github/                    # GitHub:: — the PR review-loop transport
 │           ├── bridge.rb              #   one route: secret path + HMAC, register repo hooks, handler, teardown
 │           ├── client.rb              #   thin wrapper over the `gh` CLI (JSON in/out)
@@ -132,7 +133,7 @@ behavior in Component 2. Discovery follows the standard Claude Code mechanism
 ### Invocation
 
 ```
-bin/connect @AGENT --project <project>... [--operator <profile>] [--types <types>] [--port <port>]
+bin/connect @AGENT --project <project>... [--operator <profile>] [--types <types>] [--boost-poll <seconds>|--no-boosts] [--port <port>]
 ```
 
 - `@AGENT` — the agent user / local profile name (e.g. `@Clawdito` or
@@ -151,6 +152,10 @@ bin/connect @AGENT --project <project>... [--operator <profile>] [--types <types
   relay entirely, so the bridge covers chat with an integrated poller (interval
   `--chat-poll`, default 15s) that runs each new line through the same
   authorizer + corroboration pipeline as webhook deliveries.
+- `--boost-poll` / `--no-boosts` — boosts have no webhooks (a Boost is not a
+  Recording and creates no Event in bc3), so the bridge polls the **agent's own
+  received-boosts feed** (`/my/boosts.json`) for them on this interval (default
+  60s); `--no-boosts` disables the boost trigger.
 - `--port` — local port for the Ruby server (default: an unused high port).
 
 ### Startup sequence
@@ -189,7 +194,10 @@ bin/connect @AGENT --project <project>... [--operator <profile>] [--types <types
    — the **webhook-eligible** types only; chat-typed entries went to the poller,
    and Basecamp would reject them. Skipped when no webhook types remain. Capture
    every created webhook ID for cleanup. Surface per-project registration
-   failures without aborting the rest.
+   failures without aborting the rest. Then start the **boost poller** (unless
+   `--no-boosts`): it fetches nothing until its first interval pass, well after
+   the readiness lines print, so no event can beat the funnel's consumer to the
+   stream.
 7. **Listen** — for each incoming POST, run the pipeline below. Always respond
    **200 OK quickly** (so Basecamp does not retry); filtering/verification/
    dispatch happen out of band.
@@ -225,7 +233,14 @@ For each delivered event:
    verification additionally re-fetches the parent's subscribers
    (`basecamp subscriptions show`) and stamps the agent's membership onto the
    authoritative event, so the subscription that triggers is the live one
-   Basecamp reports, not a claim in the POST.
+   Basecamp reports, not a claim in the POST. For a **boost** there is no
+   recording endpoint to re-fetch (a boost is not a Recording): verification
+   re-fetches the **agent's own received-boosts feed** and requires the claimed
+   boost id to be present with the claimed booster — the emitted booster,
+   content, and boosted recording all come from that fresh fetch, and presence
+   in the feed doubles as the targeting fact (stamped `agent_boosted`). The
+   webhook route refuses boost-kind payloads outright: Basecamp never delivers
+   them, so the poller is the sole boost source.
 4. **Emit** — print one NDJSON line to STDOUT with the verified event (see
    format below). Non-matching / unverified events are dropped (logged to
    STDERR).
@@ -268,6 +283,12 @@ One JSON object per line (NDJSON), built from the **verified** recording:
 
 `app_url` / `url` and `bucket` are the handles the downstream agent uses to pull
 full context and resolve the working repo.
+
+A **boost** event (`"kind": "boost_created"`) is synthesized from the agent's
+received-boosts feed rather than a webhook: `creator` is the **booster**,
+`recording` is the boosted recording (the agent's comment/card/answer — no
+`content` field in this feed representation), and `details.boost` carries the
+boost's own `id` and `content` (up to 16 characters, e.g. `"🔥"` or `"redo"`).
 
 ---
 
@@ -364,6 +385,7 @@ Confirmed against `bc3` source (`app/views/api/webhooks/event.jbuilder`,
 | Watched projects | Explicit `--project` list (name/URL/ID), required | — (at least one) |
 | Project→repo map | Maps Basecamp project names / app tokens to local repo paths under `~/Work/<org>/<repo>` | heuristic + ask-on-miss |
 | Default event types | Subscribed Basecamp types | `Comment, Message, Kanban::Card, Kanban::Step, Todo` + `Chat::Line` (polled — chat has no webhooks) |
+| Boost poll | Received-boosts feed poll interval (`--no-boosts` disables) | 60s |
 | Local port | WEBrick bind port | unused high port |
 
 ---
@@ -430,6 +452,7 @@ Coverage the suite must include:
 | Identity | expired token triggers a single `auth refresh`; still-failing exits with a clear message |
 | Projects | explicit `--project` list honored; empty list enumerates all accessible projects |
 | CLI/arg parsing | flags map to the right config; required `<trigger>` enforced |
+| Boost poller | first fetch baselines without replaying history; a post-start boost emits once; an uncorroborated boost is retried while it stays in the feed; a full all-new page warns of possible overflow |
 
 ## Security considerations
 
@@ -464,9 +487,18 @@ Coverage the suite must include:
   matching the agent's Person id; the author is gated exactly as a mention is
   (operator by default, else the active trust mode's authors), and the agent's
   own comments never re-trigger because its identity never authorizes.
-- Boosts on the agent's own recordings can't arrive this way — a boost never
-  fires a webhook — so boost coverage arrives separately, via a poll of the
-  agent's notifications feed (follow-up PR).
+- Boost trigger: someone boosts the agent's work. A boost never fires a webhook
+  (not a Recording, no Event), so the bridge polls the **agent's own
+  received-boosts feed** (`/my/boosts.json`, the report behind the "You've got
+  Boosts!" notification) every `--boost-poll` seconds (default 60) and
+  synthesizes a `boost_created` event per new entry. The booster is gated
+  exactly as a mention author is (operator by default, else the active trust
+  mode's authors; the agent's own boosts never authorize), corroboration is a
+  fresh fetch of the same feed (claimed id present with the claimed booster;
+  emitted booster/content/recording all from the fetch), and feed membership is
+  the targeting fact. History is baselined by time, never dispatched; the feed
+  is account-wide, so the bound is the agent's identity rather than the
+  watched-project list. `--no-boosts` disables the trigger.
 - Assignment trigger: the documented-but-previously-undocumented
   `todo_assignment_changed` / `kanban_card_assignment_changed` /
   `kanban_step_assignment_changed` events (bc3 PR #12156). Actionable when

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -50,12 +50,17 @@ author, agent replies are never re-ingested — this is the structural fix for t
 reply feedback loop. The connector warns at startup if the two resolve to the
 same user.
 
-The author match is keyed on **email address**, not id. Basecamp has two id
-spaces — a webhook's `creator.id` is an account-scoped **Person** id, while
-`basecamp me` returns a global **identity** id; they differ for the same human.
-The email address is consistent across both, so it is the reliable trust key.
-The mention match looks for a mention attachment
-(`application/vnd.basecamp.mention`) naming the agent.
+The author match is keyed on **email address or account Person id** — either
+identifies the author. Basecamp has two id spaces — a webhook's `creator.id`
+is an account-scoped **Person** id, while `basecamp me` returns a global
+**identity** id; they differ for the same human — so the connector resolves
+both the email and the account Person id for each identity at startup. Email
+alone is not enough: bc3 **redacts other users' email addresses from
+non-admin viewers** (`Person#can_see_email_address_of?` is self-or-admin), so
+a feed fetched as the (non-admin) agent shows every other author as
+`j••••@••••.•••` — there the Person id is the only usable key. The mention
+match looks for a mention attachment (`application/vnd.basecamp.mention`)
+naming the agent.
 
 ---
 
@@ -496,7 +501,12 @@ Coverage the suite must include:
   mode's authors; the agent's own boosts never authorize), corroboration is a
   fresh fetch of the same feed (claimed id present with the claimed booster;
   emitted booster/content/recording all from the fetch), and feed membership is
-  the targeting fact. History is baselined by time, never dispatched; the feed
+  the targeting fact. The agent's view of the feed **redacts other users'
+  emails** (bc3 shows real addresses only to yourself or an admin), so the
+  booster matches by account Person id; email-keyed trust modes (`allowlist`,
+  `domain`) therefore cannot broaden the boost trigger beyond the operator
+  unless the agent can see emails — `project` mode, keyed on the corroborated
+  Person id and client flag, broadens it fine. History is baselined by time, never dispatched; the feed
   is account-wide, so the bound is the agent's identity rather than the
   watched-project list. `--no-boosts` disables the trigger.
 - Assignment trigger: the documented-but-previously-undocumented

--- a/lib/basecamp_agent_connector/basecamp/boost_poller.rb
+++ b/lib/basecamp_agent_connector/basecamp/boost_poller.rb
@@ -1,0 +1,163 @@
+require "set"
+require "time"
+
+# Boost coverage. Basecamp never delivers boosts by webhook — in bc3 a Boost
+# is not a Recording and creates no Event, so no webhook can ever carry one.
+# The one place Basecamp reports a boost is the boostee's own received-boosts
+# feed (`/my/boosts.json`, the report behind the "You've got Boosts!"
+# notification), so the only way to hear a boost on the agent's work is to
+# poll that feed as the agent. On an interval the newest page of the feed is
+# fetched, and every not-yet-seen boost is synthesized into a boost-kind event
+# and fed through its own Pipeline instance with the same authorizer
+# pre-filter, corroborating re-fetch, authoritative re-check, and STDOUT
+# funnel as webhook deliveries. The feed is account-wide (notifications are
+# not project-scoped), so a boost triggers wherever the agent's boosted work
+# lives — the bound is the agent's identity, not the watched-project list.
+#
+# History is never dispatched: a boost that predates the poller is marked seen
+# without being processed — on the first successful fetch (so connecting never
+# replays the backlog) and on any later fetch that slides an old boost back
+# into the newest-page window. Boosts received since the poller started always
+# process, even when the first successful fetch comes late (a startup blip),
+# so a delayed baseline doesn't swallow them. Seen ids accumulate one integer
+# per boost for the session — small enough to keep unpruned. Boosts are
+# immutable, so there is no edit case to consider.
+class BasecampAgentConnector::Basecamp::BoostPoller
+  DEFAULT_INTERVAL = 60
+
+  # bc3's my/boosts feed is geared-paginated and only the first page is
+  # fetched; its first gear carries the newest 15 boosts (verified against
+  # production). The server owns that number — this is a hint for the
+  # overflow warning, not a request parameter.
+  FEED_WINDOW = 15
+
+  def initialize(basecamp_cli:, pipeline:, agent:, interval: DEFAULT_INTERVAL, logger: $stderr,
+    wait: ->(seconds) { sleep seconds }, clock: -> { Time.now })
+    @basecamp_cli = basecamp_cli
+    @pipeline = pipeline
+    @agent = agent
+    @interval = interval
+    @logger = logger
+    @wait = wait
+    @clock = clock
+    @seen_boost_ids = Set.new
+    # Floored to the whole second because feed timestamps may carry only
+    # second precision: comparing a sub-second start against a truncated
+    # created_at would misfile a boost landing just after start as history
+    # and drop it for good. See received_since_start?.
+    @started_at = @clock.call.floor
+    @stopping = false
+  end
+
+  # Nothing is fetched or emitted until the poll thread's first pass, one
+  # interval later — so nothing can land on the funnel before the connector
+  # has reported readiness and its consumer is watching. A boost received in
+  # the meantime is not lost: post-start boosts process even when the first
+  # fetch is the one that sees them.
+  def start
+    @thread = Thread.new { poll_loop }
+  end
+
+  def stop
+    @stopping = true
+
+    if @thread
+      @thread.kill
+      # Bounded, not guaranteed: a kill lands between CLI calls instantly, but
+      # a thread mid-subprocess dies only when the child returns. The process
+      # is tearing down anyway, so make any residue visible rather than block.
+      log "boost poll thread did not stop within 5s" if @thread.join(5).nil?
+      @thread = nil
+    end
+  end
+
+  # One rule for every fetched boost, first fetch or fiftieth: already seen —
+  # skip; received since the poller started — process; otherwise it is history
+  # and is marked seen silently. The last case covers both the initial
+  # baseline and a pre-start boost that deletions slide back into the
+  # newest-page window later — either way, history is never dispatched.
+  def poll
+    return if @stopping
+
+    boosts = Array(@basecamp_cli.received_boosts(profile: @agent.profile))
+    ordered = boosts.sort_by { |boost| boost["id"].to_i }
+    warn_of_possible_overflow(ordered)
+
+    ordered.each do |boost|
+      if @seen_boost_ids.include?(boost["id"])
+        # already handled
+      elsif received_since_start?(boost)
+        process(boost)
+      else
+        @seen_boost_ids << boost["id"]
+      end
+    end
+  rescue BasecampAgentConnector::Basecamp::Client::Error => error
+    log "boost poll failed: #{error.message}"
+  end
+
+  private
+    # The loop is the only boost thread there is; an exception that escapes a
+    # poll (a pipeline bug, say — CLI failures are already rescued closer in)
+    # must cost one tick, not all coverage for the rest of the session.
+    def poll_loop
+      until @stopping
+        @wait.call(@interval)
+
+        begin
+          poll
+        rescue => error
+          log "boost poll failed: #{error.message}"
+        end
+      end
+    end
+
+    # Fail toward history: a boost whose timestamp is missing or unreadable is
+    # baselined rather than risking a replay. The boundary itself leans the
+    # other way: @started_at is floored to the second and the comparison is
+    # inclusive, so a boost stamped in the poller's start second counts as
+    # post-start even when its created_at carries only second precision.
+    # Comparing server timestamps against the local clock assumes NTP-grade
+    # sync; skew shifts the history boundary by its own magnitude.
+    def received_since_start?(boost)
+      created_at = boost["created_at"].to_s
+      !created_at.empty? && Time.iso8601(created_at) >= @started_at
+    rescue ArgumentError
+      false
+    end
+
+    # Seen means settled. A boost the pipeline could not corroborate — the
+    # feed re-fetch failed, which a transient API or CLI blip can cause as
+    # easily as a deletion — is forgotten again so the next poll retries it
+    # while it remains in the feed; a deleted boost simply stops appearing.
+    # A pipeline exception leaves the boost seen: retrying a bug every tick
+    # would only repeat it.
+    def process(boost)
+      @seen_boost_ids << boost["id"]
+      @seen_boost_ids.delete(boost["id"]) unless @pipeline.process(BasecampAgentConnector::Basecamp::Event.boost_payload(boost))
+    end
+
+    # The feed's first page is a bound: if the agent received more boosts than
+    # one page holds between polls (or since the poller started, for a first
+    # fetch), the overflow scrolled out unseen. A full page that carries no
+    # proof of continuity — no overlap with seen boosts, or on a first fetch
+    # not even a pre-start boost — doesn't prove a gap, but say so.
+    def warn_of_possible_overflow(ordered)
+      if ordered.length >= FEED_WINDOW && overflow_suspected?(ordered)
+        log "possible boost feed overflow: every fetched boost is new; " \
+          "boosts beyond the newest #{ordered.length} may have been missed"
+      end
+    end
+
+    def overflow_suspected?(ordered)
+      if @seen_boost_ids.empty?
+        received_since_start?(ordered.first)
+      else
+        ordered.none? { |boost| @seen_boost_ids.include?(boost["id"]) }
+      end
+    end
+
+    def log(message)
+      @logger.puts message
+    end
+end

--- a/lib/basecamp_agent_connector/basecamp/bridge.rb
+++ b/lib/basecamp_agent_connector/basecamp/bridge.rb
@@ -7,7 +7,9 @@ require "securerandom"
 #
 # Campfire chat is the one watched surface webhooks cannot carry (bc3 excludes
 # chat kinds from relay outright), so chat-typed entries in `types` are split
-# off into a ChatPoller instead of the webhook registration. Both sources feed
+# off into a ChatPoller instead of the webhook registration. Boosts are just as
+# webhook-infeasible (a Boost creates no Event in bc3), so the bridge also runs
+# a BoostPoller over the agent's own received-boosts feed. All sources feed
 # identical pipelines: authorizer pre-filter, corroborating re-fetch,
 # authoritative re-check, one STDOUT funnel.
 class BasecampAgentConnector::Basecamp::Bridge
@@ -16,7 +18,8 @@ class BasecampAgentConnector::Basecamp::Bridge
   CHAT_TYPE = /\A(chat(::.+)?|campfire)\z/i
 
   def initialize(authorizer:, agent:, projects:, types:, basecamp_cli:, emitter:, logger: $stderr,
-    chat_poll_interval: BasecampAgentConnector::Basecamp::ChatPoller::DEFAULT_INTERVAL)
+    chat_poll_interval: BasecampAgentConnector::Basecamp::ChatPoller::DEFAULT_INTERVAL,
+    boost_poll_interval: BasecampAgentConnector::Basecamp::BoostPoller::DEFAULT_INTERVAL)
     @authorizer = authorizer
     @agent = agent
     @projects = projects
@@ -25,6 +28,7 @@ class BasecampAgentConnector::Basecamp::Bridge
     @emitter = emitter
     @logger = logger
     @chat_poll_interval = chat_poll_interval
+    @boost_poll_interval = boost_poll_interval
     @secret = SecureRandom.hex(16)
     @webhooks = BasecampAgentConnector::Basecamp::Webhooks.new(basecamp_cli: basecamp_cli)
   end
@@ -53,6 +57,14 @@ class BasecampAgentConnector::Basecamp::Bridge
       log "Listening for mentions of @#{agent_name} on #{@projects.length} project(s) at #{url}"
     end
 
+    # The boost poller fetches nothing until its thread's first interval pass,
+    # well after the funnel consumer has seen these readiness lines — so no
+    # event can beat the watcher to the stream.
+    if @boost_poll_interval
+      boost_poller.start
+      log "Polling @#{agent_name}'s received-boosts feed every #{@boost_poll_interval}s (boosts have no webhooks)"
+    end
+
     log "Trust: #{@authorizer.description}"
   end
 
@@ -61,11 +73,15 @@ class BasecampAgentConnector::Basecamp::Bridge
       Thread.new do
         payload = JSON.parse(request.body)
 
-        # Basecamp never delivers chat events by webhook, so a chat-kind payload
-        # on this route is by definition not from Basecamp. The poller is the
-        # sole chat source; refuse the impostor rather than corroborate it.
-        if BasecampAgentConnector::Basecamp::Event.from_payload(payload).chat_kind?
+        # Basecamp never delivers chat or boost events by webhook, so either
+        # kind on this route is by definition not from Basecamp. The pollers
+        # are the sole sources; refuse the impostor rather than corroborate it
+        # (or let it replay a real boost through this pipeline's separate dedupe).
+        event = BasecampAgentConnector::Basecamp::Event.from_payload(payload)
+        if event.chat_kind?
           log "ignored chat-kind payload: Basecamp does not deliver chat webhooks"
+        elsif event.boost?
+          log "ignored boost-kind payload: Basecamp does not deliver boost webhooks"
         else
           pipeline.process(payload)
         end
@@ -79,6 +95,7 @@ class BasecampAgentConnector::Basecamp::Bridge
 
   def teardown
     @chat_poller&.stop
+    @boost_poller&.stop
     @webhooks.delete_all
   end
 
@@ -99,6 +116,17 @@ class BasecampAgentConnector::Basecamp::Bridge
         pipeline: build_pipeline,
         projects: @projects,
         interval: @chat_poll_interval,
+        logger: @logger
+    end
+
+    # Like the chat poller: its own pipeline so boost ids and webhook event
+    # ids never share a dedupe space; trust components are the same instances.
+    def boost_poller
+      @boost_poller ||= BasecampAgentConnector::Basecamp::BoostPoller.new \
+        basecamp_cli: @basecamp_cli,
+        pipeline: build_pipeline,
+        agent: @agent,
+        interval: @boost_poll_interval,
         logger: @logger
     end
 

--- a/lib/basecamp_agent_connector/basecamp/client.rb
+++ b/lib/basecamp_agent_connector/basecamp/client.rb
@@ -40,6 +40,14 @@ class BasecampAgentConnector::Basecamp::Client
     json "subscriptions", "show", url_or_id
   end
 
+  # The boosts the profile's user has received (bc3's `/my/boosts.json` — the
+  # report behind the "You've got Boosts!" notification), newest first. The CLI
+  # has no dedicated command for the received-boosts feed, so go through its
+  # raw API passthrough.
+  def received_boosts(profile:)
+    json "api", "get", "/my/boosts.json", *profile_flag(profile)
+  end
+
   def create_webhook(url:, project:, types:)
     json "webhooks", "create", url, "--project", project.to_s, "--types", types
   end

--- a/lib/basecamp_agent_connector/basecamp/event.rb
+++ b/lib/basecamp_agent_connector/basecamp/event.rb
@@ -24,6 +24,15 @@ class BasecampAgentConnector::Basecamp::Event
   # event under `agent_subscribed`; a raw webhook payload never carries it.
   COMMENT_CREATED_KIND = "comment_created"
 
+  # A fourth way to trigger the agent: someone boosts a recording of the
+  # agent's. Basecamp never delivers boosts by webhook — in bc3 a Boost is not
+  # a Recording and creates no Event, so there is no kind to even subscribe
+  # to. Boost-kind events exist only as events the BoostPoller synthesizes
+  # from the agent's own received-boosts feed, named as bc3 would have named
+  # the event had one existed (Boost => boost_created) — and a boost-kind
+  # payload arriving on the webhook route is by definition not from Basecamp.
+  BOOST_KIND = "boost_created"
+
   MENTION_CONTENT_TYPE = "application/vnd.basecamp.mention"
 
   # The webhook delivers a mention as an unexpanded attachment carrying only an
@@ -46,7 +55,7 @@ class BasecampAgentConnector::Basecamp::Event
 
   EMITTED_RECORDING_FIELDS = %w[id type title app_url url content parent bucket]
   EMITTED_CREATOR_FIELDS = %w[id name email_address]
-  EMITTED_DETAIL_FIELDS = %w[added_person_ids removed_person_ids]
+  EMITTED_DETAIL_FIELDS = %w[added_person_ids removed_person_ids boost]
 
   def self.from_payload(payload)
     new(payload)
@@ -68,6 +77,20 @@ class BasecampAgentConnector::Basecamp::Event
 
   def self.chat_line_kind(type)
     "#{type.to_s.gsub("::", "_").gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase}_created"
+  end
+
+  # The BoostPoller has no webhook envelope to parse, so it synthesizes one per
+  # new feed entry: the boosted recording is the recording, the booster is the
+  # creator, and the boost's own id and content ride in `details`.
+  def self.boost_payload(boost)
+    {
+      "id" => boost["id"],
+      "kind" => BOOST_KIND,
+      "created_at" => boost["created_at"],
+      "creator" => boost["booster"] || {},
+      "details" => { "boost" => boost.slice("id", "content") },
+      "recording" => boost["recording"] || {}
+    }
   end
 
   def initialize(payload)
@@ -138,6 +161,10 @@ class BasecampAgentConnector::Basecamp::Event
     kind == COMMENT_CREATED_KIND
   end
 
+  def boost?
+    kind == BOOST_KIND
+  end
+
   def authored_by?(identity)
     return false if creator_email.nil? || identity.email.nil?
 
@@ -161,6 +188,14 @@ class BasecampAgentConnector::Basecamp::Event
   # parent. Reads nothing from the forgeable webhook payload.
   def subscribed?
     @payload["agent_subscribed"] == true
+  end
+
+  # True only on an authoritative event the Verifier stamped after re-fetching
+  # the agent's own received-boosts feed and finding this boost in it — the
+  # feed files a boost under the person it was aimed at, so membership is the
+  # targeting fact. Reads nothing from a forgeable payload.
+  def boosted?
+    @payload["agent_boosted"] == true
   end
 
   def to_emitted_hash

--- a/lib/basecamp_agent_connector/basecamp/event.rb
+++ b/lib/basecamp_agent_connector/basecamp/event.rb
@@ -165,10 +165,14 @@ class BasecampAgentConnector::Basecamp::Event
     kind == BOOST_KIND
   end
 
+  # Email or account Person id — either key identifies the author. Email alone
+  # is not enough: bc3 redacts other users' addresses from non-admin viewers
+  # (`Person#can_see_email_address_of?` is self-or-admin), so a feed the agent
+  # fetches shows every other booster as `j••••@••••.•••`. The Person id is
+  # visible to every viewer and is the same account-scoped id space the
+  # webhook's `creator.id` uses, so it matches where a redacted email cannot.
   def authored_by?(identity)
-    return false if creator_email.nil? || identity.email.nil?
-
-    creator_email.casecmp?(identity.email)
+    authored_by_email?(identity) || authored_by_person_id?(identity)
   end
 
   def mentions?(agent)
@@ -210,6 +214,14 @@ class BasecampAgentConnector::Basecamp::Event
   end
 
   private
+    def authored_by_email?(identity)
+      !creator_email.nil? && !identity.email.nil? && creator_email.casecmp?(identity.email)
+    end
+
+    def authored_by_person_id?(identity)
+      !identity.person_id.nil? && creator_id == identity.person_id
+    end
+
     def mentioned_person_ids
       mention_attachment_sgids.flat_map { |sgid| person_ids_in(sgid) }
     end

--- a/lib/basecamp_agent_connector/basecamp/pipeline.rb
+++ b/lib/basecamp_agent_connector/basecamp/pipeline.rb
@@ -29,15 +29,17 @@ class BasecampAgentConnector::Basecamp::Pipeline
 
     # The pre-filter is deliberately looser than the authoritative target check:
     # a comment carries no subscription flag in its payload, so it can't prove it
-    # targets the agent until the Verifier re-fetches subscribers. Admit every
-    # comment here (author is already gated) so subscription can be corroborated;
-    # `targets_agent?` on the verified event makes the real decision.
+    # targets the agent until the Verifier re-fetches subscribers — and a boost
+    # can't prove it landed on the agent's work until the Verifier re-fetches the
+    # agent's own received-boosts feed. Admit both here (author is already gated)
+    # so the live fact can be corroborated; `targets_agent?` on the verified
+    # event makes the real decision.
     def worth_verifying?(event)
-      targets_agent?(event) || event.subscribable_comment?
+      targets_agent?(event) || event.subscribable_comment? || event.boost?
     end
 
     def targets_agent?(event)
-      event.mentions?(@agent) || event.assigns?(@agent) || event.subscribed?
+      event.mentions?(@agent) || event.assigns?(@agent) || event.subscribed? || event.boosted?
     end
 
     def fresh?(event)
@@ -63,7 +65,10 @@ class BasecampAgentConnector::Basecamp::Pipeline
     # subscribed recording there is no mention to re-check; the verifier stamps
     # the subscription it confirmed against the live subscribers API, and
     # `targets_agent?` reads only that stamp — so a comment the agent doesn't
-    # actually subscribe to is dropped here too.
+    # actually subscribe to is dropped here too. A boost works the same way:
+    # the verifier stamps `agent_boosted` only after finding the boost in a
+    # fresh fetch of the agent's own received-boosts feed, with the emitted
+    # booster and content taken from that fetch.
     def emit_if_verified(event)
       verified = @verifier.verify(event)
 

--- a/lib/basecamp_agent_connector/basecamp/verifier.rb
+++ b/lib/basecamp_agent_connector/basecamp/verifier.rb
@@ -7,10 +7,14 @@ class BasecampAgentConnector::Basecamp::Verifier
   end
 
   def verify(event)
-    recording = fetch_recording(event)
+    if event.boost?
+      verify_boost(event)
+    else
+      recording = fetch_recording(event)
 
-    if corroborated?(recording, event)
-      authoritative_event(event, recording)
+      if corroborated?(recording, event)
+        authoritative_event(event, recording)
+      end
     end
   end
 
@@ -114,5 +118,43 @@ class BasecampAgentConnector::Basecamp::Verifier
       Array(@basecamp_cli.subscription(locator)["subscribers"]).map { |subscriber| subscriber["id"] }
     rescue BasecampAgentConnector::Basecamp::Client::Error
       []
+    end
+
+    # A boost has no recording endpoint to re-fetch — it is not a Recording.
+    # The one place Basecamp reports it is the boostee's own received-boosts
+    # feed, so corroborate against a fresh fetch of the agent's feed: the
+    # claimed boost id must be present with the claimed booster. Everything
+    # emitted — booster, content, boosted recording — comes from that fresh
+    # fetch, so a payload contributes nothing but the id to look up. Presence
+    # in the agent's own feed is also the targeting fact (the feed files a
+    # boost under the person it was aimed at), stamped as `agent_boosted` for
+    # the pipeline's authoritative target re-check. A boost deleted — or
+    # scrolled off the feed's newest-page window — between poll and dispatch
+    # stops being corroborable and is dropped, exactly like a deleted comment.
+    def verify_boost(event)
+      boost = fetch_boost(event)
+
+      if !boost.nil? && boost.dig("booster", "id") == event.creator_id
+        authoritative_boost_event(event, boost)
+      end
+    end
+
+    def fetch_boost(event)
+      return nil if @agent.profile.nil?
+
+      Array(@basecamp_cli.received_boosts(profile: @agent.profile)).find { |boost| boost["id"] == event.id }
+    rescue BasecampAgentConnector::Basecamp::Client::Error
+      nil
+    end
+
+    def authoritative_boost_event(event, boost)
+      BasecampAgentConnector::Basecamp::Event.from_payload \
+        "id" => event.id,
+        "kind" => event.kind,
+        "created_at" => boost["created_at"],
+        "details" => { "boost" => boost.slice("id", "content") },
+        "creator" => boost["booster"],
+        "recording" => boost["recording"] || {},
+        "agent_boosted" => true
     end
 end

--- a/lib/basecamp_agent_connector/connector.rb
+++ b/lib/basecamp_agent_connector/connector.rb
@@ -16,7 +16,7 @@ class BasecampAgentConnector::Connector
   TRUST_MODES = %w[operator allowlist project domain]
 
   Options = Data.define(:agent, :operator, :projects, :types, :repos, :events, :port,
-    :trust, :allowed_emails, :allowed_domains, :allow_assignments, :chat_poll)
+    :trust, :allowed_emails, :allowed_domains, :allow_assignments, :chat_poll, :boost_poll)
 
   def self.start(argv)
     new(parse_options(argv)).start
@@ -38,11 +38,12 @@ class BasecampAgentConnector::Connector
     allow_project = false
     allow_assignments = false
     chat_poll = BasecampAgentConnector::Basecamp::ChatPoller::DEFAULT_INTERVAL
+    boost_poll = BasecampAgentConnector::Basecamp::BoostPoller::DEFAULT_INTERVAL
 
     OptionParser.new do |parser|
       parser.banner = "Usage: connect [@AGENT] [--project PROJECT]... [--repo OWNER/REPO]... [--operator PROFILE] " \
         "[--trust MODE] [--allow EMAIL]... [--allow-domain DOMAIN]... [--allow-project] " \
-        "[--allow-assignments-from-authorized] [--types TYPES] [--chat-poll SECONDS] [--events EVENTS] [--port PORT]"
+        "[--allow-assignments-from-authorized] [--types TYPES] [--chat-poll SECONDS] [--boost-poll SECONDS] [--no-boosts] [--events EVENTS] [--port PORT]"
       parser.on("--project PROJECT", "Basecamp project name, URL, or ID (repeatable)") { |value| projects << value }
       parser.on("--repo OWNER/REPO", "GitHub repo to watch for reviews (repeatable)") { |value| repos << value }
       parser.on("--operator PROFILE", "Profile whose user is allowed to trigger (default: CLI default profile)") { |value| operator = value }
@@ -67,6 +68,13 @@ class BasecampAgentConnector::Connector
 
         chat_poll = value
       end
+      parser.on("--boost-poll SECONDS", Integer, "Received-boosts poll interval " \
+        "(default: #{BasecampAgentConnector::Basecamp::BoostPoller::DEFAULT_INTERVAL}s; boosts have no webhooks)") do |value|
+        raise ArgumentError, "--boost-poll must be a positive number of seconds" unless value.positive?
+
+        boost_poll = value
+      end
+      parser.on("--no-boosts", "Don't poll the agent's received-boosts feed") { boost_poll = nil }
       parser.on("--events EVENTS", "Comma-separated GitHub webhook events") { |value| events = value }
       parser.on("--port PORT", Integer, "Local port for the webhook server") { |value| port = value }
     end.parse!(arguments)
@@ -81,7 +89,7 @@ class BasecampAgentConnector::Connector
 
     Options.new(agent: normalize_agent(agent), operator: operator, projects: projects, types: types, repos: repos, events: events_list(events), port: port,
       trust: trust, allowed_emails: allowed_emails, allowed_domains: allowed_domains, allow_assignments: allow_assignments,
-      chat_poll: chat_poll)
+      chat_poll: chat_poll, boost_poll: boost_poll)
   end
 
   # `--trust MODE` picks the mode explicitly; otherwise the value flags imply
@@ -155,7 +163,8 @@ class BasecampAgentConnector::Connector
 
       BasecampAgentConnector::Basecamp::Bridge.new \
         authorizer: authorizer(operator, agent), agent: agent,
-        projects: @options.projects, types: @options.types, chat_poll_interval: @options.chat_poll,
+        projects: @options.projects, types: @options.types,
+        chat_poll_interval: @options.chat_poll, boost_poll_interval: @options.boost_poll,
         basecamp_cli: basecamp_cli, emitter: emitter
     end
 

--- a/lib/basecamp_agent_connector/emitter.rb
+++ b/lib/basecamp_agent_connector/emitter.rb
@@ -6,8 +6,8 @@ class BasecampAgentConnector::Emitter
     @lock = Mutex.new
   end
 
-  # Serialized: webhook deliveries are processed on their own threads and the
-  # chat poller emits from its poll thread, all into one NDJSON stream — an
+  # Serialized: webhook deliveries are processed on their own threads and a
+  # poller emits from its poll thread, all into one NDJSON stream — an
   # interleaved write would tear a line and break the watcher.
   def emit(event)
     line = JSON.generate(event.to_emitted_hash)

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -38,12 +38,13 @@ the operator alone (you — the CLI default profile, or `--operator <profile>`);
 `bin/connect`'s trust flags (`--trust`, `--allow`, `--allow-domain`,
 `--allow-project`) can deliberately broaden this to named colleagues, an email
 domain, or the whole project membership — (2) **@mentions the agent user**,
-**assigns** it a card/todo, **or** is a new comment on a recording the agent
-**subscribes** to, and (3) is corroborated against the Basecamp API. The agent's
-own identity never authorizes, in any mode. Treat every STDOUT line as
-already-trusted — but still keep dispatched agents scoped to the resolved repo.
+**assigns** it a card/todo, is a new comment on a recording the agent
+**subscribes** to, **or** is a **boost on the agent's work**, and (3) is
+corroborated against the Basecamp API. The agent's own identity never
+authorizes, in any mode. Treat every STDOUT line as already-trusted — but still
+keep dispatched agents scoped to the resolved repo.
 
-There are thus **three triggers**:
+There are thus **four triggers**:
 
 1. an `@mention` of the agent;
 2. the operator **assigning** the agent a card/todo (a `*_assignment_changed`
@@ -55,7 +56,12 @@ There are thus **three triggers**:
    **subscribes** to — corroborated by re-fetching the parent's subscribers and
    matching the agent's Person id. The comment author is gated exactly like a
    mention (operator by default, else the active trust mode's authors). See
-   [When a comment lands on a thread the agent follows](#when-a-comment-lands-on-a-thread-the-agent-follows).
+   [When a comment lands on a thread the agent follows](#when-a-comment-lands-on-a-thread-the-agent-follows);
+4. a **boost** (`boost_created`) on the agent's own work — boosts have no
+   webhooks, so the connector polls the agent's received-boosts feed (every
+   `--boost-poll` seconds, default 60; `--no-boosts` disables). The booster is
+   gated exactly like a mention author. See
+   [When someone boosts the agent's work](#when-someone-boosts-the-agents-work).
 
 ## Runs from any project — the runtime lives in the connector clone
 
@@ -112,6 +118,7 @@ The skill remembers the last successful connection in
   "trust": { "mode": "domain", "allow": [], "allow_domain": [ "37signals.com" ], "allow_assignments": false },
   "types": "Comment,Message,Kanban::Card,Kanban::Step,Todo,Chat::Line",
   "chat_poll": 15,
+  "boost_poll": 60,
   "saved_at": "2026-07-01T15:00:00Z"
 }
 ```
@@ -135,8 +142,9 @@ The skill remembers the last successful connection in
   names, **the trust configuration** (the mode and its value flags, so a
   later no-argument launch reconstructs the same trust boundary rather than
   silently falling back to operator-only), **and the coverage** — the `--types`
-  value and `--chat-poll` interval actually used, so a chat-only or custom-typed
-  run relaunches as itself instead of silently restoring the default mixed
+  value, `--chat-poll` interval, and boost polling (`--boost-poll` interval, or
+  `null` for `--no-boosts`) actually used, so a chat-only or custom-typed run
+  relaunches as itself instead of silently restoring the default mixed
   webhook/chat coverage (and its Funnel + webhooks) — so the store always
   reflects the last working connection. Create the directory if needed. Launch failures must
   not overwrite it.
@@ -151,9 +159,10 @@ The skill remembers the last successful connection in
   rather than silently broadening trust. A missing `trust` block means
   operator-only (older stores). If the stored block is internally inconsistent
   and the parser rejects it, **stop and confirm with the user** — never infer a
-  mode to make it launch. Also re-emit the stored `types` (as `--types`) and
-  `chat_poll` (as `--chat-poll`) when present; missing fields (older stores)
-  mean the defaults.
+  mode to make it launch. Also re-emit the stored `types` (as `--types`),
+  `chat_poll` (as `--chat-poll`), and `boost_poll` (`--boost-poll <n>`, or
+  `--no-boosts` for a stored `null`) when present; missing fields (older
+  stores) mean the defaults.
 
 Project ids are stored (not just names) because name lookup is exact-match;
 launching from the store passes ids.
@@ -402,6 +411,31 @@ addressed. Treat this as *activity on a followed thread*, not a directive:
 > subscribed-thread comments; how aggressively the agent should engage (answer
 > vs. stay silent, and on which threads) is an operator-tunable judgment worth
 > revisiting once there's real traffic.
+
+### When someone boosts the agent's work
+
+If the event `kind` is `boost_created`, an authorized user boosted a recording
+of the agent's — a comment it posted, a card it worked, an answer it wrote.
+`creator` is the **booster**, `recording` is the **boosted recording** (the
+agent's own work), and `details.boost.content` is the boost itself — at most 16
+characters, so it is a *signal*, not an instruction: `👍`, `🔥`, `redo`, `wrong`.
+
+1. **Read the signal in context** — the boost content plus the boosted
+   recording (`basecamp show <recording.url> -j`) and its thread. Same
+   non-blocking dispatch as every trigger: the front thread returns to the
+   monitor immediately.
+2. **Judge the valence.** An approving boost (`👍`, `🙏`, `nice`) needs **no
+   action and no reply** — it is applause, and answering applause is noise. A
+   corrective or directive boost (`redo`, `wrong`, `👎`, `🤔`) means the boosted
+   work needs another look: re-read the thread for what to fix; when the signal
+   is too terse to act on confidently, reply on the boosted recording as the
+   agent asking one concrete question.
+3. **No boost back, no card moves** — never boost a boost, and skip the Triage
+   move unless the agent actually resumes work on the recording.
+
+> This response policy is **provisional**, like the followed-thread one: 16
+> characters can't carry much intent, so lean strongly toward silence and let
+> real traffic tune the judgment.
 
 ### Validate a finished body of work with `bin/ci` (in the background)
 

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -60,7 +60,9 @@ There are thus **four triggers**:
 4. a **boost** (`boost_created`) on the agent's own work — boosts have no
    webhooks, so the connector polls the agent's received-boosts feed (every
    `--boost-poll` seconds, default 60; `--no-boosts` disables). The booster is
-   gated exactly like a mention author. See
+   gated exactly like a mention author, matched by Person id (the agent's view
+   of the feed redacts other users' emails, so under email-keyed `allowlist`/
+   `domain` trust, boosts effectively stay operator-only). See
    [When someone boosts the agent's work](#when-someone-boosts-the-agents-work).
 
 ## Runs from any project — the runtime lives in the connector clone

--- a/test/basecamp_bridge_test.rb
+++ b/test/basecamp_bridge_test.rb
@@ -91,8 +91,55 @@ class BasecampBridgeTest < Minitest::Test
     assert_empty runner.commands_matching(/chat line /)
   end
 
+  def test_register_starts_the_boost_poller_and_logs_after_the_webhook_readiness_line
+    runner = FakeCommandRunner.new
+    runner.stub "webhooks create", stdout: envelope("id" => 555)
+    runner.stub "webhooks delete", exit_status: 0
+    logs = StringIO.new
+    bridge = bridge(runner, logger: logs, boost_poll_interval: 60)
+
+    bridge.register(base_url: "https://host.ts.net")
+
+    listening = logs.string.index("Listening for mentions")
+    polling = logs.string.index("Polling @Clawdito's received-boosts feed every 60s")
+    refute_nil polling
+    assert_operator listening, :<, polling
+    # The poller starts but fetches nothing until its first interval pass, so
+    # no event can beat the readiness lines to the funnel.
+    assert_empty runner.commands_matching(%r{api get /my/boosts\.json})
+  ensure
+    bridge.teardown
+  end
+
+  def test_a_nil_boost_poll_interval_disables_the_poller
+    runner = FakeCommandRunner.new
+    runner.stub "webhooks create", stdout: envelope("id" => 555)
+    runner.stub "webhooks delete", exit_status: 0
+    logs = StringIO.new
+    bridge = bridge(runner, logger: logs, boost_poll_interval: nil)
+
+    bridge.register(base_url: "https://host.ts.net")
+    bridge.teardown
+
+    refute_match(/received-boosts feed/, logs.string)
+  end
+
+  def test_handler_refuses_boost_kind_webhook_payloads
+    runner = FakeCommandRunner.new
+    output = StringIO.new
+    logs = StringIO.new
+    bridge = bridge(runner, logger: logs, output: output)
+
+    bridge.handler.call(Struct.new(:body).new(JSON.generate(boost_payload))).join
+
+    assert_empty output.string
+    assert_match(/ignored boost-kind payload/, logs.string)
+    assert_empty runner.commands
+  end
+
   private
-    def bridge(runner, projects: [ "A" ], types: "Comment", logger: StringIO.new, output: StringIO.new)
+    def bridge(runner, projects: [ "A" ], types: "Comment", logger: StringIO.new, output: StringIO.new,
+      boost_poll_interval: nil)
       BasecampAgentConnector::Basecamp::Bridge.new \
         authorizer: authorizer,
         agent: agent_identity,
@@ -100,6 +147,7 @@ class BasecampBridgeTest < Minitest::Test
         types: types,
         basecamp_cli: build_cli(runner),
         emitter: BasecampAgentConnector::Emitter.new(output: output),
-        logger: logger
+        logger: logger,
+        boost_poll_interval: boost_poll_interval
     end
 end

--- a/test/basecamp_client_test.rb
+++ b/test/basecamp_client_test.rb
@@ -55,6 +55,16 @@ class BasecampClientTest < Minitest::Test
       "subscriptions show https://example.org/buckets/1/recordings/789"
   end
 
+  def test_received_boosts_fetches_the_profiles_boost_feed
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ])
+
+    boosts = build_cli(runner).received_boosts(profile: "clawdito")
+
+    assert_equal 88001, boosts.first.fetch("id")
+    assert_includes runner.commands.first.join(" "), "api get /my/boosts.json --profile clawdito"
+  end
+
   def test_raises_on_command_failure
     runner = FakeCommandRunner.new
     runner.stub "basecamp me", exit_status: 1, stderr: "boom"

--- a/test/boost_poller_test.rb
+++ b/test/boost_poller_test.rb
@@ -33,7 +33,9 @@ class BoostPollerTest < Minitest::Test
     assert_equal 88001, emitted["event_id"]
     assert_equal "boost_created", emitted["kind"]
     assert_equal "🔥", emitted["details"]["boost"]["content"]
-    assert_equal "operator@example.com", emitted["creator"]["email_address"]
+    # The operator authorized by Person id — the agent's view of the feed
+    # redacts other users' emails.
+    assert_equal 100, emitted["creator"]["id"]
     assert_equal 456, emitted["recording"]["id"]
     assert_includes runner.commands_matching(%r{api get /my/boosts\.json}).first.join(" "), "--profile clawdito"
   end
@@ -103,18 +105,21 @@ class BoostPollerTest < Minitest::Test
   end
 
   def test_a_boost_that_reached_a_verdict_is_not_retried
-    unauthorized_alias = { "id" => 100, "name" => "Operator", "email_address" => "impostor@elsewhere.net" }
+    # A boost from an author the trust mode cannot match — here an allowlisted
+    # colleague whose email the feed redacts, leaving only a Person id the
+    # allowlist can't key on — is a settled drop, not a retry: later polls
+    # skip it without ever re-fetching.
+    colleague = { "id" => 300, "name" => "Marie", "email_address" => "m••••@•••••••.•••", "client" => false }
     runner = FakeCommandRunner.new
-    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ]), once: true
-    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost("booster" => unauthorized_alias) ])
-    poller = poller(runner)
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost("booster" => colleague) ])
+    poller = poller(runner, trust_authorizer: authorizer(trust: :allowlist, emails: [ "marie@example.com" ]))
 
     3.times { poller.poll }
 
     assert_empty @output.string
-    assert_match(/authoritative author is not authorized/, @logs.string)
-    # poll + one corroborating re-fetch; later polls skip the settled boost.
-    assert_equal 4, runner.commands_matching(%r{api get /my/boosts\.json}).length
+    # One fetch per poll and no corroborating re-fetches: the drop settled at
+    # the pre-filter and stayed settled.
+    assert_equal 3, runner.commands_matching(%r{api get /my/boosts\.json}).length
   end
 
   def test_a_prestart_boost_entering_the_window_late_is_not_dispatched
@@ -252,10 +257,10 @@ class BoostPollerTest < Minitest::Test
   end
 
   private
-    def poller(runner, clock: -> { BEFORE_THE_BOOST }, wait: ->(_seconds) { })
+    def poller(runner, clock: -> { BEFORE_THE_BOOST }, wait: ->(_seconds) { }, trust_authorizer: authorizer)
       BasecampAgentConnector::Basecamp::BoostPoller.new \
         basecamp_cli: build_cli(runner),
-        pipeline: pipeline(runner),
+        pipeline: pipeline(runner, trust_authorizer),
         agent: @agent,
         interval: 15,
         logger: @logs,
@@ -263,9 +268,9 @@ class BoostPollerTest < Minitest::Test
         clock: clock
     end
 
-    def pipeline(runner)
+    def pipeline(runner, trust_authorizer)
       BasecampAgentConnector::Basecamp::Pipeline.new \
-        authorizer: authorizer,
+        authorizer: trust_authorizer,
         agent: @agent,
         verifier: BasecampAgentConnector::Basecamp::Verifier.new(basecamp_cli: build_cli(runner), agent: @agent),
         emitter: BasecampAgentConnector::Emitter.new(output: @output),

--- a/test/boost_poller_test.rb
+++ b/test/boost_poller_test.rb
@@ -1,0 +1,274 @@
+require "test_helper"
+
+class BoostPollerTest < Minitest::Test
+  # The sample boost is received at 12:00; a poller whose clock starts before
+  # that treats it as live, one starting after treats it as history.
+  BEFORE_THE_BOOST = Time.utc(2026, 6, 28, 11, 0, 0)
+  AFTER_THE_BOOST = Time.utc(2026, 6, 28, 13, 0, 0)
+
+  def setup
+    @agent = agent_identity
+    @output = StringIO.new
+    @logs = StringIO.new
+  end
+
+  def test_first_fetch_is_a_baseline_and_never_replays_history
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ])
+
+    poller(runner, clock: -> { AFTER_THE_BOOST }).poll
+
+    assert_empty @output.string
+    assert_equal 1, runner.commands_matching(%r{api get /my/boosts\.json}).length
+  end
+
+  def test_emits_a_new_boost_from_the_operator
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ])
+
+    poller(runner).poll
+
+    emitted = JSON.parse(@output.string)
+    assert_equal 1, @output.string.lines.length
+    assert_equal 88001, emitted["event_id"]
+    assert_equal "boost_created", emitted["kind"]
+    assert_equal "🔥", emitted["details"]["boost"]["content"]
+    assert_equal "operator@example.com", emitted["creator"]["email_address"]
+    assert_equal 456, emitted["recording"]["id"]
+    assert_includes runner.commands_matching(%r{api get /my/boosts\.json}).first.join(" "), "--profile clawdito"
+  end
+
+  def test_does_not_reprocess_a_seen_boost
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ])
+    poller = poller(runner)
+
+    3.times { poller.poll }
+
+    assert_equal 1, @output.string.lines.length
+  end
+
+  def test_ignores_a_boost_from_an_unauthorized_booster
+    stranger = { "id" => 400, "name" => "Sam", "email_address" => "sam@elsewhere.net" }
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost("booster" => stranger) ])
+
+    poller(runner).poll
+
+    assert_empty @output.string
+    # The pre-filter dropped it before any corroborating re-fetch.
+    assert_equal 1, runner.commands_matching(%r{api get /my/boosts\.json}).length
+  end
+
+  def test_ignores_the_agents_own_boost
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: \
+      envelope([ received_boost("booster" => { "id" => 200, "name" => "Clawdito", "email_address" => "clawdito@example.com" }) ])
+
+    poller(runner).poll
+
+    assert_empty @output.string
+    assert_equal 1, runner.commands_matching(%r{api get /my/boosts\.json}).length
+  end
+
+  def test_corroboration_drops_a_boost_that_left_the_feed
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ]), once: true
+    runner.stub "api get /my/boosts.json", stdout: envelope([])
+    poller = poller(runner)
+
+    poller.poll
+    poller.poll
+
+    assert_empty @output.string
+    assert_match(/not corroborated/, @logs.string)
+  end
+
+  def test_a_transient_corroboration_failure_is_retried_on_the_next_poll
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ]), once: true
+    runner.stub "api get /my/boosts.json", exit_status: 1, stderr: "502 Bad Gateway", once: true
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ])
+    poller = poller(runner)
+
+    poller.poll
+    assert_empty @output.string
+    assert_match(/not corroborated/, @logs.string)
+
+    poller.poll
+    assert_equal 1, @output.string.lines.length
+
+    poller.poll
+    assert_equal 1, @output.string.lines.length
+  end
+
+  def test_a_boost_that_reached_a_verdict_is_not_retried
+    unauthorized_alias = { "id" => 100, "name" => "Operator", "email_address" => "impostor@elsewhere.net" }
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ]), once: true
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost("booster" => unauthorized_alias) ])
+    poller = poller(runner)
+
+    3.times { poller.poll }
+
+    assert_empty @output.string
+    assert_match(/authoritative author is not authorized/, @logs.string)
+    # poll + one corroborating re-fetch; later polls skip the settled boost.
+    assert_equal 4, runner.commands_matching(%r{api get /my/boosts\.json}).length
+  end
+
+  def test_a_prestart_boost_entering_the_window_late_is_not_dispatched
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([]), once: true
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost("created_at" => "2026-06-28T10:59:59Z") ])
+    poller = poller(runner)
+
+    poller.poll
+    poller.poll
+
+    assert_empty @output.string
+    assert_equal 2, runner.commands_matching(%r{api get /my/boosts\.json}).length
+  end
+
+  def test_a_boost_in_the_pollers_start_second_is_dispatched
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost("created_at" => "2026-06-28T11:00:00Z") ])
+
+    poller(runner, clock: -> { BEFORE_THE_BOOST + 0.5 }).poll
+
+    assert_equal 1, @output.string.lines.length
+  end
+
+  def test_a_boost_with_an_unreadable_timestamp_is_baselined
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: \
+      envelope([ received_boost("created_at" => "garbage"), received_boost("id" => 88002, "created_at" => nil) ])
+
+    poller(runner).poll
+
+    assert_empty @output.string
+    assert_equal 1, runner.commands_matching(%r{api get /my/boosts\.json}).length
+  end
+
+  def test_warns_of_a_possible_feed_overflow_when_every_fetched_boost_is_new
+    stranger = { "id" => 400, "name" => "Sam", "email_address" => "sam@elsewhere.net" }
+    window = Array.new(BasecampAgentConnector::Basecamp::BoostPoller::FEED_WINDOW) do |index|
+      received_boost("id" => 88100 + index, "booster" => stranger)
+    end
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope(window)
+
+    poller(runner).poll
+
+    assert_match(/possible boost feed overflow/, @logs.string)
+  end
+
+  def test_no_overflow_warning_when_the_window_overlaps_seen_boosts
+    stranger = { "id" => 400, "name" => "Sam", "email_address" => "sam@elsewhere.net" }
+    window = Array.new(BasecampAgentConnector::Basecamp::BoostPoller::FEED_WINDOW) do |index|
+      received_boost("id" => 88100 + index, "booster" => stranger)
+    end
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope(window.first(1)), once: true
+    runner.stub "api get /my/boosts.json", stdout: envelope(window)
+    poller = poller(runner)
+
+    poller.poll
+    poller.poll
+
+    refute_match(/possible boost feed overflow/, @logs.string)
+  end
+
+  def test_a_failed_fetch_leaves_the_baseline_for_the_next_successful_poll
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", exit_status: 1, stderr: "boom", once: true
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ])
+    poller = poller(runner, clock: -> { AFTER_THE_BOOST })
+
+    poller.poll
+    assert_match(/boost poll failed/, @logs.string)
+
+    # First success baselines by time instead of replaying history as "new".
+    poller.poll
+    assert_empty @output.string
+  end
+
+  def test_malformed_feed_output_is_logged_and_retried
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: '{"data": [{"id": 88', once: true
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ])
+    poller = poller(runner)
+
+    poller.poll
+    assert_match(/boost poll failed.*malformed JSON/, @logs.string)
+
+    poller.poll
+    assert_equal 1, @output.string.lines.length
+  end
+
+  def test_the_poll_thread_survives_an_exception_escaping_a_poll
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([])
+    ticks = Queue.new
+    polled = Queue.new
+    poller = poller(runner, wait: ->(_seconds) { ticks.pop })
+    attempts = 0
+    poller.define_singleton_method(:poll) do
+      attempts += 1
+      polled << attempts
+      raise "surprise" if attempts == 1
+      super()
+    end
+
+    poller.start
+    ticks << true
+    ticks << true
+    polled.pop until attempts >= 2
+
+    assert_match(/boost poll failed: surprise/, @logs.string)
+    assert_predicate poller.instance_variable_get(:@thread), :alive?
+  ensure
+    poller&.stop
+  end
+
+  def test_start_fetches_nothing_before_the_first_interval_and_stop_ends_the_thread
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ])
+    ticks = Queue.new
+    poller = poller(runner, wait: ->(_seconds) { ticks.pop })
+
+    poller.start
+    # Nothing is fetched or emitted before the thread's first pass, so the
+    # caller can report readiness before any event can reach the funnel.
+    assert_empty runner.commands_matching(%r{api get /my/boosts\.json})
+
+    2.times { ticks << true }
+    deadline = Time.now + 2
+    sleep 0.01 while @output.string.empty? && Time.now < deadline
+    assert_equal 1, @output.string.lines.length
+
+    poller.stop
+    refute poller.instance_variable_get(:@thread)
+  end
+
+  private
+    def poller(runner, clock: -> { BEFORE_THE_BOOST }, wait: ->(_seconds) { })
+      BasecampAgentConnector::Basecamp::BoostPoller.new \
+        basecamp_cli: build_cli(runner),
+        pipeline: pipeline(runner),
+        agent: @agent,
+        interval: 15,
+        logger: @logs,
+        wait: wait,
+        clock: clock
+    end
+
+    def pipeline(runner)
+      BasecampAgentConnector::Basecamp::Pipeline.new \
+        authorizer: authorizer,
+        agent: @agent,
+        verifier: BasecampAgentConnector::Basecamp::Verifier.new(basecamp_cli: build_cli(runner), agent: @agent),
+        emitter: BasecampAgentConnector::Emitter.new(output: @output),
+        logger: @logs
+    end
+end

--- a/test/connector_test.rb
+++ b/test/connector_test.rb
@@ -66,6 +66,18 @@ class ConnectorTest < Minitest::Test
     end
   end
 
+  def test_parses_the_boost_poll_interval
+    assert_equal 60, parse("@clawdito", "--project", "A").boost_poll
+    assert_equal 120, parse("@clawdito", "--project", "A", "--boost-poll", "120").boost_poll
+    assert_nil parse("@clawdito", "--project", "A", "--no-boosts").boost_poll
+  end
+
+  def test_refuses_a_non_positive_boost_poll_interval
+    assert_raises ArgumentError do
+      parse "@clawdito", "--project", "A", "--boost-poll", "0"
+    end
+  end
+
   def test_refuses_value_flags_that_imply_different_trust_modes
     assert_raises ArgumentError do
       parse "@clawdito", "--project", "A", "--allow", "marie@example.com", "--allow-domain", "example.com"

--- a/test/emitter_test.rb
+++ b/test/emitter_test.rb
@@ -14,4 +14,22 @@ class EmitterTest < Minitest::Test
     assert_equal({ "id" => 100, "name" => "Operator", "email_address" => "operator@example.com" }, parsed["creator"])
     assert_equal 456, parsed["recording"]["id"]
   end
+
+  def test_concurrent_emits_never_tear_a_line
+    output = StringIO.new
+    emitter = BasecampAgentConnector::Emitter.new(output: output)
+
+    threads = 8.times.map do |thread_number|
+      Thread.new do
+        25.times do |emission|
+          emitter.emit BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload("id" => thread_number * 1000 + emission))
+        end
+      end
+    end
+    threads.each(&:join)
+
+    lines = output.string.lines
+    assert_equal 200, lines.length
+    assert(lines.all? { |line| JSON.parse(line)["event_id"].is_a?(Integer) })
+  end
 end

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -59,7 +59,9 @@ class EventTest < Minitest::Test
     assert_equal "boost_created", event.kind
     assert_equal 88001, event.id
     assert_equal 100, event.creator_id
-    assert_equal "operator@example.com", event.creator_email
+    # The agent's view of the feed redacts the booster's email; the Person id
+    # still identifies the operator.
+    assert event.authored_by?(operator_identity)
     assert_equal 456, event.recording["id"]
     refute event.assignment_changed?
     refute event.subscribable_comment?
@@ -84,6 +86,18 @@ class EventTest < Minitest::Test
     assert BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload("creator" => { "email_address" => "OPERATOR@example.com" })).authored_by?(operator_identity)
     refute BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload("creator" => { "email_address" => "someone@example.com" })).authored_by?(operator_identity)
     refute BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload("creator" => {})).authored_by?(operator_identity)
+  end
+
+  def test_authored_by_matches_on_person_id_when_the_email_is_redacted
+    # bc3 redacts other users' emails from non-admin viewers, so a feed the
+    # agent fetches identifies the operator only by account Person id.
+    redacted = { "id" => 100, "name" => "Operator", "email_address" => "o•••••••@•••••••.•••" }
+
+    assert BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload("creator" => redacted)).authored_by?(operator_identity)
+    refute BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload("creator" => redacted.merge("id" => 999))).authored_by?(operator_identity)
+    # No resolved person id means email is the only key.
+    emailless_operator = BasecampAgentConnector::Basecamp::Identity.new(id: 100, email: "operator@example.com")
+    refute BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload("creator" => redacted)).authored_by?(emailless_operator)
   end
 
   def test_mentions_the_agent

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -37,6 +37,42 @@ class EventTest < Minitest::Test
     refute BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload("agent_subscribed" => "true")).subscribed?
   end
 
+  def test_boost_kind
+    assert from_kind("boost_created").boost?
+    refute from_kind("comment_created").boost?
+    refute from_kind("kanban_card_assignment_changed").boost?
+    refute from_kind(nil).boost?
+  end
+
+  def test_boosted_reflects_only_the_verifier_stamp
+    refute BasecampAgentConnector::Basecamp::Event.from_payload(boost_payload).boosted?
+    assert BasecampAgentConnector::Basecamp::Event.from_payload(boost_payload.merge("agent_boosted" => true)).boosted?
+    # strictly boolean true — a truthy stand-in must not read as boosted
+    refute BasecampAgentConnector::Basecamp::Event.from_payload(boost_payload.merge("agent_boosted" => "true")).boosted?
+  end
+
+  def test_boost_payload_synthesizes_a_boost_kind_event
+    event = BasecampAgentConnector::Basecamp::Event.from_payload(boost_payload)
+
+    assert event.boost?
+    assert event.actionable_kind?
+    assert_equal "boost_created", event.kind
+    assert_equal 88001, event.id
+    assert_equal 100, event.creator_id
+    assert_equal "operator@example.com", event.creator_email
+    assert_equal 456, event.recording["id"]
+    refute event.assignment_changed?
+    refute event.subscribable_comment?
+  end
+
+  def test_to_emitted_hash_carries_boost_details
+    emitted = BasecampAgentConnector::Basecamp::Event.from_payload(boost_payload).to_emitted_hash
+
+    assert_equal({ "id" => 88001, "content" => "🔥" }, emitted["details"]["boost"])
+    assert_equal "boost_created", emitted["kind"]
+    assert_equal 456, emitted["recording"]["id"]
+  end
+
   def test_to_emitted_hash_carries_assignment_details
     emitted = BasecampAgentConnector::Basecamp::Event.from_payload(assignment_payload).to_emitted_hash
 

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -152,6 +152,78 @@ class PipelineTest < Minitest::Test
     assert_equal 1, @output.string.lines.length
   end
 
+  def test_emits_for_a_boost_on_the_agents_work_by_the_operator
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ])
+
+    pipeline(runner).process(boost_payload)
+
+    emitted = JSON.parse(@output.string)
+    assert_equal 88001, emitted["event_id"]
+    assert_equal "boost_created", emitted["kind"]
+    assert_equal "🔥", emitted["details"]["boost"]["content"]
+  end
+
+  def test_the_emitted_boost_is_the_fetched_one_not_the_claimed_one
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ])
+
+    pipeline(runner).process(boost_payload(received_boost("content" => "forged claim")))
+
+    assert_equal "🔥", JSON.parse(@output.string)["details"]["boost"]["content"]
+  end
+
+  def test_a_forged_boosted_flag_in_the_payload_cannot_emit
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(sample_recording("content" => "<p>no mention</p>"))
+    runner.stub "subscriptions show", stdout: subscribers_envelope(999)
+
+    payload = sample_payload("recording" => sample_recording("content" => "<p>no mention</p>"), "agent_boosted" => true)
+    pipeline(runner).process(payload)
+
+    assert_empty @output.string
+    assert_match(/does not target the agent/, @logs.string)
+  end
+
+  def test_drops_a_boost_basecamp_no_longer_reports
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([])
+    pipeline = pipeline(runner)
+
+    refute pipeline.process(boost_payload)
+    assert_empty @output.string
+    assert_match(/not corroborated/, @logs.string)
+  end
+
+  def test_ignores_a_boost_from_an_unauthorized_booster_without_fetching
+    runner = FakeCommandRunner.new
+
+    pipeline(runner).process(boost_payload(received_boost("booster" => { "id" => 400, "email_address" => "sam@elsewhere.net" })))
+
+    assert_empty @output.string
+    assert_empty runner.commands
+  end
+
+  def test_ignores_the_agents_own_boost_without_fetching
+    runner = FakeCommandRunner.new
+
+    pipeline(runner).process(boost_payload(received_boost("booster" => { "id" => 200, "email_address" => "clawdito@example.com" })))
+
+    assert_empty @output.string
+    assert_empty runner.commands
+  end
+
+  def test_an_authorized_colleagues_boost_emits_under_domain_trust
+    runner = FakeCommandRunner.new
+    booster = { "id" => 300, "name" => "Marie", "email_address" => "marie@example.com" }
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost("booster" => booster) ])
+
+    pipeline(runner, authorizer: authorizer(trust: :domain, domains: [ "example.com" ])).process \
+      boost_payload(received_boost("booster" => booster))
+
+    assert_equal "marie@example.com", JSON.parse(@output.string)["creator"]["email_address"]
+  end
+
   def test_emits_for_an_assignment_of_the_agent_by_the_operator
     runner = FakeCommandRunner.new
     runner.stub "basecamp show", stdout: envelope(assigned_recording)

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -213,6 +213,9 @@ class PipelineTest < Minitest::Test
     assert_empty runner.commands
   end
 
+  # Email-keyed trust modes reach boosts only when the agent can see the
+  # booster's address (bc3 redacts emails from non-admin viewers), so this
+  # models an agent allowed to see it.
   def test_an_authorized_colleagues_boost_emits_under_domain_trust
     runner = FakeCommandRunner.new
     booster = { "id" => 300, "name" => "Marie", "email_address" => "marie@example.com" }
@@ -222,6 +225,17 @@ class PipelineTest < Minitest::Test
       boost_payload(received_boost("booster" => booster))
 
     assert_equal "marie@example.com", JSON.parse(@output.string)["creator"]["email_address"]
+  end
+
+  def test_a_redacted_colleagues_boost_cannot_authorize_email_keyed_trust
+    redacted = { "id" => 300, "name" => "Marie", "email_address" => "m••••@•••••••.•••" }
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost("booster" => redacted) ])
+
+    pipeline(runner, authorizer: authorizer(trust: :allowlist, emails: [ "marie@example.com" ])).process \
+      boost_payload(received_boost("booster" => redacted))
+
+    assert_empty @output.string
   end
 
   def test_emits_for_an_assignment_of_the_agent_by_the_operator
@@ -250,10 +264,12 @@ class PipelineTest < Minitest::Test
   end
 
   def test_drops_event_whose_claimed_author_is_not_the_authoritative_one
+    # The POST claims the operator's email on the real author's Person id; the
+    # corroborated creator (Sam) is who must be authorized, and isn't.
     runner = FakeCommandRunner.new
-    runner.stub "basecamp show", stdout: envelope(sample_recording("creator" => { "id" => 100, "name" => "Sam", "email_address" => "sam@elsewhere.net" }))
+    runner.stub "basecamp show", stdout: envelope(sample_recording("creator" => { "id" => 400, "name" => "Sam", "email_address" => "sam@elsewhere.net" }))
 
-    pipeline(runner).process(sample_payload)
+    pipeline(runner).process(sample_payload("creator" => { "id" => 400, "name" => "Sam", "email_address" => "operator@example.com" }))
 
     assert_empty @output.string
     assert_match(/authoritative author is not authorized/, @logs.string)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -134,6 +134,37 @@ module PayloadHelpers
     BasecampAgentConnector::Basecamp::Event.chat_line_payload(line)
   end
 
+  # An entry from the agent's received-boosts feed (`/my/boosts.json`): the
+  # boost itself plus the booster and the boosted recording (which has no
+  # `content` field in this representation). There is no webhook envelope —
+  # the BoostPoller synthesizes one via Event.boost_payload.
+  def received_boost(overrides = {})
+    {
+      "id" => 88001,
+      "content" => "🔥",
+      "created_at" => "2026-06-28T12:00:00Z",
+      "booster" => { "id" => 100, "name" => "Operator", "email_address" => "operator@example.com", "client" => false },
+      "recording" => boosted_recording
+    }.merge(overrides)
+  end
+
+  def boosted_recording(overrides = {})
+    {
+      "id" => 456,
+      "type" => "Comment",
+      "title" => "Re: a card",
+      "app_url" => "https://3.basecamp.com/000/buckets/222/comments/456",
+      "url" => "https://3.basecamp.com/000/buckets/222/comments/456.json",
+      "creator" => { "id" => 200, "name" => "Clawdito", "email_address" => "clawdito@example.com" },
+      "parent" => { "id" => 789, "type" => "Kanban::Card", "app_url" => "https://3.basecamp.com/000/buckets/222/card_tables/cards/789" },
+      "bucket" => { "id" => 222, "name" => "BC5 Calendar", "type" => "Project" }
+    }.merge(overrides)
+  end
+
+  def boost_payload(boost = received_boost)
+    BasecampAgentConnector::Basecamp::Event.boost_payload(boost)
+  end
+
   # The `basecamp subscriptions show` envelope: the subscribers of a recording,
   # each a person with an id. The connector matches the agent's Person id here.
   def subscribers_envelope(*person_ids)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -138,12 +138,15 @@ module PayloadHelpers
   # boost itself plus the booster and the boosted recording (which has no
   # `content` field in this representation). There is no webhook envelope —
   # the BoostPoller synthesizes one via Event.boost_payload.
+  # The booster's email arrives redacted: bc3 shows real addresses only to the
+  # person themselves or an admin, and the agent fetching its feed is neither.
+  # The account Person id is what identifies the booster.
   def received_boost(overrides = {})
     {
       "id" => 88001,
       "content" => "🔥",
       "created_at" => "2026-06-28T12:00:00Z",
-      "booster" => { "id" => 100, "name" => "Operator", "email_address" => "operator@example.com", "client" => false },
+      "booster" => { "id" => 100, "name" => "Operator", "email_address" => "o•••••••@•••••••.•••", "client" => false },
       "recording" => boosted_recording
     }.merge(overrides)
   end
@@ -172,7 +175,7 @@ module PayloadHelpers
   end
 
   def operator_identity
-    BasecampAgentConnector::Basecamp::Identity.new(id: 100, email: "operator@example.com")
+    BasecampAgentConnector::Basecamp::Identity.new(id: 100, email: "operator@example.com", person_id: 100)
   end
 
   def authorizer(trust: :operator, emails: [], domains: [], allow_assignments: false, operator: operator_identity, agent: agent_identity)

--- a/test/verifier_test.rb
+++ b/test/verifier_test.rb
@@ -132,6 +132,52 @@ class VerifierTest < Minitest::Test
     refute verified.subscribed?
   end
 
+  def test_corroborates_a_boost_against_the_agents_own_feed_and_stamps_it
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost("content" => "👏") ])
+
+    verified = verifier(runner).verify(event(boost_payload))
+
+    refute_nil verified
+    assert verified.boosted?
+    # The authoritative content is the fetched one, not the claimed one.
+    assert_equal "👏", verified.details["boost"]["content"]
+    assert_equal 456, verified.recording["id"]
+    assert_includes runner.commands.first.join(" "), "--profile clawdito"
+    assert_empty runner.commands_matching(/basecamp show/)
+  end
+
+  def test_rejects_a_boost_absent_from_the_agents_feed
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost("id" => 77000) ])
+
+    assert_nil verifier(runner).verify(event(boost_payload))
+  end
+
+  def test_rejects_a_boost_whose_authoritative_booster_does_not_match
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost("booster" => { "id" => 999 }) ])
+
+    assert_nil verifier(runner).verify(event(boost_payload))
+  end
+
+  def test_rejects_a_boost_when_the_feed_fetch_fails
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", exit_status: 1, stderr: "boom"
+
+    assert_nil verifier(runner).verify(event(boost_payload))
+  end
+
+  def test_rejects_a_boost_when_the_agent_has_no_profile
+    runner = FakeCommandRunner.new
+    verifier = BasecampAgentConnector::Basecamp::Verifier.new \
+      basecamp_cli: build_cli(runner),
+      agent: BasecampAgentConnector::Basecamp::Identity.new(id: 200, email: "clawdito@example.com", person_id: 200)
+
+    assert_nil verifier.verify(event(boost_payload))
+    assert_empty runner.commands
+  end
+
   private
     def verifier(runner)
       BasecampAgentConnector::Basecamp::Verifier.new(basecamp_cli: build_cli(runner), agent: agent_identity)


### PR DESCRIPTION
Adds the **boost trigger**: someone boosts a recording of the agent's — a comment it posted, a card it worked, an answer it wrote — and the connector fires. This is the follow-up PR that #11's body and spec pointer promised: boosts are webhook-infeasible, so this trigger is delivered by a poll of the agent's notification surface.

## Delivery mechanism: poll the received-boosts feed — webhooks are impossible

Verified against bc3 source: a `Boost` is not a Recording and creates no `Event`, so there is no webhook kind to even subscribe to. The one place Basecamp reports a boost to its target is the **boostee's own received-boosts feed** — `/my/boosts.json` (`My::BoostsController`: `Boost.where(boostee: self)`, newest first, active and visible only), the report behind the "You've got Boosts!" notification. The notification *list* itself only carries an aggregate `BoostReport` entry pointing at that feed, so the feed is the authoritative endpoint; the connector polls it **as the agent** via the CLI's raw API passthrough (`basecamp api get /my/boosts.json --profile <agent>`; the CLI has no dedicated received-boosts command). Each entry carries the boost (`id`, `content`, `created_at`), the `booster` (person), and the boosted `recording` — everything one `boost_created` event needs.

New `BoostPoller` (default every 60s; `--boost-poll` tunes, `--no-boosts` disables), mirroring #10's ChatPoller discipline with its review lessons baked in from the start:

- **Baseline by time, never by fetch** — boosts predating the poller are marked seen without dispatch, on the first successful fetch *and* when a deletion slides an old boost back into the feed's newest-page window; boosts received since start always process, even when the first successful fetch comes late. The start boundary is floored to the second and compared inclusively; unreadable timestamps fail toward history.
- **Transient failures retry** — `Pipeline#process` now reports whether an event reached a verdict; an uncorroborated boost is forgotten on both sides (pipeline dedupe + poller seen-set) so the next poll retries it while it stays in the feed. A deleted boost simply stops appearing — no churn.
- **The poll thread survives everything** — CLI failures and malformed JSON are `Client::Error` (new rescue in `Client#json`), rescued and logged per tick; anything else escaping a poll costs one tick, not the session.
- **Possible-overflow is warned, not silent** — a full first page with no continuity proof logs a warning stating the actual evidence.
- **Readiness ordering** — the poller fetches nothing until its first interval pass, after the bridge prints its readiness lines; the emitter now serializes NDJSON writes across the webhook threads and the poll thread.

## Trust, corroboration, targeting: identical pipeline, one new stamp

Every polled boost runs through its own `Pipeline` instance (boost ids and webhook event ids never share a dedupe space): authorizer pre-filter — the **booster** is gated exactly as a mention author is, operator by default, and the agent's own boosts never authorize — corroborating re-fetch, authoritative re-check, one NDJSON funnel.

- **Corroboration** re-fetches the agent's feed and requires the claimed boost id to be present with the claimed booster; the emitted booster, content, and recording all come from that fresh fetch, so the synthesized payload contributes nothing but the id to look up.
- **Targeting** is feed membership itself: bc3 files a boost under `boostable.boostee`, so presence in the agent's own feed *is* Basecamp's statement that this boost was aimed at the agent — stamped `agent_boosted` by the verifier (the same pattern as #11's `agent_subscribed`), and `targets_agent?` reads only the stamp. A forged `agent_boosted` in a payload is discarded; the verifier rebuilds the event from its own fetch.
- **The webhook route refuses boost-kind payloads outright**: Basecamp never delivers them, so one arriving on the funnel is by definition not from Basecamp — the poller is the sole boost source, closing the cross-dedupe replay hole Copilot found on #10's chat equivalent.

## Finding along the way: bc3 redacts emails from the agent — authors now match by Person id too

The operator match was keyed on email alone. bc3 shows a real address only to the person themselves or an admin (`Person#can_see_email_address_of?`), and the agent is a non-admin bot — so the feed it fetches redacts every booster to `j••••@••••.•••` (verified live), and **no boost could ever have authorized in production**. `Event#authored_by?` now matches on the account Person id as well as the email: it is the same account-scoped id space a webhook's `creator.id` uses, both identities already resolve it at startup, and it is re-checked on the corroborated event exactly as the email is. Known bound, documented: email-keyed trust modes (`allowlist`, `domain`) cannot see through the redaction, so under them boosts effectively stay operator-only; `project` mode (corroborated Person id + client flag) broadens boosts fine.

## Known bounds, chosen deliberately

- The feed is **account-wide** — notifications are not project-scoped — so a boost triggers wherever the agent's boosted work lives; the bound is the agent's identity, not the `--project` list. Documented in README/spec.
- The feed's first page (~15 entries) is the fetch window; >15 boosts between polls can scroll out unseen, which logs the possible-overflow warning.
- Boosts are immutable; there is no edit case.

## End-to-end smoke test against production

Baseline poll replayed nothing; an operator boost on the agent's own comment emitted exactly **one** complete `boost_created` event (booster matched by Person id through the redacted email; content, recording, bucket all present); the next poll re-emitted nothing; the test boost was deleted afterwards. An earlier run that boosted a recording the agent *didn't* create emitted nothing — accidentally confirming the targeting property live.

## Tests

`boost_poller_test` (baseline/no-replay, emit-once, unauthorized/self boosters dropped pre-fetch, left-the-feed drop, transient-failure retry, settled-verdict no-retry, pre-start re-entry, start-second boundary, unreadable timestamps, overflow warning + continuity suppression, failed/malformed fetch recovery, thread survival, start/stop lifecycle); verifier boost corroboration (stamp, fetched-content authority, absent/mismatched/failed/profile-less rejections); pipeline boost paths (emit, forged-claim override, forged stamp, uncorroborated retry, pre-fetch drops, domain-trust broadening, redacted-allowlist bound); event synthesis + strict-boolean stamp + person-id author matching; client passthrough + malformed-JSON error; bridge poller wiring/readiness ordering/boost-payload refusal; connector flag parsing; emitter concurrency. All fixtures model the redacted feed production actually returns. Full suite + rubocop green.

## Base-branch decision — stacked on #11 (`oncall/comment-boost-triggers`)

Based on **#11**, not `main`, per the split agreed there. The boost trigger reuses the exact structure #11 introduced — the `worth_verifying?` pre-filter split (a payload that can't prove targeting until the verifier corroborates a live fact) and the verifier's stamp pattern (`agent_subscribed` → `agent_boosted`, adjacent code) — and #9's post-verify authorizer/target re-checks beneath it. **Merge order: after #9 and #11.** Sibling of #10 (chat poller): the emitter mutex, `Client#json` malformed-JSON rescue, and `Pipeline#process` verdict return are deliberately identical in shape to #10's so whichever lands second merges cleanly.
