### PR TITLE
Unwrap the CLI envelope by its ok marker, not by data presence

### DIFF
--- a/lib/basecamp_agent_connector/basecamp/boost_poller.rb
+++ b/lib/basecamp_agent_connector/basecamp/boost_poller.rb
@@ -79,7 +79,7 @@ class BasecampAgentConnector::Basecamp::BoostPoller
   def poll
     return if @stopping
 
-    boosts = Array(@basecamp_cli.received_boosts(profile: @agent.profile))
+    boosts = @basecamp_cli.received_boosts(profile: @agent.profile)
     ordered = boosts.sort_by { |boost| boost["id"].to_i }
     warn_of_possible_overflow(ordered)
 

--- a/lib/basecamp_agent_connector/basecamp/chat_poller.rb
+++ b/lib/basecamp_agent_connector/basecamp/chat_poller.rb
@@ -109,7 +109,7 @@ class BasecampAgentConnector::Basecamp::ChatPoller
     end
 
     def discover(project)
-      Array(@basecamp_cli.chats(project: project)).map do |chat|
+      @basecamp_cli.chats(project: project).map do |chat|
         Room.new(project: project, chat_id: chat["id"], title: chat["title"])
       end
     rescue BasecampAgentConnector::Basecamp::Client::Error => error
@@ -138,7 +138,7 @@ class BasecampAgentConnector::Basecamp::ChatPoller
     # baseline and a pre-start line that a deletion slides back into the
     # newest-N window later — either way, history is never dispatched.
     def poll_room(room)
-      lines = Array(@basecamp_cli.chat_lines(project: room.project, chat: room.chat_id, limit: FETCH_LIMIT))
+      lines = @basecamp_cli.chat_lines(project: room.project, chat: room.chat_id, limit: FETCH_LIMIT)
       first_fetch = !@seen_line_ids.key?(room.chat_id)
       seen = @seen_line_ids[room.chat_id] ||= Set.new
       ordered = lines.sort_by { |line| line["id"].to_i }

--- a/lib/basecamp_agent_connector/basecamp/client.rb
+++ b/lib/basecamp_agent_connector/basecamp/client.rb
@@ -25,11 +25,11 @@ class BasecampAgentConnector::Basecamp::Client
   end
 
   def chats(project:)
-    json "chat", "list", "--project", project.to_s
+    Array json("chat", "list", "--project", project.to_s)
   end
 
   def chat_lines(project:, chat:, limit:)
-    json "chat", "messages", "--project", project.to_s, "--room", chat.to_s, "--limit", limit.to_s
+    Array json("chat", "messages", "--project", project.to_s, "--room", chat.to_s, "--limit", limit.to_s)
   end
 
   def chat_line(url_or_id)
@@ -45,7 +45,7 @@ class BasecampAgentConnector::Basecamp::Client
   # has no dedicated command for the received-boosts feed, so go through its
   # raw API passthrough.
   def received_boosts(profile:)
-    json "api", "get", "/my/boosts.json", *profile_flag(profile)
+    Array json("api", "get", "/my/boosts.json", *profile_flag(profile))
   end
 
   def create_webhook(url:, project:, types:)
@@ -73,8 +73,16 @@ class BasecampAgentConnector::Basecamp::Client
       raise Error, "`basecamp #{arguments.join(' ')}` returned malformed JSON: #{error.message}"
     end
 
+    # `-j` wraps every result in an envelope — {"ok": ..., "data": ...,
+    # "summary": ...} — and an empty result may omit "data" entirely:
+    # `chat messages` on a room with no lines returns just
+    # {"ok": true, "summary": "0 messages"} (verified against production).
+    # So the envelope is recognized by its "ok" marker, not by "data" —
+    # keying on "data" hands the bare envelope back for an empty room, and
+    # Array() on that hash downstream explodes it into ["ok", true]-style
+    # pairs whose ["id"] lookups raise TypeError.
     def unwrap(parsed)
-      if parsed.is_a?(Hash) && parsed.key?("data")
+      if parsed.is_a?(Hash) && parsed.key?("ok")
         parsed["data"]
       else
         parsed

