### PR TITLE
Retry transient CLI failures and answer 503 so Basecamp redelivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,10 +352,15 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
    line of NDJSON** to STDOUT. Dropped/diagnostic lines go to STDERR. The
    delivery is answered with the verdict: `200` once the event is settled
    (emitted, dropped, or a duplicate), `503` when Basecamp could not be asked —
-   the CLI retries a transient failure (its keyring probe loses a race under
-   concurrent invocations and reports stale credentials) a few times first,
-   and a `503` makes bc3's delivery job redeliver the event with backoff
-   rather than settling it as uncorroborated.
+   the connector re-runs the CLI a few times first (its keyring probe loses a
+   race under concurrent invocations and reports stale credentials; bc3 may
+   answer 5xx mid-deploy), and a `503` makes bc3's delivery job redeliver the
+   event with backoff rather than settling it as uncorroborated. A delivery
+   that stays unanswerable for all of bc3's 10 attempts (~4.3h — a revoked
+   credential looks just like the race) makes bc3 deactivate the webhook: fix
+   the CLI's credentials (`basecamp auth status --profile <agent>`) and
+   restart `bin/connect`, which re-registers it. The connector logs that
+   remedy with every `503`.
 
 **Emitted event (STDOUT, one JSON object per line):**
 

--- a/README.md
+++ b/README.md
@@ -345,12 +345,17 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
    received-boosts feed is fetched every `--boost-poll` seconds and each new
    boost runs the same pipeline as a webhook delivery. The first fetch is a
    baseline — history is never dispatched.
-5. **Listen.** For each delivery: respond `200` immediately, then off the hot
-   path — pre-filter (authorized author + mentions agent + actionable kind),
-   de-duplicate by event id, verify against the Basecamp API, re-check that the
+5. **Listen.** For each delivery, on the request thread: pre-filter
+   (authorized author + mentions agent + actionable kind), de-duplicate by
+   event id, verify against the Basecamp API, re-check that the
    **corroborated** author is authorized, and **print the trusted event as one
-   line of NDJSON** to STDOUT. Dropped/diagnostic lines go
-   to STDERR.
+   line of NDJSON** to STDOUT. Dropped/diagnostic lines go to STDERR. The
+   delivery is answered with the verdict: `200` once the event is settled
+   (emitted, dropped, or a duplicate), `503` when Basecamp could not be asked —
+   the CLI retries a transient failure (its keyring probe loses a race under
+   concurrent invocations and reports stale credentials) a few times first,
+   and a `503` makes bc3's delivery job redeliver the event with backoff
+   rather than settling it as uncorroborated.
 
 **Emitted event (STDOUT, one JSON object per line):**
 
@@ -431,7 +436,7 @@ bin/connect                          # shim → Connector.start(ARGV) — Baseca
 lib/basecamp_agent_connector/
   connector        # unified: one multi-route server on shared-funnel paths, mounts each transport's bridge
   command_runner   # shared: runs subprocesses; the seam tests stub
-  server           # shared: WEBrick server, path→handler routes; 200-fast, raw body + headers
+  server           # shared: WEBrick server, path→handler routes; answers the handler's status, raw body + headers
   tunnel           # shared: mounts/unmounts our own paths on the host's Tailscale Funnel
   emitter          # shared: NDJSON writer
   basecamp/        # Basecamp:: — the Basecamp webhook transport

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -203,9 +203,15 @@ bin/connect @AGENT --project <project>... [--operator <profile>] [--types <types
    `--no-boosts`): it fetches nothing until its first interval pass, well after
    the readiness lines print, so no event can beat the funnel's consumer to the
    stream.
-7. **Listen** — for each incoming POST, run the pipeline below. Always respond
-   **200 OK quickly** (so Basecamp does not retry); filtering/verification/
-   dispatch happen out of band.
+7. **Listen** — for each incoming POST, run the pipeline below on the request
+   thread and answer with its verdict: **200 OK** once the event is settled
+   (emitted, dropped, or a duplicate — Basecamp must not redeliver those),
+   **503** when Basecamp could not be asked, so its delivery job redelivers the
+   event with backoff (bc3 retries any non-2xx delivery). Only a transient CLI
+   failure that outlasts the client's own retries — the keyring-probe race
+   under concurrent CLI invocations, a token refresh that lost that race, a
+   network blip, garbled output — earns a 503; Basecamp's own refusal (not
+   found, forbidden) is a verdict.
 
 ### Event pipeline
 
@@ -225,9 +231,12 @@ For each delivered event:
      are admitted here and decided at verification).
 2. **Dedup** — drop the event if its `event.id` has already been seen (in-memory
    set; at-least-once delivery means duplicates are expected). An id counts as