--- a/lib/basecamp_agent_connector/basecamp/verifier.rb
+++ b/lib/basecamp_agent_connector/basecamp/verifier.rb
@@ -142,7 +142,7 @@ class BasecampAgentConnector::Basecamp::Verifier
     def fetch_boost(event)
       return nil if @agent.profile.nil?
 
-      Array(@basecamp_cli.received_boosts(profile: @agent.profile)).find { |boost| boost["id"] == event.id }
+      @basecamp_cli.received_boosts(profile: @agent.profile).find { |boost| boost["id"] == event.id }
     rescue BasecampAgentConnector::Basecamp::Client::Error
       nil
     end

--- a/test/basecamp_bridge_test.rb
+++ b/test/basecamp_bridge_test.rb
@@ -65,7 +65,7 @@ class BasecampBridgeTest < Minitest::Test
   def test_chat_only_types_register_no_webhooks
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: envelope([ chat_hash ])
-    runner.stub "chat messages", stdout: envelope([])
+    runner.stub "chat messages", stdout: empty_envelope
     bridge = bridge(runner, types: "Chat::Line")
 
     bridge.register(base_url: "https://host.ts.net")

--- a/test/basecamp_client_test.rb
+++ b/test/basecamp_client_test.rb
@@ -74,6 +74,20 @@ class BasecampClientTest < Minitest::Test
     end
   end
 
+  # A failing command prints the {"ok": false, ...} error envelope on stdout
+  # and exits nonzero (verified against production); the raised error carries
+  # that envelope as its detail, which the pollers log and retry.
+  def test_a_failed_command_surfaces_the_error_envelope_as_detail
+    runner = FakeCommandRunner.new
+    runner.stub "chat messages", exit_status: 2,
+      stdout: JSON.generate("ok" => false, "error" => "Too many requests", "code" => "too_many_requests")
+
+    error = assert_raises(BasecampAgentConnector::Basecamp::Client::Error) do
+      build_cli(runner).chat_lines(project: 222, chat: 333, limit: 50)
+    end
+    assert_match(/too_many_requests/, error.message)
+  end
+
   def test_chats_lists_a_projects_chats
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: envelope([ chat_hash ])

--- a/test/basecamp_client_test.rb
+++ b/test/basecamp_client_test.rb
@@ -94,6 +94,22 @@ class BasecampClientTest < Minitest::Test
     assert_includes runner.commands.first.join(" "), "chat messages --project 222 --room 333 --limit 25"
   end
 
+  # `chat messages` on a room with no lines omits "data" from the envelope
+  # entirely; the list commands must come back empty, not as the bare
+  # envelope hash.
+  def test_a_dataless_envelope_is_an_empty_list_for_list_commands
+    runner = FakeCommandRunner.new
+    runner.stub "chat messages", stdout: empty_envelope
+    runner.stub "chat list", stdout: empty_envelope("0 chats")
+    runner.stub "api get /my/boosts.json", stdout: empty_envelope("0 boosts")
+
+    cli = build_cli(runner)
+
+    assert_equal [], cli.chat_lines(project: 222, chat: 333, limit: 25)
+    assert_equal [], cli.chats(project: 222)
+    assert_equal [], cli.received_boosts(profile: "clawdito")
+  end
+
   def test_chat_line_fetches_one_line_by_url
     runner = FakeCommandRunner.new
     runner.stub "chat line ", stdout: envelope(chat_line)

--- a/test/chat_poller_test.rb
+++ b/test/chat_poller_test.rb
@@ -19,6 +19,19 @@ class ChatPollerTest < Minitest::Test
     assert_empty runner.commands_matching(/chat line /)
   end
 
+  # The live regression: the CLI omits "data" from the envelope for a room
+  # with no lines, and the poller choked on the bare envelope every tick.
+  def test_an_empty_room_polls_clean
+    runner = FakeCommandRunner.new
+    runner.stub "chat list", stdout: envelope([ chat_hash ])
+    runner.stub "chat messages", stdout: empty_envelope
+
+    poller(runner).poll
+
+    assert_empty @output.string
+    assert_empty @logs.string
+  end
+
   def test_emits_a_new_line_mentioning_the_agent_by_the_operator
     runner = corroborating_runner
     poller = poller(runner)