-   seen once it reaches a verdict; an event Basecamp could not corroborate is
-   forgotten again so a redelivery (or, for chat, the next poll) retries it —
-   the fetch may have failed transiently, and re-verifying is idempotent.
+   seen once it reaches a verdict; an event Basecamp did not corroborate is
+   forgotten again so a redelivery (or, for chat and boosts, the next poll)
+   retries it — re-verifying is idempotent. An event Basecamp could not be
+   asked about (the corroborating fetch failed transiently, even after the
+   CLI client's retries) is forgotten the same way and, for a webhook,
+   answered 503 so the redelivery actually comes.
 3. **Authoritative verification** (the real trust gate): re-fetch the recording
    from Basecamp via the CLI (`basecamp show <recording.url|app_url>` /
    `basecamp ... -j`) and confirm it **actually exists** with the claimed creator

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -389,8 +389,8 @@ Confirmed against `bc3` source (`app/views/api/webhooks/event.jbuilder`,
   — there is no shared-secret signature to verify, which is *why* authoritative
   API verification (not the payload) is the trust gate.
 - **Delivery semantics**: at-least-once, up to 10 retries on non-2xx before the
-  webhook is deactivated; redirects not followed. → respond 200 fast + dedup by
-  `event.id`.
+  webhook is deactivated; redirects not followed. → answer 200 only once the
+  event is settled (dedup by `event.id`), 503 to request redelivery.
 - **Scope**: per-bucket (= per-project). Type filtering possible but cannot be
   scoped narrower than a project. Limit: 50 active webhooks per project.
 
@@ -537,7 +537,8 @@ Coverage the suite must include:
   card/todo as the instruction.
 - Reply: post results back **as the agent** (`basecamp comment --profile
   <agent>`). On failure, post an error summary that @mentions the operator.
-- Dedup: in-memory, keyed on `event.id`; always 200-OK fast.
+- Dedup: in-memory, keyed on `event.id`; 200 once settled, 503 to ask for
+  redelivery.
 - Working dir: infer from project name (app token → repo); **ask interactively**
   on miss.
 - Triggers: both `*_created` and `*_content_changed`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -210,8 +210,13 @@ bin/connect @AGENT --project <project>... [--operator <profile>] [--types <types
    event with backoff (bc3 retries any non-2xx delivery). Only a transient CLI
    failure that outlasts the client's own retries — the keyring-probe race
    under concurrent CLI invocations, a token refresh that lost that race, a
-   network blip, garbled output — earns a 503; Basecamp's own refusal (not
-   found, forbidden) is a verdict.
+   network blip, bc3 answering 5xx, the CLI's open circuit breaker, garbled
+   output — earns a 503; Basecamp's own refusal (not found, forbidden) is a
+   verdict. A delivery that stays unanswerable for all 10 of bc3's attempts
+   (~4.3h; a revoked credential is indistinguishable from the race) gets the
+   webhook deactivated, silently on bc3's side — the 503 log line names the
+   remedy: fix the CLI's credentials and restart `bin/connect`, which
+   re-registers.
 
 ### Event pipeline
 

--- a/lib/basecamp_agent_connector/basecamp/boost_poller.rb
+++ b/lib/basecamp_agent_connector/basecamp/boost_poller.rb
@@ -126,15 +126,19 @@ class BasecampAgentConnector::Basecamp::BoostPoller
       false
     end
 
-    # Seen means settled. A boost the pipeline could not corroborate — the
-    # feed re-fetch failed, which a transient API or CLI blip can cause as
-    # easily as a deletion — is forgotten again so the next poll retries it
-    # while it remains in the feed; a deleted boost simply stops appearing.
-    # A pipeline exception leaves the boost seen: retrying a bug every tick
-    # would only repeat it.
+    # Seen means settled. A boost Basecamp did not corroborate — the feed
+    # re-fetch no longer lists it — is forgotten again so the next poll
+    # retries it while it remains in the feed; a deleted boost simply stops
+    # appearing. A re-fetch the CLI could not complete (even after its own
+    # retries) is forgotten the same way: the next tick is this poller's
+    # redelivery. A pipeline exception leaves the boost seen: retrying a bug
+    # every tick would only repeat it.
     def process(boost)
       @seen_boost_ids << boost["id"]
       @seen_boost_ids.delete(boost["id"]) unless @pipeline.process(BasecampAgentConnector::Basecamp::Event.boost_payload(boost))
+    rescue BasecampAgentConnector::Basecamp::Client::TransientError => error
+      @seen_boost_ids.delete(boost["id"])
+      log "could not corroborate boost #{boost["id"]}: #{error.message}; retried on the next poll"
     end
 
     # The feed's first page is a bound: if the agent received more boosts than

--- a/lib/basecamp_agent_connector/basecamp/bridge.rb
+++ b/lib/basecamp_agent_connector/basecamp/bridge.rb
@@ -68,28 +68,45 @@ class BasecampAgentConnector::Basecamp::Bridge
     log "Trust: #{@authorizer.description}"
   end
 
+  # Each delivery is verified on the request thread and answered with its
+  # verdict: 200 once the event is settled (emitted, dropped, or a
+  # duplicate), 503 when Basecamp could not be asked. bc3 retries any
+  # non-2xx delivery (Webhook::DeliveryJob: polynomially_longer backoff,
+  # 10 attempts, then the webhook is deactivated), so a 503 is a request
+  # for redelivery — of an event whose id the pipeline has forgotten, so the
+  # redelivery gets a fresh attempt. Everything else answers 200: an
+  # impostor payload, a malformed body, and a pipeline bug are settled here,
+  # and redelivering them would only repeat the same outcome. The client's
+  # retry budget keeps the synchronous verification inside bc3's 10s
+  # delivery timeout; overrunning it is harmless (a timed-out delivery is
+  # redelivered and then deduped or re-verified), just wasteful.
   def handler
     lambda do |request|
-      Thread.new do
-        payload = JSON.parse(request.body)
+      payload = JSON.parse(request.body)
 
-        # Basecamp never delivers chat or boost events by webhook, so either
-        # kind on this route is by definition not from Basecamp. The pollers
-        # are the sole sources; refuse the impostor rather than corroborate it
-        # (or let it replay a real boost through this pipeline's separate dedupe).
-        event = BasecampAgentConnector::Basecamp::Event.from_payload(payload)
-        if event.chat_kind?
-          log "ignored chat-kind payload: Basecamp does not deliver chat webhooks"
-        elsif event.boost?
-          log "ignored boost-kind payload: Basecamp does not deliver boost webhooks"
-        else
-          pipeline.process(payload)
-        end
-      rescue JSON::ParserError => error
-        log "ignored malformed payload: #{error.message}"
-      rescue => error
-        log "pipeline error: #{error.message}"
+      # Basecamp never delivers chat or boost events by webhook, so either
+      # kind on this route is by definition not from Basecamp. The pollers
+      # are the sole sources; refuse the impostor rather than corroborate it
+      # (or let it replay a real boost through this pipeline's separate dedupe).
+      event = BasecampAgentConnector::Basecamp::Event.from_payload(payload)
+      if event.chat_kind?
+        log "ignored chat-kind payload: Basecamp does not deliver chat webhooks"
+      elsif event.boost?
+        log "ignored boost-kind payload: Basecamp does not deliver boost webhooks"
+      else
+        pipeline.process(payload)
       end
+
+      nil
+    rescue BasecampAgentConnector::Basecamp::Client::TransientError => error
+      log "could not fetch recording for event #{event.id}: #{error.message}; answered 503 so Basecamp redelivers"
+      503
+    rescue JSON::ParserError => error
+      log "ignored malformed payload: #{error.message}"
+      nil
+    rescue => error
+      log "pipeline error: #{error.message}"
+      nil
     end
   end
 

--- a/lib/basecamp_agent_connector/basecamp/bridge.rb
+++ b/lib/basecamp_agent_connector/basecamp/bridge.rb
@@ -84,7 +84,9 @@ class BasecampAgentConnector::Basecamp::Bridge
   # revoked credential reports auth_required on every call, exactly like the
   # keyring race) ends with bc3 deactivating the webhook, silently; the 503
   # log line names that and the remedy — fix the CLI's credentials and
-  # restart bin/connect, which re-registers.
+  # restart bin/connect, which re-registers. Which call could not be
+  # answered — the recording fetch, or the subscriber lookup after it — is
+  # in the error's message, which names the failed command.
   #
   # Because the work is on the request thread, shutdown (WEBrick joins its
   # request threads before `start` returns) waits for in-flight deliveries
@@ -110,7 +112,7 @@ class BasecampAgentConnector::Basecamp::Bridge
 
       nil
     rescue BasecampAgentConnector::Basecamp::Client::TransientError => error
-      log "could not fetch recording for event #{event.id}: #{error.message}; answered 503 so Basecamp redelivers " \
+      log "could not corroborate event #{event.id}: #{error.message}; answered 503 so Basecamp redelivers " \
         "(bc3 deactivates the webhook after 10 failed deliveries: if this repeats, check `basecamp auth status " \
         "--profile #{@agent.profile}` and restart bin/connect to re-register)"
       503

--- a/lib/basecamp_agent_connector/basecamp/bridge.rb
+++ b/lib/basecamp_agent_connector/basecamp/bridge.rb
@@ -76,10 +76,21 @@ class BasecampAgentConnector::Basecamp::Bridge
   # for redelivery — of an event whose id the pipeline has forgotten, so the
   # redelivery gets a fresh attempt. Everything else answers 200: an
   # impostor payload, a malformed body, and a pipeline bug are settled here,
-  # and redelivering them would only repeat the same outcome. The client's
-  # retry budget keeps the synchronous verification inside bc3's 10s
-  # delivery timeout; overrunning it is harmless (a timed-out delivery is
+  # and redelivering them would only repeat the same outcome. Overrunning
+  # bc3's 10s delivery timeout is harmless (a timed-out delivery is
   # redelivered and then deduped or re-verified), just wasteful.
+  #
+  # A failure that stays transient through all 10 attempts (~4.3h: a
+  # revoked credential reports auth_required on every call, exactly like the
+  # keyring race) ends with bc3 deactivating the webhook, silently; the 503
+  # log line names that and the remedy — fix the CLI's credentials and
+  # restart bin/connect, which re-registers.
+  #
+  # Because the work is on the request thread, shutdown (WEBrick joins its
+  # request threads before `start` returns) waits for in-flight deliveries
+  # to be answered before teardown deletes the webhooks, so none is lost to
+  # a Ctrl-C. The wait is bounded only by the CLI's own timeouts, which on
+  # a stalled network can run to minutes.
   def handler
     lambda do |request|
       payload = JSON.parse(request.body)
@@ -99,7 +110,9 @@ class BasecampAgentConnector::Basecamp::Bridge
 
       nil
     rescue BasecampAgentConnector::Basecamp::Client::TransientError => error
-      log "could not fetch recording for event #{event.id}: #{error.message}; answered 503 so Basecamp redelivers"
+      log "could not fetch recording for event #{event.id}: #{error.message}; answered 503 so Basecamp redelivers " \
+        "(bc3 deactivates the webhook after 10 failed deliveries: if this repeats, check `basecamp auth status " \
+        "--profile #{@agent.profile}` and restart bin/connect to re-register)"
       503
     rescue JSON::ParserError => error
       log "ignored malformed payload: #{error.message}"

--- a/lib/basecamp_agent_connector/basecamp/chat_poller.rb
+++ b/lib/basecamp_agent_connector/basecamp/chat_poller.rb
@@ -179,15 +179,19 @@ class BasecampAgentConnector::Basecamp::ChatPoller
       false
     end
 
-    # Seen means settled. A line the pipeline could not corroborate — the
-    # corroborating fetch failed, which a transient API or CLI blip can cause
-    # as easily as a deletion — is forgotten again so the next poll retries it
-    # while it remains in the window; a deleted line simply stops appearing.
-    # A pipeline exception leaves the line seen: retrying a bug every tick
-    # would only repeat it.
+    # Seen means settled. A line Basecamp did not corroborate — the
+    # corroborating fetch says it is gone — is forgotten again so the next
+    # poll retries it while it remains in the window; a deleted line simply
+    # stops appearing. A fetch the CLI could not complete (even after its own
+    # retries) is forgotten the same way: the next tick is this poller's
+    # redelivery. A pipeline exception leaves the line seen: retrying a bug
+    # every tick would only repeat it.
     def process(line, seen)
       seen << line["id"]
       seen.delete(line["id"]) unless @pipeline.process(BasecampAgentConnector::Basecamp::Event.chat_line_payload(line))
+    rescue BasecampAgentConnector::Basecamp::Client::TransientError => error
+      seen.delete(line["id"])
+      log "could not corroborate chat line #{line["id"]}: #{error.message}; retried on the next poll"
     end
 
     # The fetch window is a bound: if a chat produced more than FETCH_LIMIT

--- a/lib/basecamp_agent_connector/basecamp/client.rb
+++ b/lib/basecamp_agent_connector/basecamp/client.rb
@@ -1,11 +1,47 @@
 require "json"
 
 class BasecampAgentConnector::Basecamp::Client
+  # Basecamp answered, and the answer was no: not found, forbidden, invalid.
+  # Asking again cannot change it.
   class Error < StandardError; end
 
-  def initialize(command_runner: BasecampAgentConnector::CommandRunner.new, executable: "basecamp")
+  # The CLI never got an answer out of Basecamp — on any of ATTEMPTS tries.
+  # Asking again later may well succeed, so a caller that can defer (a webhook
+  # redelivery, the next poll) should, rather than read this as a verdict.
+  class TransientError < Error
+    attr_reader :attempts
+
+    def initialize(message, attempts:)
+      super(message)
+      @attempts = attempts
+    end
+  end
+
+  # The CLI probes the OS keyring on every invocation by writing and deleting
+  # one shared item (service "credstore.probe.basecamp"). Concurrent
+  # invocations — this connector's pollers plus the agents it dispatches —
+  # race on that item; a loser's probe fails, the CLI silently falls back to a
+  # stale credentials file, and the command fails with auth_required or a
+  # token-refresh api_error although nothing is wrong with the credentials
+  # (19/20 parallel probes lost in a 20-way run; 20/20 serial ones passed).
+  # The race clears as soon as the neighbours finish, so a failed invocation
+  # is tried again after a short, growing pause. The whole budget (~2s of
+  # waiting plus the calls themselves) stays inside the 10s Basecamp allows a
+  # webhook delivery, so a verdict can still be answered synchronously.
+  ATTEMPTS = 3
+  RETRY_DELAYS = [ 0.5, 1.5 ] # seconds before the second and third attempt
+
+  # Error-envelope codes that describe the CLI's plight, not Basecamp's
+  # answer. `api_error` is ambiguous: a token refresh that lost the keyring
+  # race reports as one, a real 4xx from the API does too.
+  TRANSIENT_CODES = %w[auth_required network rate_limit]
+  TRANSIENT_API_ERROR = /token refresh/i
+
+  def initialize(command_runner: BasecampAgentConnector::CommandRunner.new, executable: "basecamp",
+    wait: ->(seconds) { sleep seconds })
     @command_runner = command_runner
     @executable = executable
+    @wait = wait
   end
 
   def me(profile: nil)
@@ -57,20 +93,58 @@ class BasecampAgentConnector::Basecamp::Client
   end
 
   private
+    # A command either answers (its envelope is handed back), is refused
+    # (Error, at once — Basecamp's verdict doesn't improve with repetition),
+    # or fails without an answer, in which case it is tried again up to
+    # ATTEMPTS times before the failure surfaces as a TransientError.
     def json(*arguments)
-      result = run(*arguments, "-j")
+      result = parsed = nil
 
-      unless result.success?
-        detail = result.stderr.strip
-        detail = result.stdout.strip if detail.empty?
-        raise Error, "`basecamp #{arguments.join(' ')}` failed: #{detail}"
+      ATTEMPTS.times do |attempt|
+        result = run(*arguments, "-j")
+        parsed = parse(result.stdout)
+
+        if result.success? && !parsed.nil?
+          return unwrap(parsed)
+        elsif !transient?(parsed)
+          raise Error, "`basecamp #{arguments.join(' ')}` #{outcome(result)}: #{detail(result)}"
+        elsif attempt < ATTEMPTS - 1
+          @wait.call(RETRY_DELAYS.fetch(attempt))
+        end
       end
 
-      unwrap JSON.parse(result.stdout)
-    rescue JSON::ParserError => error
-      # A truncated or garbled success is a failed command, not a crash:
-      # every caller already rescues Error, so it stays on the same path.
-      raise Error, "`basecamp #{arguments.join(' ')}` returned malformed JSON: #{error.message}"
+      raise TransientError.new("`basecamp #{arguments.join(' ')}` #{outcome(result)} on all #{ATTEMPTS} attempts: #{detail(result)}",
+        attempts: ATTEMPTS)
+    end
+
+    def parse(stdout)
+      JSON.parse(stdout)
+    rescue JSON::ParserError
+      nil
+    end
+
+    # No envelope at all — the process died before it could answer, or its
+    # output was cut off — is the CLI's failure, not Basecamp's answer.
+    def transient?(parsed)
+      if envelope?(parsed)
+        code = parsed["code"].to_s
+        TRANSIENT_CODES.include?(code) || (code == "api_error" && parsed["error"].to_s.match?(TRANSIENT_API_ERROR))
+      else
+        true
+      end
+    end
+
+    # A successful exit only gets this far when its output didn't parse.
+    def outcome(result)
+      result.success? ? "returned malformed JSON" : "failed"
+    end
+
+    def detail(result)
+      if result.success?
+        result.stdout.strip[0, 200]
+      else
+        [ result.stderr.strip, result.stdout.strip, "exit status #{result.exit_status}" ].find { |candidate| !candidate.empty? }
+      end
     end
 
     # `-j` wraps every result in an envelope — {"ok": ..., "data": ...,
@@ -82,11 +156,15 @@ class BasecampAgentConnector::Basecamp::Client
     # Array() on that hash downstream explodes it into ["ok", true]-style
     # pairs whose ["id"] lookups raise TypeError.
     def unwrap(parsed)
-      if parsed.is_a?(Hash) && parsed.key?("ok")
+      if envelope?(parsed)
         parsed["data"]
       else
         parsed
       end
+    end
+
+    def envelope?(parsed)
+      parsed.is_a?(Hash) && parsed.key?("ok")
     end
 
     def profile_flag(profile)

--- a/lib/basecamp_agent_connector/basecamp/client.rb
+++ b/lib/basecamp_agent_connector/basecamp/client.rb
@@ -89,8 +89,11 @@ class BasecampAgentConnector::Basecamp::Client
     Array json("api", "get", "/my/boosts.json", *profile_flag(profile))
   end
 
+  # One attempt: a create whose answer was lost may still have created, and
+  # asking again would register a second webhook whose id nobody keeps for
+  # teardown. Webhooks#create_with_retries retries the registration.
   def create_webhook(url:, project:, types:)
-    json "webhooks", "create", url, "--project", project.to_s, "--types", types
+    json "webhooks", "create", url, "--project", project.to_s, "--types", types, attempts: 1
   end
 
   def delete_webhook(id:, project:)
@@ -101,11 +104,13 @@ class BasecampAgentConnector::Basecamp::Client
     # A command either answers (its envelope is handed back), is refused
     # (Error, at once — Basecamp's verdict doesn't improve with repetition),
     # or fails without an answer, in which case it is tried again up to
-    # ATTEMPTS times before the failure surfaces as a TransientError.
-    def json(*arguments)
+    # `attempts` times before the failure surfaces as a TransientError.
+    # Reads take the default, since re-asking is idempotent; a mutation
+    # passes `attempts: 1`, because a lost answer is not a lost request.
+    def json(*arguments, attempts: ATTEMPTS)
       result = parsed = nil
 
-      ATTEMPTS.times do |attempt|
+      attempts.times do |attempt|
         result = run(*arguments, "-j")
         parsed = parse(result.stdout)
 
@@ -113,12 +118,12 @@ class BasecampAgentConnector::Basecamp::Client
           return unwrap(parsed)
         elsif !transient?(parsed)
           raise Error, "`basecamp #{arguments.join(' ')}` #{outcome(result)}: #{detail(result)}"
-        elsif attempt < ATTEMPTS - 1
+        elsif attempt < attempts - 1
           @wait.call(RETRY_DELAYS.fetch(attempt))
         end
       end
 
-      raise TransientError, "`basecamp #{arguments.join(' ')}` #{outcome(result)} on all #{ATTEMPTS} attempts: #{detail(result)}"
+      raise TransientError, "`basecamp #{arguments.join(' ')}` #{outcome(result)}#{" on all #{attempts} attempts" if attempts > 1}: #{detail(result)}"
     end
 
     def parse(stdout)

--- a/lib/basecamp_agent_connector/basecamp/client.rb
+++ b/lib/basecamp_agent_connector/basecamp/client.rb
@@ -8,14 +8,7 @@ class BasecampAgentConnector::Basecamp::Client
   # The CLI never got an answer out of Basecamp — on any of ATTEMPTS tries.
   # Asking again later may well succeed, so a caller that can defer (a webhook
   # redelivery, the next poll) should, rather than read this as a verdict.
-  class TransientError < Error
-    attr_reader :attempts
-
-    def initialize(message, attempts:)
-      super(message)
-      @attempts = attempts
-    end
-  end
+  class TransientError < Error; end
 
   # The CLI probes the OS keyring on every invocation by writing and deleting
   # one shared item (service "credstore.probe.basecamp"). Concurrent
@@ -125,8 +118,7 @@ class BasecampAgentConnector::Basecamp::Client
         end
       end
 
-      raise TransientError.new("`basecamp #{arguments.join(' ')}` #{outcome(result)} on all #{ATTEMPTS} attempts: #{detail(result)}",
-        attempts: ATTEMPTS)
+      raise TransientError, "`basecamp #{arguments.join(' ')}` #{outcome(result)} on all #{ATTEMPTS} attempts: #{detail(result)}"
     end
 
     def parse(stdout)

--- a/lib/basecamp_agent_connector/basecamp/client.rb
+++ b/lib/basecamp_agent_connector/basecamp/client.rb
@@ -25,17 +25,29 @@ class BasecampAgentConnector::Basecamp::Client
   # token-refresh api_error although nothing is wrong with the credentials
   # (19/20 parallel probes lost in a 20-way run; 20/20 serial ones passed).
   # The race clears as soon as the neighbours finish, so a failed invocation
-  # is tried again after a short, growing pause. The whole budget (~2s of
-  # waiting plus the calls themselves) stays inside the 10s Basecamp allows a
-  # webhook delivery, so a verdict can still be answered synchronously.
+  # is tried again after a short, growing pause: ~2s of waiting per command,
+  # plus the calls themselves. A verification that runs two commands (a
+  # comment on a subscribed recording: `show`, then `subscriptions show`)
+  # can still overrun the 10s Basecamp allows a webhook delivery, which the
+  # bridge tolerates (see Bridge#handler).
   ATTEMPTS = 3
   RETRY_DELAYS = [ 0.5, 1.5 ] # seconds before the second and third attempt
 
   # Error-envelope codes that describe the CLI's plight, not Basecamp's
-  # answer. `api_error` is ambiguous: a token refresh that lost the keyring
-  # race reports as one, a real 4xx from the API does too.
+  # answer. `api_error` is ambiguous: Basecamp's own 4xx verdicts arrive as
+  # one, but so do three failures to get an answer at all — a token refresh
+  # that lost the keyring race ("token refresh failed: …"), bc3 answering 5xx
+  # ("Server error (500)" surfaces at once; "Gateway error (502|503|504)" and
+  # the generic "API error: 5xx …" are retried inside the SDK for ~3s first
+  # and then surface as "request failed after 3 attempts: …", a prefix the
+  # SDK puts only on retryable failures), and the CLI's own circuit breaker
+  # refusing to ask ("Service temporarily unavailable": file-backed across
+  # processes, open for 30s after five consecutive network/5xx failures).
+  # The envelope drops the SDK's Retryable flag, so these fixed messages are
+  # all there is to key on until the CLI emits that flag — the intended end
+  # state, after which this pattern goes.
   TRANSIENT_CODES = %w[auth_required network rate_limit]
-  TRANSIENT_API_ERROR = /token refresh/i
+  TRANSIENT_API_ERROR = /token refresh|request failed after \d+ attempts?|server error \(500\)|gateway error \(50\d\)|\bAPI error: 5\d\d\b|service temporarily unavailable/i
 
   def initialize(command_runner: BasecampAgentConnector::CommandRunner.new, executable: "basecamp",
     wait: ->(seconds) { sleep seconds })

--- a/lib/basecamp_agent_connector/basecamp/pipeline.rb
+++ b/lib/basecamp_agent_connector/basecamp/pipeline.rb
@@ -92,7 +92,7 @@ class BasecampAgentConnector::Basecamp::Pipeline
 
       if verified.nil?
         @seen_event_ids.delete(event.id)
-        log "dropped event #{event.id}: not corroborated by Basecamp (retried if delivered again)"
+        log "dropped event #{event.id}: not corroborated by Basecamp (id forgotten; a later delivery of it is verified afresh)"
       elsif !@authorizer.authorizes?(verified)
         log "dropped event #{event.id}: authoritative author is not authorized"
       elsif !targets_agent?(verified)

--- a/lib/basecamp_agent_connector/basecamp/pipeline.rb
+++ b/lib/basecamp_agent_connector/basecamp/pipeline.rb
@@ -6,7 +6,9 @@ class BasecampAgentConnector::Basecamp::Pipeline
     @emitter = emitter
     @logger = logger
     @seen_event_ids = Set.new
-    @verdict = Mutex.new
+    @in_flight_event_ids = Set.new
+    @lock = Mutex.new
+    @settled = ConditionVariable.new
   end
 
   # Returns whether the event reached a verdict (emitted, dropped, ignored,
@@ -19,24 +21,30 @@ class BasecampAgentConnector::Basecamp::Pipeline
   # Basecamp redelivers, a poller retries on its next tick — and must not
   # record a verdict, because there is none.
   #
-  # One delivery at a time, so that "seen" always means settled. Deliveries
-  # arrive on concurrent server threads, and a verification that overruns
-  # bc3's 10s delivery timeout is redelivered while the original is still in
-  # flight; unserialized, the redelivery would find the id seen, be answered
-  # 200 as a duplicate, and then the original could fail and forget the id —
-  # with nobody left to redeliver. Held here, the redelivery waits and finds
-  # either a settled id (a duplicate) or a forgotten one (a fresh attempt).
-  # The pollers each own a pipeline and poll from a single thread, so they
-  # never wait on this.
+  # Verdicts are per event id, so that "seen" always means settled: an id is
+  # claimed while its verification is in flight and stays seen once it
+  # settled. Deliveries arrive on concurrent server threads, and a
+  # verification that overruns bc3's 10s delivery timeout is redelivered
+  # while the original is still in flight; unsynchronized, the redelivery
+  # would find the id seen, be answered 200 as a duplicate, and then the
+  # original could fail and forget the id — with nobody left to redeliver.
+  # So a delivery of an id in flight waits for that id's verdict (see
+  # `claim`) and finds either a settled id (a duplicate) or a forgotten one
+  # (a fresh attempt). Distinct ids never wait on each other: each
+  # verification shells out to the CLI, and a burst serialized behind one
+  # slow verification would time out delivery after delivery. The pollers
+  # each own a pipeline and poll from a single thread, so they never wait.
   def process(payload)
     event = BasecampAgentConnector::Basecamp::Event.from_payload(payload)
 
-    @verdict.synchronize do
-      if actionable?(event) && fresh?(event)
+    if actionable?(event) && claim(event)
+      begin
         emit_if_verified(event)
-      else
-        true
+      ensure
+        release(event)
       end
+    else
+      true
     end
   end
 
@@ -60,13 +68,33 @@ class BasecampAgentConnector::Basecamp::Pipeline
       event.mentions?(@agent) || event.assigns?(@agent) || event.subscribed? || event.boosted?
     end
 
-    def fresh?(event)
-      if @seen_event_ids.include?(event.id)
-        false
-      else
-        @seen_event_ids << event.id
-        true
+    # The in-flight set plus one condition variable is the whole mechanism:
+    # the lock is held only to read and update the two sets, never across a
+    # verification, and every settled verification broadcasts so a waiter
+    # re-checks its own id (a wake-up for someone else's id just loops).
+    def claim(event)
+      @lock.synchronize do
+        @settled.wait(@lock) while @in_flight_event_ids.include?(event.id)
+
+        if @seen_event_ids.include?(event.id)
+          false
+        else
+          @seen_event_ids << event.id
+          @in_flight_event_ids << event.id
+          true
+        end
       end
+    end
+
+    def release(event)
+      @lock.synchronize do
+        @in_flight_event_ids.delete(event.id)
+        @settled.broadcast
+      end
+    end
+
+    def forget(event)
+      @lock.synchronize { @seen_event_ids.delete(event.id) }
     end
 
     # Both trust predicates are re-checked on the verified event, not just the
@@ -91,7 +119,7 @@ class BasecampAgentConnector::Basecamp::Pipeline
       verified = @verifier.verify(event)
 
       if verified.nil?
-        @seen_event_ids.delete(event.id)
+        forget(event)
         log "dropped event #{event.id}: not corroborated by Basecamp (id forgotten; a later delivery of it is verified afresh)"
       elsif !@authorizer.authorizes?(verified)
         log "dropped event #{event.id}: authoritative author is not authorized"
@@ -103,7 +131,7 @@ class BasecampAgentConnector::Basecamp::Pipeline
 
       !verified.nil?
     rescue BasecampAgentConnector::Basecamp::Client::TransientError
-      @seen_event_ids.delete(event.id)
+      forget(event)
       raise
     end
 

--- a/lib/basecamp_agent_connector/basecamp/pipeline.rb
+++ b/lib/basecamp_agent_connector/basecamp/pipeline.rb
@@ -6,19 +6,37 @@ class BasecampAgentConnector::Basecamp::Pipeline
     @emitter = emitter
     @logger = logger
     @seen_event_ids = Set.new
+    @verdict = Mutex.new
   end
 
   # Returns whether the event reached a verdict (emitted, dropped, ignored,
-  # or a duplicate). False means Basecamp could not corroborate it, in which
-  # case the id is forgotten so a redelivery gets a fresh attempt: the fetch
-  # may have failed transiently, and re-verifying is idempotent either way.
+  # or a duplicate). False means Basecamp did not corroborate it — the
+  # recording is gone, or never existed — in which case the id is forgotten
+  # so a redelivery gets a fresh attempt, since re-verifying is idempotent.
+  # When Basecamp could not be asked at all (Client::TransientError, after
+  # the client's own retries) that error propagates with the id likewise
+  # forgotten: the caller decides how to defer — a webhook answers 503 so
+  # Basecamp redelivers, a poller retries on its next tick — and must not
+  # record a verdict, because there is none.
+  #
+  # One delivery at a time, so that "seen" always means settled. Deliveries
+  # arrive on concurrent server threads, and a verification that overruns
+  # bc3's 10s delivery timeout is redelivered while the original is still in
+  # flight; unserialized, the redelivery would find the id seen, be answered
+  # 200 as a duplicate, and then the original could fail and forget the id —
+  # with nobody left to redeliver. Held here, the redelivery waits and finds
+  # either a settled id (a duplicate) or a forgotten one (a fresh attempt).
+  # The pollers each own a pipeline and poll from a single thread, so they
+  # never wait on this.
   def process(payload)
     event = BasecampAgentConnector::Basecamp::Event.from_payload(payload)
 
-    if actionable?(event) && fresh?(event)
-      emit_if_verified(event)
-    else
-      true
+    @verdict.synchronize do
+      if actionable?(event) && fresh?(event)
+        emit_if_verified(event)
+      else
+        true
+      end
     end
   end
 
@@ -84,6 +102,9 @@ class BasecampAgentConnector::Basecamp::Pipeline
       end
 
       !verified.nil?
+    rescue BasecampAgentConnector::Basecamp::Client::TransientError
+      @seen_event_ids.delete(event.id)
+      raise
     end
 
     def log(message)

--- a/lib/basecamp_agent_connector/basecamp/verifier.rb
+++ b/lib/basecamp_agent_connector/basecamp/verifier.rb
@@ -25,6 +25,12 @@ class BasecampAgentConnector::Basecamp::Verifier
     # fetched is not redundant: it keeps chat on the identical trust path as
     # webhook kinds, and re-reads the line at dispatch time so one deleted (or
     # edited away from the mention) between poll and processing is dropped.
+    #
+    # Only Basecamp's own refusal (not found, forbidden) means "no such
+    # recording". A fetch the CLI could not complete even after its retries
+    # says nothing about the recording, so it propagates for the caller to
+    # defer — a webhook answers 503 for redelivery, a poller retries next
+    # tick — instead of masquerading as a forged or deleted event.
     def fetch_recording(event)
       locator = event.recording_url || event.recording_app_url
       return nil if locator.nil?
@@ -34,6 +40,8 @@ class BasecampAgentConnector::Basecamp::Verifier
       else
         @basecamp_cli.show(locator)
       end
+    rescue BasecampAgentConnector::Basecamp::Client::TransientError
+      raise
     rescue BasecampAgentConnector::Basecamp::Client::Error
       nil
     end
@@ -79,8 +87,10 @@ class BasecampAgentConnector::Basecamp::Verifier
     # comment's parent (the commented-on recording — subscriptions live on the
     # container, not the comment). This is the connector's own re-fetch, so the
     # stamp binds to what Basecamp reports now, not to anything in the POST. A
-    # failed or missing lookup stamps false: never emit on an unconfirmed
-    # subscription.
+    # refused or missing lookup stamps false: never emit on an unconfirmed
+    # subscription. A lookup the CLI could not complete propagates instead
+    # (see fetch_recording): stamping false would turn a transient failure
+    # into a settled "does not target the agent" drop.
     #
     # The recording's authoritative `type` must be a Comment, not just the
     # claimed `comment_created` kind: otherwise a forged POST naming that kind
@@ -116,6 +126,8 @@ class BasecampAgentConnector::Basecamp::Verifier
 
     def subscriber_ids(locator)
       Array(@basecamp_cli.subscription(locator)["subscribers"]).map { |subscriber| subscriber["id"] }
+    rescue BasecampAgentConnector::Basecamp::Client::TransientError
+      raise
     rescue BasecampAgentConnector::Basecamp::Client::Error
       []
     end
@@ -131,6 +143,8 @@ class BasecampAgentConnector::Basecamp::Verifier
     # the pipeline's authoritative target re-check. A boost deleted — or
     # scrolled off the feed's newest-page window — between poll and dispatch
     # stops being corroborable and is dropped, exactly like a deleted comment.
+    # A feed fetch the CLI could not complete propagates, exactly like a
+    # recording fetch (see fetch_recording), so the poller retries it.
     def verify_boost(event)
       boost = fetch_boost(event)
 
@@ -143,6 +157,8 @@ class BasecampAgentConnector::Basecamp::Verifier
       return nil if @agent.profile.nil?
 
       @basecamp_cli.received_boosts(profile: @agent.profile).find { |boost| boost["id"] == event.id }
+    rescue BasecampAgentConnector::Basecamp::Client::TransientError
+      raise
     rescue BasecampAgentConnector::Basecamp::Client::Error
       nil
     end

--- a/lib/basecamp_agent_connector/github/bridge.rb
+++ b/lib/basecamp_agent_connector/github/bridge.rb
@@ -29,6 +29,9 @@ class BasecampAgentConnector::GitHub::Bridge
     log "To watch another repo on the fly, register a webhook to #{endpoint} (secret #{@hmac_secret})."
   end
 
+  # Answers 200 at once (nil, to the server) and verifies off the request
+  # thread: GitHub does not redeliver a failed delivery on its own, so there
+  # is no verdict worth holding the response for.
   def handler
     lambda do |request|
       Thread.new do
@@ -36,6 +39,8 @@ class BasecampAgentConnector::GitHub::Bridge
       rescue => error
         log "pipeline error: #{error.message}"
       end
+
+      nil
     end
   end
 

--- a/lib/basecamp_agent_connector/server.rb
+++ b/lib/basecamp_agent_connector/server.rb
@@ -34,10 +34,12 @@ class BasecampAgentConnector::Server
         AccessLog: []
     end
 
+    # A handler answers with the HTTP status to send, or nil for 200. The
+    # Basecamp route uses that to ask for a redelivery (503) when it could
+    # not reach a verdict; a handler that defers its work returns nil.
     def handle(request, response, handler)
       if request.request_method == "POST"
-        handler.call(Request.new(body: request.body, headers: request.header))
-        response.status = 200
+        response.status = handler.call(Request.new(body: request.body, headers: request.header)) || 200
       else
         response.status = 404
       end

--- a/test/basecamp_bridge_test.rb
+++ b/test/basecamp_bridge_test.rb
@@ -84,11 +84,69 @@ class BasecampBridgeTest < Minitest::Test
     logs = StringIO.new
     bridge = bridge(runner, types: "Comment", logger: logs, output: output)
 
-    bridge.handler.call(Struct.new(:body).new(JSON.generate(chat_line_payload))).join
+    assert_nil bridge.handler.call(request(chat_line_payload))
 
     assert_empty output.string
     assert_match(/ignored chat-kind payload/, logs.string)
     assert_empty runner.commands_matching(/chat line /)
+  end
+
+  def test_handler_answers_200_once_an_event_is_settled
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(sample_recording)
+    output = StringIO.new
+    bridge = bridge(runner, output: output)
+
+    assert_nil bridge.handler.call(request(sample_payload))
+    assert_equal 1, output.string.lines.length
+  end
+
+  # A recording Basecamp says is not there is a verdict — the event is
+  # dropped and the delivery is acknowledged, so a forged or deleted event
+  # is never redelivered.
+  def test_handler_answers_200_for_an_uncorroborated_event
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", exit_status: 2, stdout: error_envelope("not_found", "Resource not found")
+    output = StringIO.new
+    logs = StringIO.new
+    bridge = bridge(runner, logger: logs, output: output)
+
+    assert_nil bridge.handler.call(request(sample_payload))
+
+    assert_empty output.string
+    assert_match(/dropped event 99001: not corroborated/, logs.string)
+    assert_equal 1, runner.commands_matching(/basecamp show/).length
+  end
+
+  # A fetch the CLI could not complete is no verdict: answer 503 so bc3's
+  # delivery job redelivers (Webhook::DeliveryJob retries any non-2xx), and
+  # say so in the log instead of calling the event uncorroborated.
+  def test_handler_answers_503_when_the_recording_could_not_be_fetched
+    runner = FakeCommandRunner.new
+    stub_transient_failure runner, "basecamp show"
+    output = StringIO.new
+    logs = StringIO.new
+    bridge = bridge(runner, logger: logs, output: output)
+
+    assert_equal 503, bridge.handler.call(request(sample_payload))
+
+    assert_empty output.string
+    assert_match(/could not fetch recording for event 99001: .*failed on all 3 attempts.*; answered 503 so Basecamp redelivers/, logs.string)
+    refute_match(/not corroborated/, logs.string)
+  end
+
+  def test_a_redelivery_after_a_503_is_verified_afresh_and_emitted_once
+    runner = FakeCommandRunner.new
+    stub_transient_failure runner, "basecamp show"
+    runner.stub "basecamp show", stdout: envelope(sample_recording)
+    output = StringIO.new
+    bridge = bridge(runner, output: output)
+
+    assert_equal 503, bridge.handler.call(request(sample_payload))
+    assert_nil bridge.handler.call(request(sample_payload))
+    assert_nil bridge.handler.call(request(sample_payload))
+
+    assert_equal 1, output.string.lines.length
   end
 
   def test_register_starts_the_boost_poller_and_logs_after_the_webhook_readiness_line
@@ -130,7 +188,7 @@ class BasecampBridgeTest < Minitest::Test
     logs = StringIO.new
     bridge = bridge(runner, logger: logs, output: output)
 
-    bridge.handler.call(Struct.new(:body).new(JSON.generate(boost_payload))).join
+    assert_nil bridge.handler.call(request(boost_payload))
 
     assert_empty output.string
     assert_match(/ignored boost-kind payload/, logs.string)
@@ -138,6 +196,10 @@ class BasecampBridgeTest < Minitest::Test
   end
 
   private
+    def request(payload)
+      BasecampAgentConnector::Server::Request.new(body: JSON.generate(payload), headers: {})
+    end
+
     def bridge(runner, projects: [ "A" ], types: "Comment", logger: StringIO.new, output: StringIO.new,
       boost_poll_interval: nil)
       BasecampAgentConnector::Basecamp::Bridge.new \

--- a/test/basecamp_bridge_test.rb
+++ b/test/basecamp_bridge_test.rb
@@ -131,9 +131,28 @@ class BasecampBridgeTest < Minitest::Test
     assert_equal 503, bridge.handler.call(request(sample_payload))
 
     assert_empty output.string
-    assert_match(/could not fetch recording for event 99001: .*failed on all 3 attempts.*; answered 503 so Basecamp redelivers/, logs.string)
+    assert_match(/could not corroborate event 99001: `basecamp show .*` failed on all 3 attempts.*; answered 503 so Basecamp redelivers/, logs.string)
     assert_match(/deactivates the webhook after 10 failed deliveries.*basecamp auth status --profile clawdito.*restart/, logs.string)
     refute_match(/not corroborated/, logs.string)
+  end
+
+  # The subscriber lookup is the second call a comment's verification makes,
+  # after the recording fetch succeeded; a 503 from there names that call,
+  # not the fetch that worked.
+  def test_handler_answers_503_naming_the_subscriber_lookup_that_could_not_be_answered
+    recording = sample_recording("content" => "<p>just a normal comment, no mention</p>")
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(recording)
+    stub_transient_failure runner, "subscriptions show"
+    output = StringIO.new
+    logs = StringIO.new
+    bridge = bridge(runner, logger: logs, output: output)
+
+    assert_equal 503, bridge.handler.call(request(sample_payload("recording" => recording)))
+
+    assert_empty output.string
+    assert_match(/could not corroborate event 99001: `basecamp subscriptions show .*` failed on all 3 attempts/, logs.string)
+    refute_match(/fetch recording/, logs.string)
   end
 
   # bc3 answering 5xx (a deploy, an incident) is the other way Basecamp could

--- a/test/basecamp_bridge_test.rb
+++ b/test/basecamp_bridge_test.rb
@@ -132,6 +132,7 @@ class BasecampBridgeTest < Minitest::Test
 
     assert_empty output.string
     assert_match(/could not fetch recording for event 99001: .*failed on all 3 attempts.*; answered 503 so Basecamp redelivers/, logs.string)
+    assert_match(/deactivates the webhook after 10 failed deliveries.*basecamp auth status --profile clawdito.*restart/, logs.string)
     refute_match(/not corroborated/, logs.string)
   end
 

--- a/test/basecamp_bridge_test.rb
+++ b/test/basecamp_bridge_test.rb
@@ -135,6 +135,23 @@ class BasecampBridgeTest < Minitest::Test
     refute_match(/not corroborated/, logs.string)
   end
 
+  # bc3 answering 5xx (a deploy, an incident) is the other way Basecamp could
+  # not be asked; a 200 here would settle a real mention as uncorroborated
+  # while a 503 brings it back seconds later.
+  def test_handler_answers_503_when_basecamp_answered_5xx
+    runner = FakeCommandRunner.new
+    stub_transient_failure runner, "basecamp show", exit_status: 7,
+      stdout: error_envelope("api_error", "request failed after 3 attempts: Gateway error (503)")
+    output = StringIO.new
+    logs = StringIO.new
+    bridge = bridge(runner, logger: logs, output: output)
+
+    assert_equal 503, bridge.handler.call(request(sample_payload))
+
+    assert_empty output.string
+    assert_match(/Gateway error \(503\).*; answered 503 so Basecamp redelivers/, logs.string)
+  end
+
   def test_a_redelivery_after_a_503_is_verified_afresh_and_emitted_once
     runner = FakeCommandRunner.new
     stub_transient_failure runner, "basecamp show"

--- a/test/basecamp_client_test.rb
+++ b/test/basecamp_client_test.rb
@@ -17,11 +17,11 @@ class BasecampClientTest < Minitest::Test
     assert_includes runner.commands.last.join(" "), "--profile clawdito"
   end
 
-  def test_malformed_json_from_a_successful_command_is_a_client_error
+  def test_malformed_json_from_a_successful_command_is_a_transient_error
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: '{"data": [{"id": 333, "tit'
 
-    error = assert_raises(BasecampAgentConnector::Basecamp::Client::Error) { build_cli(runner).chats(project: 222) }
+    error = assert_raises(BasecampAgentConnector::Basecamp::Client::TransientError) { build_cli(runner).chats(project: 222) }
     assert_match(/malformed JSON/, error.message)
   end
 
@@ -72,6 +72,91 @@ class BasecampClientTest < Minitest::Test
     assert_raises BasecampAgentConnector::Basecamp::Client::Error do
       build_cli(runner).me
     end
+  end
+
+  # The keyring-probe race: a concurrent CLI invocation lost its keyring
+  # probe, fell back to a stale credentials file, and reported auth_required
+  # though the profile is fine. The next attempt, once the neighbours are
+  # done, succeeds — and the caller never learns there was a hiccup.
+  def test_retries_a_transient_failure_and_returns_the_eventual_answer
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", exit_status: 3, once: true,
+      stdout: error_envelope("auth_required", "Not authenticated for profile:clawdito: credentials not found")
+    runner.stub "basecamp show", stdout: envelope(sample_recording)
+    delays = []
+
+    recording = build_cli(runner, wait: ->(seconds) { delays << seconds }).show("https://example.org/recordings/456")
+
+    assert_equal 456, recording.fetch("id")
+    assert_equal 2, runner.commands_matching(/basecamp show/).length
+    assert_equal [ BasecampAgentConnector::Basecamp::Client::RETRY_DELAYS.first ], delays
+  end
+
+  def test_a_token_refresh_failure_is_transient
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", exit_status: 7, once: true,
+      stdout: error_envelope("api_error", "token refresh failed: Post \"https://launchpad.localhost:3011/oauth/token\": connection refused")
+    runner.stub "basecamp show", stdout: envelope(sample_recording)
+
+    assert_equal 456, build_cli(runner).show("https://example.org/recordings/456").fetch("id")
+  end
+
+  def test_a_nonzero_exit_without_an_envelope_is_transient
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", exit_status: 1, stderr: "502 Bad Gateway", once: true
+    runner.stub "basecamp show", stdout: envelope(sample_recording)
+
+    assert_equal 456, build_cli(runner).show("https://example.org/recordings/456").fetch("id")
+  end
+
+  def test_a_transient_failure_that_outlasts_the_retries_is_a_transient_error
+    runner = FakeCommandRunner.new
+    stub_transient_failure runner, "basecamp show"
+    delays = []
+
+    error = assert_raises(BasecampAgentConnector::Basecamp::Client::TransientError) do
+      build_cli(runner, wait: ->(seconds) { delays << seconds }).show("https://example.org/recordings/456")
+    end
+
+    assert_equal BasecampAgentConnector::Basecamp::Client::ATTEMPTS, error.attempts
+    assert_equal BasecampAgentConnector::Basecamp::Client::ATTEMPTS, runner.commands_matching(/basecamp show/).length
+    assert_equal BasecampAgentConnector::Basecamp::Client::RETRY_DELAYS, delays
+    assert_match(/failed on all 3 attempts: .*auth_required/, error.message)
+  end
+
+  # Basecamp's own verdict is final: a recording that is not there (deleted,
+  # or never existed because the POST was forged) must stay uncorroborated,
+  # and asking twice more would only delay saying so.
+  def test_does_not_retry_a_not_found
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", exit_status: 2, stdout: error_envelope("not_found", "Resource not found: https://example.org/recordings/456.json")
+    delays = []
+
+    error = assert_raises(BasecampAgentConnector::Basecamp::Client::Error) do
+      build_cli(runner, wait: ->(seconds) { delays << seconds }).show("https://example.org/recordings/456")
+    end
+
+    refute_kind_of BasecampAgentConnector::Basecamp::Client::TransientError, error
+    assert_equal 1, runner.commands_matching(/basecamp show/).length
+    assert_empty delays
+  end
+
+  def test_does_not_retry_a_forbidden
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", exit_status: 4, stdout: error_envelope("forbidden", "Access denied")
+
+    error = assert_raises(BasecampAgentConnector::Basecamp::Client::Error) { build_cli(runner).show("https://example.org/recordings/456") }
+
+    refute_kind_of BasecampAgentConnector::Basecamp::Client::TransientError, error
+    assert_equal 1, runner.commands.length
+  end
+
+  def test_retries_malformed_output_from_a_successful_command
+    runner = FakeCommandRunner.new
+    runner.stub "chat list", stdout: '{"data": [{"id": 333, "tit', once: true
+    runner.stub "chat list", stdout: envelope([ chat_hash ])
+
+    assert_equal 333, build_cli(runner).chats(project: 222).first.fetch("id")
   end
 
   # A failing command prints the {"ok": false, ...} error envelope on stdout

--- a/test/basecamp_client_test.rb
+++ b/test/basecamp_client_test.rb
@@ -101,6 +101,41 @@ class BasecampClientTest < Minitest::Test
     assert_equal 456, build_cli(runner).show("https://example.org/recordings/456").fetch("id")
   end
 
+  # bc3 answering 5xx, or the CLI's own circuit breaker refusing to ask,
+  # arrive as api_error too — each with a fixed message from the SDK or the
+  # CLI, since the envelope drops the SDK's Retryable flag. None is a
+  # verdict on the recording.
+  def test_a_5xx_or_an_open_circuit_is_transient
+    [
+      "Gateway error (503)",
+      "request failed after 3 attempts: Gateway error (502)",
+      "Server error (500)",
+      "request failed after 3 attempts: API error: 502 Bad Gateway",
+      "Service temporarily unavailable"
+    ].each do |message|
+      runner = FakeCommandRunner.new
+      stub_transient_failure runner, "basecamp show", stdout: error_envelope("api_error", message), exit_status: 7
+
+      error = assert_raises(BasecampAgentConnector::Basecamp::Client::TransientError, message) do
+        build_cli(runner).show("https://example.org/recordings/456")
+      end
+
+      assert_equal BasecampAgentConnector::Basecamp::Client::ATTEMPTS, runner.commands_matching(/basecamp show/).length, message
+      assert_includes error.message, message
+    end
+  end
+
+  # A 4xx Basecamp reports as api_error is its verdict, like a not_found.
+  def test_a_4xx_api_error_is_not_transient
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", exit_status: 7, stdout: error_envelope("api_error", "API error: 410 Gone")
+
+    error = assert_raises(BasecampAgentConnector::Basecamp::Client::Error) { build_cli(runner).show("https://example.org/recordings/456") }
+
+    refute_kind_of BasecampAgentConnector::Basecamp::Client::TransientError, error
+    assert_equal 1, runner.commands.length
+  end
+
   def test_a_nonzero_exit_without_an_envelope_is_transient
     runner = FakeCommandRunner.new
     runner.stub "basecamp show", exit_status: 1, stderr: "502 Bad Gateway", once: true

--- a/test/basecamp_client_test.rb
+++ b/test/basecamp_client_test.rb
@@ -213,16 +213,23 @@ class BasecampClientTest < Minitest::Test
 
   # A failing command prints the {"ok": false, ...} error envelope on stdout
   # and exits nonzero (verified against production); the raised error carries
-  # that envelope as its detail, which the pollers log and retry.
-  def test_a_failed_command_surfaces_the_error_envelope_as_detail
+  # that envelope as its detail, which the pollers log. A 429 arrives as
+  # `rate_limit` — the one spelling the SDK (checkResponse, the 429 arm of
+  # the raw client) and the CLI (convertSDKError, for its own limiter and
+  # bulkhead too) give it, exit status 5 — and is no verdict on the
+  # recording, so it is retried and then surfaces transient.
+  def test_a_rate_limit_is_transient_and_surfaces_the_envelope_as_detail
     runner = FakeCommandRunner.new
-    runner.stub "chat messages", exit_status: 2,
-      stdout: JSON.generate("ok" => false, "error" => "Too many requests", "code" => "too_many_requests")
+    stub_transient_failure runner, "chat messages", exit_status: 5,
+      stdout: JSON.generate("ok" => false, "error" => "Rate limit exceeded", "code" => "rate_limit",
+        "hint" => "Too many requests. Please wait before trying again.")
 
-    error = assert_raises(BasecampAgentConnector::Basecamp::Client::Error) do
+    error = assert_raises(BasecampAgentConnector::Basecamp::Client::TransientError) do
       build_cli(runner).chat_lines(project: 222, chat: 333, limit: 50)
     end
-    assert_match(/too_many_requests/, error.message)
+
+    assert_equal BasecampAgentConnector::Basecamp::Client::ATTEMPTS, runner.commands.length
+    assert_match(/failed on all 3 attempts: .*rate_limit/, error.message)
   end
 
   def test_chats_lists_a_projects_chats

--- a/test/basecamp_client_test.rb
+++ b/test/basecamp_client_test.rb
@@ -37,6 +37,24 @@ class BasecampClientTest < Minitest::Test
     assert_includes command, "--types Comment"
   end
 
+  # A create is not re-asked: Basecamp may have registered the webhook and
+  # lost only the answer, and a second create would register a second
+  # webhook whose id is never kept for teardown. The registration's own
+  # outer retry (Webhooks#create_with_retries) decides whether to try again.
+  def test_create_webhook_is_not_retried_on_a_transient_failure
+    runner = FakeCommandRunner.new
+    stub_transient_failure runner, "webhooks create"
+    delays = []
+
+    error = assert_raises(BasecampAgentConnector::Basecamp::Client::TransientError) do
+      build_cli(runner, wait: ->(seconds) { delays << seconds }).create_webhook(url: "https://example.org/hook/x", project: 222, types: "Comment")
+    end
+
+    assert_equal 1, runner.commands.length
+    assert_empty delays
+    assert_match(/`basecamp webhooks create .*` failed: .*auth_required/, error.message)
+  end
+
   def test_delete_webhook_returns_success_flag
     runner = FakeCommandRunner.new
     runner.stub "webhooks delete", exit_status: 0

--- a/test/basecamp_client_test.rb
+++ b/test/basecamp_client_test.rb
@@ -153,7 +153,6 @@ class BasecampClientTest < Minitest::Test
       build_cli(runner, wait: ->(seconds) { delays << seconds }).show("https://example.org/recordings/456")
     end
 
-    assert_equal BasecampAgentConnector::Basecamp::Client::ATTEMPTS, error.attempts
     assert_equal BasecampAgentConnector::Basecamp::Client::ATTEMPTS, runner.commands_matching(/basecamp show/).length
     assert_equal BasecampAgentConnector::Basecamp::Client::RETRY_DELAYS, delays
     assert_match(/failed on all 3 attempts: .*auth_required/, error.message)

--- a/test/boost_poller_test.rb
+++ b/test/boost_poller_test.rb
@@ -86,7 +86,10 @@ class BoostPollerTest < Minitest::Test
     assert_match(/not corroborated/, @logs.string)
   end
 
-  def test_a_transient_corroboration_failure_is_retried_on_the_next_poll
+  # One lost keyring probe on the corroborating re-fetch is absorbed by the
+  # client's retry: the boost settles on this poll, nothing is logged as
+  # uncorroborated, and later polls see it as seen.
+  def test_a_transient_corroboration_failure_is_retried_within_the_poll
     runner = FakeCommandRunner.new
     runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ]), once: true
     runner.stub "api get /my/boosts.json", exit_status: 1, stderr: "502 Bad Gateway", once: true
@@ -94,8 +97,26 @@ class BoostPollerTest < Minitest::Test
     poller = poller(runner)
 
     poller.poll
+    assert_equal 1, @output.string.lines.length
+    refute_match(/not corroborated/, @logs.string)
+
+    poller.poll
+    assert_equal 1, @output.string.lines.length
+  end
+
+  # A failure that outlasts the client's retries is forgotten, not settled:
+  # the next poll — this poller's redelivery — verifies it afresh.
+  def test_a_corroboration_failure_that_outlasts_the_retries_is_retried_on_the_next_poll
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ]), once: true
+    stub_transient_failure runner, "api get /my/boosts.json"
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ])
+    poller = poller(runner)
+
+    poller.poll
     assert_empty @output.string
-    assert_match(/not corroborated/, @logs.string)
+    assert_match(/could not corroborate boost 88001: .*retried on the next poll/, @logs.string)
+    refute_match(/not corroborated/, @logs.string)
 
     poller.poll
     assert_equal 1, @output.string.lines.length
@@ -186,7 +207,7 @@ class BoostPollerTest < Minitest::Test
 
   def test_a_failed_fetch_leaves_the_baseline_for_the_next_successful_poll
     runner = FakeCommandRunner.new
-    runner.stub "api get /my/boosts.json", exit_status: 1, stderr: "boom", once: true
+    stub_transient_failure runner, "api get /my/boosts.json", stdout: "", exit_status: 1
     runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ])
     poller = poller(runner, clock: -> { AFTER_THE_BOOST })
 