@@ -47,7 +60,7 @@ class ChatPollerTest < Minitest::Test
     stranger = { "id" => 400, "name" => "Sam", "email_address" => "sam@elsewhere.net" }
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: envelope([ chat_hash ])
-    runner.stub "chat messages", stdout: envelope([]), once: true
+    runner.stub "chat messages", stdout: empty_envelope, once: true
     runner.stub "chat messages", stdout: envelope([ chat_line("creator" => stranger) ])
     poller = poller(runner)
 
@@ -61,7 +74,7 @@ class ChatPollerTest < Minitest::Test
   def test_ignores_the_agents_own_line
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: envelope([ chat_hash ])
-    runner.stub "chat messages", stdout: envelope([]), once: true
+    runner.stub "chat messages", stdout: empty_envelope, once: true
     runner.stub "chat messages", stdout: \
       envelope([ chat_line("creator" => { "id" => 200, "name" => "Clawdito", "email_address" => "clawdito@example.com" }) ])
     poller = poller(runner)
@@ -76,7 +89,7 @@ class ChatPollerTest < Minitest::Test
   def test_corroboration_drops_a_line_basecamp_does_not_return
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: envelope([ chat_hash ])
-    runner.stub "chat messages", stdout: envelope([]), once: true
+    runner.stub "chat messages", stdout: empty_envelope, once: true
     runner.stub "chat messages", stdout: envelope([ chat_line ])
     runner.stub "chat line ", exit_status: 1, stderr: "not found"
     poller = poller(runner)
@@ -91,7 +104,7 @@ class ChatPollerTest < Minitest::Test
   def test_a_transient_corroboration_failure_is_retried_on_the_next_poll
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: envelope([ chat_hash ])
-    runner.stub "chat messages", stdout: envelope([]), once: true
+    runner.stub "chat messages", stdout: empty_envelope, once: true
     runner.stub "chat messages", stdout: envelope([ chat_line ])
     runner.stub "chat line ", exit_status: 1, stderr: "502 Bad Gateway", once: true
     runner.stub "chat line ", stdout: envelope(chat_line)
@@ -113,7 +126,7 @@ class ChatPollerTest < Minitest::Test
   def test_a_line_that_reached_a_verdict_is_not_retried
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: envelope([ chat_hash ])
-    runner.stub "chat messages", stdout: envelope([]), once: true
+    runner.stub "chat messages", stdout: empty_envelope, once: true
     runner.stub "chat messages", stdout: envelope([ chat_line ])
     runner.stub "chat line ", stdout: envelope(chat_line("content" => "<div>edited away</div>"))
     poller = poller(runner)
@@ -128,7 +141,7 @@ class ChatPollerTest < Minitest::Test
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: '{"data": [{"id": 333', once: true
     runner.stub "chat list", stdout: envelope([ chat_hash ])
-    runner.stub "chat messages", stdout: envelope([])
+    runner.stub "chat messages", stdout: empty_envelope
     poller = poller(runner)
 
     poller.poll
@@ -141,7 +154,7 @@ class ChatPollerTest < Minitest::Test
   def test_the_poll_thread_survives_an_exception_escaping_a_poll
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: envelope([ chat_hash ])
-    runner.stub "chat messages", stdout: envelope([])
+    runner.stub "chat messages", stdout: empty_envelope
     ticks = Queue.new
     polled = Queue.new
     poller = poller(runner, wait: ->(_seconds) { ticks.pop })
@@ -169,7 +182,7 @@ class ChatPollerTest < Minitest::Test
   def test_authoritative_recheck_drops_a_line_whose_fetched_content_lost_the_mention
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: envelope([ chat_hash ])
-    runner.stub "chat messages", stdout: envelope([]), once: true
+    runner.stub "chat messages", stdout: empty_envelope, once: true
     runner.stub "chat messages", stdout: envelope([ chat_line ])
     runner.stub "chat line ", stdout: envelope(chat_line("content" => "<div>edited away</div>"))
     poller = poller(runner)
@@ -216,7 +229,7 @@ class ChatPollerTest < Minitest::Test
   def test_polls_every_chat_in_a_project
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: envelope([ chat_hash, chat_hash("id" => 444, "title" => "Ops") ])
-    runner.stub "chat messages", stdout: envelope([])
+    runner.stub "chat messages", stdout: empty_envelope
 
     poller(runner).poll
 
@@ -257,7 +270,7 @@ class ChatPollerTest < Minitest::Test
     end
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: envelope([ chat_hash ])
-    runner.stub "chat messages", stdout: envelope([]), once: true
+    runner.stub "chat messages", stdout: empty_envelope, once: true
     runner.stub "chat messages", stdout: envelope(window)
     poller = poller(runner)
 
@@ -271,7 +284,7 @@ class ChatPollerTest < Minitest::Test
     now = Time.now
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: envelope([ chat_hash ])
-    runner.stub "chat messages", stdout: envelope([])
+    runner.stub "chat messages", stdout: empty_envelope
     poller = poller(runner, clock: -> { now })
 
     poller.poll
@@ -289,7 +302,7 @@ class ChatPollerTest < Minitest::Test
     runner.stub "chat list", stdout: envelope([ chat_hash ]), once: true
     runner.stub "chat list", exit_status: 1, stderr: "boom", once: true
     runner.stub "chat list", stdout: envelope([ chat_hash ])
-    runner.stub "chat messages", stdout: envelope([])
+    runner.stub "chat messages", stdout: empty_envelope
     poller = poller(runner, clock: -> { now })
 
     poller.poll
@@ -351,7 +364,7 @@ class ChatPollerTest < Minitest::Test
     runner = FakeCommandRunner.new
     runner.stub "chat list --project A", stdout: envelope([ chat_hash ])
     runner.stub "chat list --project B", exit_status: 1, stderr: "boom"
-    runner.stub "chat messages", stdout: envelope([])
+    runner.stub "chat messages", stdout: empty_envelope
     poller = poller(runner, projects: [ "A", "B" ], clock: -> { now })
 
     poller.poll
@@ -404,7 +417,7 @@ class ChatPollerTest < Minitest::Test
     def corroborating_runner
       runner = FakeCommandRunner.new
       runner.stub "chat list", stdout: envelope([ chat_hash ])
-      runner.stub "chat messages", stdout: envelope([]), once: true
+      runner.stub "chat messages", stdout: empty_envelope, once: true
       runner.stub "chat messages", stdout: envelope([ chat_line ])
       runner.stub "chat line ", stdout: envelope(chat_line)
       runner

--- a/test/connector_test.rb
+++ b/test/connector_test.rb
@@ -170,9 +170,9 @@ class ConnectorTest < Minitest::Test
 
   def test_start_skips_the_funnel_entirely_for_a_chat_only_run
     runner = FakeCommandRunner.new
-    runner.stub "basecamp me --profile clawdito", stdout: JSON.generate("data" => { "identity" => { "id" => 1, "email_address" => "clawdito@example.com", "first_name" => "Clawdito" } })
-    runner.stub "basecamp me", stdout: JSON.generate("data" => { "identity" => { "id" => 2, "email_address" => "operator@example.com", "first_name" => "Operator" } })
-    runner.stub "people show me", stdout: JSON.generate("data" => { "id" => 52007412 })
+    runner.stub "basecamp me --profile clawdito", stdout: JSON.generate("ok" => true, "data" => { "identity" => { "id" => 1, "email_address" => "clawdito@example.com", "first_name" => "Clawdito" } })
+    runner.stub "basecamp me", stdout: JSON.generate("ok" => true, "data" => { "identity" => { "id" => 2, "email_address" => "operator@example.com", "first_name" => "Operator" } })
+    runner.stub "people show me", stdout: JSON.generate("ok" => true, "data" => { "id" => 52007412 })
     runner.stub "chat list", stdout: "[]"
 
     _out, err = start_connector [ "@clawdito", "--project", "123", "--types", "Chat::Line", "--port", "4567" ], runner

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -188,8 +188,16 @@ module PayloadHelpers
     BasecampAgentConnector::Basecamp::Identity.new(id: 200, profile: "clawdito", email: "clawdito@example.com", name: name, person_id: person_id)
   end
 