@@ -200,7 +221,7 @@ class BoostPollerTest < Minitest::Test
 
   def test_malformed_feed_output_is_logged_and_retried
     runner = FakeCommandRunner.new
-    runner.stub "api get /my/boosts.json", stdout: '{"data": [{"id": 88', once: true
+    stub_transient_failure runner, "api get /my/boosts.json", stdout: '{"data": [{"id": 88', exit_status: 0
     runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ])
     poller = poller(runner)
 

--- a/test/chat_poller_test.rb
+++ b/test/chat_poller_test.rb
@@ -91,7 +91,7 @@ class ChatPollerTest < Minitest::Test
     runner.stub "chat list", stdout: envelope([ chat_hash ])
     runner.stub "chat messages", stdout: empty_envelope, once: true
     runner.stub "chat messages", stdout: envelope([ chat_line ])
-    runner.stub "chat line ", exit_status: 1, stderr: "not found"
+    runner.stub "chat line ", exit_status: 2, stdout: error_envelope("not_found", "Resource not found")
     poller = poller(runner)
 
     poller.poll
@@ -101,7 +101,10 @@ class ChatPollerTest < Minitest::Test
     assert_match(/not corroborated/, @logs.string)
   end
 
-  def test_a_transient_corroboration_failure_is_retried_on_the_next_poll
+  # One lost keyring probe on the corroborating re-fetch is absorbed by the
+  # client's retry: the line settles on this poll, nothing is logged as
+  # uncorroborated, and later polls see it as seen.
+  def test_a_transient_corroboration_failure_is_retried_within_the_poll
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: envelope([ chat_hash ])
     runner.stub "chat messages", stdout: empty_envelope, once: true
@@ -112,12 +115,34 @@ class ChatPollerTest < Minitest::Test
 
     poller.poll
     poller.poll
-    assert_empty @output.string
-    assert_match(/not corroborated/, @logs.string)
+    assert_equal 1, @output.string.lines.length
+    assert_equal 2, runner.commands_matching(/chat line /).length
+    refute_match(/not corroborated/, @logs.string)
 
     poller.poll
     assert_equal 1, @output.string.lines.length
     assert_equal 2, runner.commands_matching(/chat line /).length
+  end
+
+  # A failure that outlasts the client's retries is forgotten, not settled:
+  # the next poll — this poller's redelivery — verifies it afresh.
+  def test_a_corroboration_failure_that_outlasts_the_retries_is_retried_on_the_next_poll
+    runner = FakeCommandRunner.new
+    runner.stub "chat list", stdout: envelope([ chat_hash ])
+    runner.stub "chat messages", stdout: empty_envelope, once: true
+    runner.stub "chat messages", stdout: envelope([ chat_line ])
+    stub_transient_failure runner, "chat line "
+    runner.stub "chat line ", stdout: envelope(chat_line)
+    poller = poller(runner)
+
+    poller.poll
+    poller.poll
+    assert_empty @output.string
+    assert_match(/could not corroborate chat line 91001: .*retried on the next poll/, @logs.string)
+    refute_match(/not corroborated/, @logs.string)
+
+    poller.poll
+    assert_equal 1, @output.string.lines.length
 
     poller.poll
     assert_equal 1, @output.string.lines.length