+  # The CLI's `-j` success envelope. An empty result is not always
+  # "data": [] — `chat messages` on a room with no lines omits "data"
+  # entirely, returning {"ok": true, "summary": "0 messages"} (verified
+  # against production) — which empty_envelope mirrors.
   def envelope(data)
     JSON.generate("ok" => true, "data" => data, "summary" => "ok")
+  end
+
+  def empty_envelope(summary = "0 messages")
+    JSON.generate("ok" => true, "summary" => summary)
   end
 
   def build_cli(command_runner)


### PR DESCRIPTION
Fixes the live chat-poll regression: every 15s tick against a project whose Campfire has no lines logged

```
chat poll failed for "Chat" in project 48672814: no implicit conversion of String into Integer
```

and Campfire coverage for that project was fully broken.

## Root cause

`basecamp chat messages -j` on a room with **zero** lines omits `data` from the success envelope entirely (verified against production, project 48672814 room 10247404319):

```json
{"ok": true, "summary": "0 messages"}
```

`Client#unwrap` recognized the envelope by the presence of `data`, so it handed the **bare envelope hash** back. `ChatPoller#poll_room` then did `Array(hash)`, which explodes a Hash into `["ok", true]`-style pairs, and the first `line["id"]` — `Array#[]` with a String — raised `TypeError: no implicit conversion of String into Integer`, rescued and logged every tick. The same landmine sat under `discover` (`chat list` on a Campfire-less project) and, in principle, `BoostPoller`.

## Real vs fixture shape

| | real CLI | old fixture |
|---|---|---|
| room with lines | `{"ok": true, "data": [line, …], "summary": "N messages"}` | `{"ok": true, "data": [line], "summary": "ok"}` |
| empty room | `{"ok": true, "summary": "0 messages"}` — no `data` key | `{"ok": true, "data": [], "summary": "ok"}` |
| `me` | `{"ok": true, "data": {…}, "summary": …}` | `{"data": {…}}` — no `ok` key |
| failed command | `{"ok": false, "error": …, "code": …}` on stdout, nonzero exit | exit 1 with bare stderr text |

The fixtures modeled an empty room the CLI never returns, so the suite could not see the bug.

## Fix ([eea90a6](https://github.com/basecamp/basecamp-local-agent-connector/commit/eea90a6168cdb24f905c8f67daa693318d633450), [8174033](https://github.com/basecamp/basecamp-local-agent-connector/commit/8174033a3c9a76407fe6502f59f9d9e136593d1f))

- `Client#unwrap` recognizes the envelope by its `ok` marker, not by `data` presence, so a dataless success unwraps to nothing instead of the bare envelope.
- The list commands (`chats`, `chat_lines`, `received_boosts`) guarantee arrays at the client boundary; the callers' `Array()` shims in ChatPoller, BoostPoller, and Verifier go away.
- Fixtures now mirror the real CLI: empty rooms stub the dataless envelope (`empty_envelope`), the `me`/`people show me` stubs carry the `ok` the CLI always emits, and a failed command is stubbed as the real `{"ok": false, ...}`-on-stdout shape.

Two adjacent suspects checked against reality and cleared:

- **BoostPoller**: `basecamp api get /my/boosts.json` preserves `"data": []` when empty, so it had no live bug — the client-level guarantee now covers it regardless.
- **`--limit` flag**: `chat messages --help` shows `-n, --limit int`; `--limit 50` runs clean. The one live `chat poll failed ... failed: {...}` line between successful ticks was a transient nonzero-exit run surfacing the error envelope — already raised as `Client::Error`, logged, and retried next tick, now pinned by a reality-shaped test.

## Verification

- `bundle exec rake test`: 226 runs, 674 assertions, 0 failures. `bundle exec rubocop`: clean.
- Ran the real `ChatPoller` (discovery + two polls) and `BoostPoller` (two polls) against the live project/feed with a stub pipeline: rooms discovered, zero errors logged, boost feed baselined 15 entries.