@@ -139,7 +164,7 @@ class ChatPollerTest < Minitest::Test
 
   def test_malformed_discovery_output_is_logged_and_retried
     runner = FakeCommandRunner.new
-    runner.stub "chat list", stdout: '{"data": [{"id": 333', once: true
+    stub_transient_failure runner, "chat list", stdout: '{"data": [{"id": 333', exit_status: 0
     runner.stub "chat list", stdout: envelope([ chat_hash ])
     runner.stub "chat messages", stdout: empty_envelope
     poller = poller(runner)
@@ -197,7 +222,7 @@ class ChatPollerTest < Minitest::Test
   def test_a_failed_fetch_leaves_the_baseline_for_the_next_successful_poll
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: envelope([ chat_hash ])
-    runner.stub "chat messages", exit_status: 1, stderr: "boom", once: true
+    stub_transient_failure runner, "chat messages", stdout: "", exit_status: 1
     runner.stub "chat messages", stdout: envelope([ chat_line ])
     poller = poller(runner, clock: -> { Time.utc(2026, 6, 28, 13, 0, 0) })
 
@@ -213,7 +238,7 @@ class ChatPollerTest < Minitest::Test
 
   def test_a_failed_chat_listing_is_retried_on_the_next_poll
     runner = FakeCommandRunner.new
-    runner.stub "chat list", exit_status: 1, stderr: "boom", once: true
+    stub_transient_failure runner, "chat list", stdout: "", exit_status: 1
     runner.stub "chat list", stdout: envelope([ chat_hash ])
     runner.stub "chat messages", stdout: envelope([ chat_line ])
     poller = poller(runner, clock: -> { Time.utc(2026, 6, 28, 13, 0, 0) })
@@ -300,7 +325,7 @@ class ChatPollerTest < Minitest::Test
     now = Time.now
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: envelope([ chat_hash ]), once: true
-    runner.stub "chat list", exit_status: 1, stderr: "boom", once: true
+    runner.stub "chat list", exit_status: 4, stdout: error_envelope("forbidden", "Access denied"), once: true
     runner.stub "chat list", stdout: envelope([ chat_hash ])
     runner.stub "chat messages", stdout: empty_envelope
     poller = poller(runner, clock: -> { now })
@@ -363,7 +388,7 @@ class ChatPollerTest < Minitest::Test
     now = Time.now
     runner = FakeCommandRunner.new
     runner.stub "chat list --project A", stdout: envelope([ chat_hash ])
-    runner.stub "chat list --project B", exit_status: 1, stderr: "boom"
+    runner.stub "chat list --project B", exit_status: 4, stdout: error_envelope("forbidden", "Access denied")
     runner.stub "chat messages", stdout: empty_envelope
     poller = poller(runner, projects: [ "A", "B" ], clock: -> { now })
 

--- a/test/identity_test.rb
+++ b/test/identity_test.rb
@@ -27,7 +27,7 @@ class IdentityTest < Minitest::Test
 
   def test_refreshes_once_when_token_expired_then_succeeds
     runner = FakeCommandRunner.new
-    runner.stub "basecamp me", exit_status: 1, stderr: "token expired", once: true
+    stub_transient_failure runner, "basecamp me", stdout: error_envelope("auth_required", "token expired")
     runner.stub "auth refresh", exit_status: 0
     runner.stub "basecamp me", stdout: identity_envelope("id" => 123)
     runner.stub "people show me", stdout: person_envelope(52007412)

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -214,6 +214,36 @@ class PipelineTest < Minitest::Test
     assert_equal 1, @output.string.lines.length
   end
 
+  # Waiting is per event id: a delivery of a different id is verified while
+  # the first is still parked on its CLI call, not queued behind it — a
+  # burst serialized behind one slow verification would overrun bc3's 10s
+  # delivery timeout for every delivery after it.
+  def test_distinct_events_are_verified_concurrently
+    gate = Queue.new
+    other_recording = sample_recording("id" => 457, "url" => "https://3.basecamp.com/000/buckets/222/comments/457.json",
+      "app_url" => "https://3.basecamp.com/000/buckets/222/comments/457")
+    runner = FakeCommandRunner.new
+    runner.stub "comments/456", stdout: envelope(sample_recording)
+    runner.stub "comments/457", stdout: envelope(other_recording)
+    gated = Object.new
+    gated.define_singleton_method(:run) { |*command| gate.pop if command.join(" ").include?("comments/456"); runner.run(*command) }
+    pipeline = pipeline(gated)
+    first = Thread.new { pipeline.process(sample_payload) }
+    Thread.pass while first.alive? && first.status != "sleep"
+    flunk "the first verification finished before blocking on the gate" unless first.alive?
+
+    second = Thread.new { pipeline.process(sample_payload("id" => 99003, "recording" => other_recording)) }
+    refute_nil second.join(2), "the second event queued behind the first's in-flight verification"
+    assert second.value
+    assert first.alive?, "the first verification settled without passing its gate"
+
+    gate << :go
+    assert first.value
+    assert_equal [ 99003, 99001 ], @output.string.lines.map { |line| JSON.parse(line)["event_id"] }
+  ensure
+    gate << :go
+  end
+
   def test_emits_for_a_boost_on_the_agents_work_by_the_operator
     runner = FakeCommandRunner.new
     runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ])

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -131,11 +131,49 @@ class PipelineTest < Minitest::Test
 
   def test_an_uncorroborated_event_is_retried_when_delivered_again
     runner = FakeCommandRunner.new
-    runner.stub "basecamp show", exit_status: 1, stderr: "502 Bad Gateway", once: true
+    runner.stub "basecamp show", exit_status: 2, stdout: error_envelope("not_found", "Resource not found"), once: true
     runner.stub "basecamp show", stdout: envelope(sample_recording)
     pipeline = pipeline(runner)
 
     refute pipeline.process(sample_payload)
+    assert pipeline.process(sample_payload)
+
+    assert_equal 1, @output.string.lines.length
+  end
+
+  # One lost keyring probe must cost nothing visible: the client's retry
+  # absorbs it, the event settles on this delivery, and the redelivery
+  # Basecamp would send anyway is a duplicate.
+  def test_an_event_corroborated_after_one_transient_failure_is_emitted_exactly_once
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", exit_status: 3, once: true,
+      stdout: error_envelope("auth_required", "Not authenticated for profile:clawdito: credentials not found")
+    runner.stub "basecamp show", stdout: envelope(sample_recording)
+    pipeline = pipeline(runner)
+
+    assert pipeline.process(sample_payload)
+    assert pipeline.process(sample_payload)
+
+    assert_equal 1, @output.string.lines.length
+    assert_equal 2, runner.commands_matching(/basecamp show/).length
+    refute_match(/not corroborated/, @logs.string)
+  end
+
+  # A failure that outlasts the retries is no verdict: it propagates (for the
+  # webhook handler to answer 503) rather than logging "not corroborated",
+  # and forgets the id so the redelivery is verified afresh — and emitted
+  # exactly once.
+  def test_a_transient_failure_that_outlasts_the_retries_propagates_and_forgets_the_event
+    runner = FakeCommandRunner.new
+    stub_transient_failure runner, "basecamp show"
+    runner.stub "basecamp show", stdout: envelope(sample_recording)
+    pipeline = pipeline(runner)
+
+    assert_raises(BasecampAgentConnector::Basecamp::Client::TransientError) { pipeline.process(sample_payload) }
+    assert_empty @output.string
+    refute_match(/not corroborated/, @logs.string)
+
+    assert pipeline.process(sample_payload)
     assert pipeline.process(sample_payload)
 
     assert_equal 1, @output.string.lines.length
@@ -149,6 +187,29 @@ class PipelineTest < Minitest::Test
     assert pipeline.process(sample_payload)
     assert pipeline.process(sample_payload)
     assert pipeline.process(sample_payload("kind" => "comment_archived"))
+    assert_equal 1, @output.string.lines.length
+  end
+
+  # The interleaving the pipeline's lock prevents: a verification overruns
+  # bc3's delivery timeout, the redelivery arrives while it is in flight, and
+  # the original then fails. Answered 200 as a duplicate, the redelivery
+  # would have been the last one; waiting, it becomes the fresh attempt.
+  def test_a_redelivery_during_an_in_flight_verification_waits_for_its_outcome
+    gate = Queue.new
+    runner = FakeCommandRunner.new
+    stub_transient_failure runner, "basecamp show"
+    runner.stub "basecamp show", stdout: envelope(sample_recording)
+    gated = Object.new
+    gated.define_singleton_method(:run) { |*command| gate.pop; runner.run(*command) }
+    pipeline = pipeline(gated)
+    original = Thread.new { pipeline.process(sample_payload) rescue $! }
+    Thread.pass until original.status == "sleep"
+
+    redelivery = Thread.new { pipeline.process(sample_payload) }
+    4.times { gate << :go }
+
+    assert_kind_of BasecampAgentConnector::Basecamp::Client::TransientError, original.value
+    assert redelivery.value
     assert_equal 1, @output.string.lines.length
   end
 

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -203,7 +203,8 @@ class PipelineTest < Minitest::Test
     gated.define_singleton_method(:run) { |*command| gate.pop; runner.run(*command) }
     pipeline = pipeline(gated)
     original = Thread.new { pipeline.process(sample_payload) rescue $! }
-    Thread.pass until original.status == "sleep"
+    Thread.pass while original.alive? && original.status != "sleep"
+    flunk "the original verification finished (#{original.value.inspect}) before blocking on the gate" unless original.alive?
 
     redelivery = Thread.new { pipeline.process(sample_payload) }
     4.times { gate << :go }

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -6,9 +6,10 @@ class ServerTest < Minitest::Test
     @port = free_port
     @hook = []
     @gh = []
+    @status = nil
     @server = BasecampAgentConnector::Server.new(port: @port, logger: StringIO.new, routes: {
-      "/hook/s3cret" => ->(request) { @hook << request },
-      "/gh/ghs3cret" => ->(request) { @gh << request }
+      "/hook/s3cret" => ->(request) { @hook << request; @status },
+      "/gh/ghs3cret" => ->(request) { @gh << request; nil }
     })
     @thread = Thread.new { @server.start }
     wait_until_listening(@port)
@@ -31,6 +32,18 @@ class ServerTest < Minitest::Test
     post("/gh/ghs3cret", "{}", "X-Hub-Signature-256" => "sha256=abc")
 
     assert_equal "sha256=abc", @gh.first.header("X-Hub-Signature-256")
+  end
+
+  def test_answers_200_when_the_handler_returns_no_status
+    assert_equal "200", post("/hook/s3cret", "{}").code
+    assert_equal "200", post("/gh/ghs3cret", "{}").code
+  end
+
+  def test_answers_the_status_the_handler_returns
+    @status = 503
+
+    assert_equal "503", post("/hook/s3cret", "{}").code
+    assert_equal 1, @hook.length
   end
 
   def test_returns_404_for_unknown_paths

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,17 +16,20 @@ class FakeCommandRunner
     @stubs = []
   end
 
-  def stub(matcher, stdout: "", stderr: "", exit_status: 0, once: false)
+  # A stub answers every matching command until it is used up: `once: true`
+  # answers one, `times: n` answers n (a transient failure the client retries
+  # through needs one per attempt), and the default answers forever.
+  def stub(matcher, stdout: "", stderr: "", exit_status: 0, once: false, times: nil)
     result = BasecampAgentConnector::CommandRunner::Result.new(stdout: stdout, stderr: stderr, exit_status: exit_status)
-    @stubs << { matcher: matcher, result: result, once: once, consumed: false }
+    @stubs << { matcher: matcher, result: result, remaining: once ? 1 : times }
   end
 
   def run(*command)
     @commands << command
-    stub = @stubs.find { |candidate| !candidate[:consumed] && matches?(command, candidate[:matcher]) }
+    stub = @stubs.find { |candidate| candidate[:remaining] != 0 && matches?(command, candidate[:matcher]) }
     raise "no stub for command: #{command.join(' ')}" if stub.nil?
 
-    stub[:consumed] = true if stub[:once]
+    stub[:remaining] -= 1 unless stub[:remaining].nil?
     stub[:result]
   end
 
@@ -200,8 +203,22 @@ module PayloadHelpers
     JSON.generate("ok" => true, "summary" => summary)
   end
 
-  def build_cli(command_runner)
-    BasecampAgentConnector::Basecamp::Client.new(command_runner: command_runner)
+  # The CLI's `-j` failure envelope, printed on stdout with a nonzero exit
+  # (verified against production: `basecamp show <missing> -j` exits 2 with
+  # {"ok": false, "error": "Resource not found: ...", "code": "not_found"}).
+  def error_envelope(code, error = code.tr("_", " "))
+    JSON.generate("ok" => false, "error" => error, "code" => code)
+  end
+
+  # Stubs a command to fail transiently on every attempt the client makes,
+  # so the failure survives its retries.
+  def stub_transient_failure(runner, matcher, stdout: error_envelope("auth_required", "Not authenticated for profile:clawdito: credentials not found"), exit_status: 3)
+    runner.stub matcher, stdout: stdout, exit_status: exit_status, times: BasecampAgentConnector::Basecamp::Client::ATTEMPTS
+  end
+
+  # No sleeping between retries in tests; pass `wait:` to observe the delays.
+  def build_cli(command_runner, wait: ->(_seconds) { })
+    BasecampAgentConnector::Basecamp::Client.new(command_runner: command_runner, wait: wait)
   end
 
   def build_github_cli(command_runner)

--- a/test/verifier_test.rb
+++ b/test/verifier_test.rb
@@ -20,9 +20,26 @@ class VerifierTest < Minitest::Test
 
   def test_rejects_when_recording_not_found
     runner = FakeCommandRunner.new
-    runner.stub "basecamp show", exit_status: 1, stderr: "not found"
+    runner.stub "basecamp show", exit_status: 2, stdout: error_envelope("not_found", "Resource not found")
 
     assert_nil verifier(runner).verify(event(sample_payload))
+    assert_equal 1, runner.commands.length
+  end
+
+  # No verdict without an answer: a fetch the CLI could not complete is not
+  # "Basecamp says it isn't there", so it propagates instead of rejecting.
+  def test_a_transient_fetch_failure_propagates_instead_of_rejecting
+    runner = FakeCommandRunner.new
+    stub_transient_failure runner, "basecamp show"
+
+    assert_raises(BasecampAgentConnector::Basecamp::Client::TransientError) { verifier(runner).verify(event(sample_payload)) }
+  end
+
+  def test_a_transient_chat_line_fetch_failure_propagates_instead_of_rejecting
+    runner = FakeCommandRunner.new
+    stub_transient_failure runner, "chat line "
+
+    assert_raises(BasecampAgentConnector::Basecamp::Client::TransientError) { verifier(runner).verify(event(chat_line_payload)) }
   end
 
   def test_does_not_call_basecamp_without_a_locator
@@ -121,15 +138,26 @@ class VerifierTest < Minitest::Test
     assert_empty runner.commands_matching(/subscriptions show/)
   end
 
-  def test_a_failed_subscribers_lookup_stamps_not_subscribed
+  def test_a_refused_subscribers_lookup_stamps_not_subscribed
     runner = FakeCommandRunner.new
     runner.stub "basecamp show", stdout: envelope(sample_recording("content" => "<p>no mention</p>"))
-    runner.stub "subscriptions show", exit_status: 1, stderr: "boom"
+    runner.stub "subscriptions show", exit_status: 2, stdout: error_envelope("not_found", "Resource not found")
 
     verified = verifier(runner).verify(event(sample_payload))
 
     refute_nil verified
     refute verified.subscribed?
+  end
+
+  # Stamping "not subscribed" on a lookup that never got an answer would
+  # settle the event as "does not target the agent" — a drop Basecamp never
+  # redelivers. It propagates instead, like the recording fetch.
+  def test_a_transient_subscribers_lookup_failure_propagates
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(sample_recording("content" => "<p>no mention</p>"))
+    stub_transient_failure runner, "subscriptions show"
+
+    assert_raises(BasecampAgentConnector::Basecamp::Client::TransientError) { verifier(runner).verify(event(sample_payload)) }
   end
 
   def test_corroborates_a_boost_against_the_agents_own_feed_and_stamps_it
@@ -161,11 +189,18 @@ class VerifierTest < Minitest::Test
     assert_nil verifier(runner).verify(event(boost_payload))
   end
 
-  def test_rejects_a_boost_when_the_feed_fetch_fails
+  def test_rejects_a_boost_when_the_feed_fetch_is_refused
     runner = FakeCommandRunner.new
-    runner.stub "api get /my/boosts.json", exit_status: 1, stderr: "boom"
+    runner.stub "api get /my/boosts.json", exit_status: 4, stdout: error_envelope("forbidden", "Access denied")
 
     assert_nil verifier(runner).verify(event(boost_payload))
+  end
+
+  def test_a_transient_feed_fetch_failure_propagates_instead_of_rejecting
+    runner = FakeCommandRunner.new
+    stub_transient_failure runner, "api get /my/boosts.json"
+
+    assert_raises(BasecampAgentConnector::Basecamp::Client::TransientError) { verifier(runner).verify(event(boost_payload)) }
   end
 
   def test_rejects_a_boost_when_the_agent_has_no_profile


### PR DESCRIPTION
## The failure

Under concurrent `basecamp` invocations the CLI's keyring probe races on one shared keychain item (service `credstore.probe.basecamp`): the loser's probe fails, the CLI silently falls back to a stale credentials file, and the command fails with `auth_required` or a token-refresh `api_error` although the credentials are fine (19/20 parallel probes lost in a 20-way run; 20/20 serial ones passed). The connector treated every `Client::Error` as "not corroborated by Basecamp", dropped the event, and answered the webhook 200 — so Basecamp never redelivered, and a real @mention vanished with a log line blaming a forgery.

The same drop happened for every other way Basecamp could not be asked: bc3 answering 5xx mid-deploy, the CLI's own circuit breaker, a network blip, garbled output.

## The contract

A webhook delivery is answered with its **verdict**: `200` once the event is settled (emitted, dropped, or a duplicate), `503` when Basecamp could not be asked. The pollers forget the id and retry on their next tick, which is their redelivery.

- `Basecamp::Client#json` retries a transient failure up to `ATTEMPTS = 3` with `RETRY_DELAYS = [0.5, 1.5]`s, then raises `Client::TransientError < Client::Error`. Only the reads take that budget: `create_webhook` passes `attempts: 1`, since a create whose answer was lost may still have created and a second attempt would register a second webhook nobody tears down — `Webhooks#create_with_retries` remains its (pre-existing) retry. Transient = envelope code `auth_required` / `network` / `rate_limit` (the one spelling every layer gives a 429: SDK `helpers.go:77` and `client.go:797`, CLI `convertSDKError`, `basecamp/cli` `output/codes.go:23`); `api_error` whose message is one of the SDK's or CLI's fixed no-answer strings (`token refresh …`, `Server error (500)`, `Gateway error (50x)`, `API error: 5xx …`, `request failed after N attempts: …`, `Service temporarily unavailable`); or no parseable envelope on stdout. `not_found` / `forbidden` / `validation` / a 4xx `api_error` raise plain `Error` at once, no retry: Basecamp's verdict doesn't improve with repetition.
- `Verifier` re-raises `TransientError`; plain `Error` still means nil / not subscribed.
- `Pipeline#process` forgets the event id and propagates `TransientError`. Coordination is per event id: an in-flight set plus one condition variable under a lock held only for the bookkeeping. A redelivery of an id in flight waits for that id's verdict (named interleaving: a verification overruns bc3's 10s timeout, the redelivery is answered 200 as a duplicate, then the original fails and forgets the id — nobody left to redeliver); distinct ids verify concurrently, so a burst is not serialized behind one slow CLI call.
- `Basecamp::Bridge#handler` runs the pipeline on the request thread: nil (200) on a verdict, 503 on `TransientError`, with a log line — `could not corroborate event N: \`basecamp <command>\` failed on all K attempts: …` — that names the call that went unanswered (the recording fetch, or the subscriber lookup after it) and what happens if it keeps happening (below). `Server` sends the handler's status (nil = 200); the GitHub bridge still answers 200 at once.

## Why 503 is safe: bc3 redelivers

- `app/jobs/webhook/delivery_job.rb:3`: `retry_on(Webhook::Delivery::Error, wait: :polynomially_longer, attempts: 10, queue: :webhook_retries) { |job, error| job.deactivate_webhook }`
- `app/models/webhook/delivery.rb:23-27`: `raise Error unless succeeded?` where `succeeded?` is `response[:code].in?(200...300)`; the POST runs with `timeout: 10`, `follow_redirects: false`.

So a 503 is redelivered at roughly 3s, 18s, 83s, 258s, 627s, 1298s, 2403s, 4098s, 6563s (+15% jitter) — about 4.3h — after which bc3 sets `active: false` on the webhook (`app/models/webhook.rb:60`, `update_columns`, no notice) and `DeliveryJob#perform` skips it. No local retry queue is needed. The consequence of a failure that stays transient that long (a revoked credential reports `auth_required` on every call, exactly like the race) is stated in the 503 log line, README step 5 and spec §7: fix the CLI's credentials (`basecamp auth status --profile <agent>`) and restart `bin/connect`, which re-registers.

## Verified CLI shapes

- `basecamp show <missing> -j --profile clawdito` exits 2 with `{"ok":false,"error":"Resource not found: …","code":"not_found"}` on stdout, nothing on stderr.
- basecamp-cli @ 0225c45d (installed 0.9.1, SDK v0.14.0): `internal/output/envelope.go` `ErrorResponse` has `ok`/`error`/`code`/`hint`/`meta` — the SDK's `Retryable` flag is dropped, so message text is the only discriminator. `Err()` writes `AsError(err).Message`, which for a wrapped SDK error is `err.Error()` of the outer error — hence `request failed after 3 attempts: Gateway error (503)` after the SDK's own GET retries (`DefaultMaxRetries = 3`, `DefaultBaseDelay = 1s`, sleeps 1s + 2s).
- SDK `pkg/basecamp/client.go:852-859`: 500 → `ErrAPI(500, "Server error (500)")` (not retryable, surfaces at once); 502/503/504 → `Code: api_error, Message: "Gateway error (N)", Retryable: true`. `helpers.go:97` default arm: `API error: <resp.Status>`, retryable for 5xx.
- basecamp-cli `internal/commands/projects.go:430` `convertSDKError`: `ErrCircuitOpen` → `api_error` / `Service temporarily unavailable` / retryable; called from `show`, `recordings`, `subscriptions`, `chat`, `api` (273 call sites). The breaker is file-backed across processes (`internal/appctx/context.go`, `resilience.DefaultConfig`).

## Declined

- **Keep the async handler and answer 200 immediately.** bc3 never redelivers a 2xx; a 200 says "settled". Anything deferred after it has no redelivery to fall back on.
- **A local retry queue for unverifiable deliveries.** bc3's delivery job already is one (10 attempts, backoff); a local one would duplicate it and lose its state on restart.
- **Classify `too_many_requests` as transient.** No layer emits that code. A 429 is `rate_limit` at every one of them — SDK `pkg/basecamp/helpers.go:77` (`checkResponse`) and `client.go:797` (the raw client's 429 arm), CLI `internal/commands/projects.go:424` (`convertSDKError`, for its own limiter and bulkhead too), `basecamp/cli` `output/codes.go:23` across all eight cached versions, and the installed 0.9.1 (`internal/output/codes.go:25`) — and `rate_limit` has been in `TRANSIENT_CODES` since the first commit here. The `too_many_requests` envelope was a fixture from #16, now corrected, with a test pinning `rate_limit` as transient. Adding the spelling would be the fourth entry in a list this PR should stop growing (see Follow-ups).
- **Match only 502-504, not 500.** A 500 is Basecamp failing to answer, not answering no. A persistent per-record 500 costs the webhook after 10 deliveries — logged with the remedy — where dropping a real mention silently is the worse failure.
- **Narrow the token-refresh match to exclude `invalid_grant` / `invalid_client`.** The stale credentials file the lost probe falls back to can carry a superseded refresh token, which the token endpoint rejects with the same body as a revoked one; they can't be told apart from the message. The deactivation remedy in the 503 log covers the persistent case.
- **Bound the shutdown wait (kill request threads after ~5s).** Verification on the request thread means WEBrick's shutdown joins it, so an in-flight delivery is answered before teardown deletes the webhooks — that is what keeps a Ctrl-C from losing it. Killing a thread mid-CLI-call trades a bounded wait for a lost event. The wait is bounded by the CLI's own timeouts (minutes on a stalled network); stated in the handler comment.
- **Detect webhook deactivation from the connector** (e.g. `basecamp webhooks show` on repeated 503s). A separate change; the remedy is logged and documented here.
- **`TransientError` as a sibling of `Error` rather than a subclass.** Every existing `rescue Client::Error` stays safe by default; the callers that can defer (verifier, pipeline, bridge, pollers) rescue `TransientError` first and opt in.
- **Exempt startup identity resolution from the retry budget.** `Identity.resolve` now pays ~2s of retries on a genuinely expired token before `refresh_auth`, and again after it; latency only, on the startup path.
- **Make `stub_transient_failure` take a literal `times: 3` so the pre-PR proof reaches its assertions.** The helper tracking `Client::ATTEMPTS` is what keeps the tests honest when the budget changes. Stated plainly instead: against `main` the helper-based tests error on the missing constant; the `once:`-based client/pipeline tests and the lock test (with `synchronize` removed: Expected 1, Actual 0) fail on their assertions.

## Follow-ups

- **Key transient `api_error` on a `retryable` field, and retire the message list.** The transient classifier has grown three times in this PR (token-refresh message → 5xx / circuit-open strings → a request for the 429 code): a list of spellings for a fact the CLI already holds and discards. basecamp-cli's SDK errors carry `Retryable` (`pkg/basecamp/errors.go`; set at `client.go:852-859`, `helpers.go:97`), the CLI's own `output.Error` carries it through `AsError` (`internal/output/errors.go:49`), and `Writer#Err` drops it when building the `-j` envelope (`internal/output/envelope.go:156-174`; `ErrorResponse` at `:58-64` has `ok`/`error`/`code`/`hint`/`meta` only). The durable fix is a `retryable: true/false` field in that envelope, with the connector keying on it when present and falling back to the list for older CLIs. The connector shells out to the installed binary (0.9.1), so the list stays until a release ships the field; a further spelling should not be added to it — reassess against this instead.

## Verification

- `bundle exec rake test`: 254 runs, 802 assertions, 0 failures. `bundle exec rubocop lib test`: clean.
- The 5xx / circuit-breaker tests (`test_a_5xx_or_an_open_circuit_is_transient`, `test_handler_answers_503_when_basecamp_answered_5xx`) fail against `0bc1293` (`Client::Error` raised after 1 attempt, handler returns nil) and pass with the widened match.
- Review round 2, each against the head before its commit: `test_distinct_events_are_verified_concurrently` fails on the global mutex (`second.join(2)` → nil, the second id queued behind the first) and `test_a_redelivery_during_an_in_flight_verification_waits_for_its_outcome` fails with the per-id wait removed (Expected 1 line, got 0 — the redelivery was answered as a duplicate); `test_create_webhook_is_not_retried_on_a_transient_failure` fails on the blind retry (Expected 1 invocation, Actual 3); the two 503 log tests fail on the old "could not fetch recording" wording; `test_a_rate_limit_is_transient_and_surfaces_the_envelope_as_detail` fails with `rate_limit` removed from `TRANSIENT_CODES`.

