### PR TITLE
Key transient classification on the envelope's retryable field

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,13 +362,17 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
    the connector re-runs the CLI a few times first (its keyring probe loses a
    race under concurrent invocations and reports stale credentials; bc3 may
    answer 5xx mid-deploy), and a `503` makes bc3's delivery job redeliver the
-   event with backoff rather than settling it as uncorroborated. Whether a
-   failure was Basecamp's answer or the CLI's plight is read from the
-   `retryable` field of the CLI's `-j` error envelope; a CLI older than the
-   one that emits it is classified by a fixed list of codes and messages
-   instead (`Client::TRANSIENT_CODES`, `TRANSIENT_API_ERROR`). A delivery
-   that stays unanswerable for all of bc3's 10 attempts (~4.3h — a revoked
-   credential looks just like the race) makes bc3 deactivate the webhook: fix
+   event with backoff rather than settling it as uncorroborated. Which
+   failures count as the CLI's plight rather than Basecamp's answer is a
+   fixed list of codes and messages (`Client::TRANSIENT_CODES`,
+   `TRANSIENT_API_ERROR`), widened by the `retryable` field of the CLI's
+   `-j` error envelope from the release that adds it (pending in
+   basecamp-cli): a failure stamped `retryable: true` is retried whatever
+   its code, while `false` — the CLI's stamp for its verdicts and for
+   anything it never classified, the keyring race included — leaves the list
+   in force. A delivery that stays unanswerable for all of bc3's 10 attempts
+   (~4.3h — a revoked credential looks just like the race) makes bc3
+   deactivate the webhook: fix
    the CLI's credentials (`basecamp auth status --profile <agent>`) and
    restart `bin/connect`, which re-registers it. The connector logs that
    remedy with every `503`.

--- a/README.md
+++ b/README.md
@@ -362,7 +362,11 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
    the connector re-runs the CLI a few times first (its keyring probe loses a
    race under concurrent invocations and reports stale credentials; bc3 may
    answer 5xx mid-deploy), and a `503` makes bc3's delivery job redeliver the
-   event with backoff rather than settling it as uncorroborated. A delivery
+   event with backoff rather than settling it as uncorroborated. Whether a
+   failure was Basecamp's answer or the CLI's plight is read from the
+   `retryable` field of the CLI's `-j` error envelope; a CLI older than the
+   one that emits it is classified by a fixed list of codes and messages
+   instead (`Client::TRANSIENT_CODES`, `TRANSIENT_API_ERROR`). A delivery
    that stays unanswerable for all of bc3's 10 attempts (~4.3h — a revoked
    credential looks just like the race) makes bc3 deactivate the webhook: fix
    the CLI's credentials (`basecamp auth status --profile <agent>`) and

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -215,7 +215,10 @@ bin/connect @AGENT --project <project>... [--operator <profile>] [--types <types
    under concurrent CLI invocations, a token refresh that lost that race, a
    network blip, bc3 answering 5xx, the CLI's open circuit breaker, garbled
    output — earns a 503; Basecamp's own refusal (not found, forbidden) is a
-   verdict. A delivery that stays unanswerable for all 10 of bc3's attempts
+   verdict. The CLI's `-j` error envelope tells the two apart with its
+   `retryable` field; an older CLI's envelope, without it, is classified by
+   a fixed list of codes and messages. A delivery that stays unanswerable
+   for all 10 of bc3's attempts
    (~4.3h; a revoked credential is indistinguishable from the race) gets the
    webhook deactivated, silently on bc3's side — the 503 log line names the
    remedy: fix the CLI's credentials and restart `bin/connect`, which

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -215,10 +215,13 @@ bin/connect @AGENT --project <project>... [--operator <profile>] [--types <types
    under concurrent CLI invocations, a token refresh that lost that race, a
    network blip, bc3 answering 5xx, the CLI's open circuit breaker, garbled
    output — earns a 503; Basecamp's own refusal (not found, forbidden) is a
-   verdict. The CLI's `-j` error envelope tells the two apart with its
-   `retryable` field; an older CLI's envelope, without it, is classified by
-   a fixed list of codes and messages. A delivery that stays unanswerable
-   for all 10 of bc3's attempts
+   verdict. The two are told apart by a fixed list of codes and messages,
+   which the `retryable` field of the CLI's `-j` error envelope (from the
+   release that adds it, pending in basecamp-cli) widens but never narrows:
+   `true` is retried whatever the code, `false` — the CLI's stamp for its
+   verdicts and for anything it never classified, the keyring race included
+   — falls through to the list. A delivery that stays unanswerable for all
+   10 of bc3's attempts
    (~4.3h; a revoked credential is indistinguishable from the race) gets the
    webhook deactivated, silently on bc3's side — the 503 log line names the
    remedy: fix the CLI's credentials and restart `bin/connect`, which

--- a/lib/basecamp_agent_connector/basecamp/client.rb
+++ b/lib/basecamp_agent_connector/basecamp/client.rb
@@ -54,31 +54,37 @@ class BasecampAgentConnector::Basecamp::Client
   ATTEMPTS = 3
   RETRY_DELAYS = [ 0.5, 1.5 ] # seconds before the second and third attempt
 
-  # The CLI's error envelope says outright whether the failure was Basecamp's
-  # answer or the CLI's plight: a top-level boolean `retryable`, the SDK's
-  # own Retryable flag surfaced. It is on every error envelope the CLI
-  # writes (false when the CLI has no positive signal) and never on a
-  # success, and when present it decides — the code and message below are
-  # not consulted.
+  # A CLI that classifies its own failures says so in its error envelope: a
+  # top-level boolean `retryable`, the SDK's Retryable flag surfaced, on every
+  # error envelope and never on a success. The field speaks in one direction
+  # only. `true` is a positive signal — the CLI knows the failure was its own
+  # plight, whatever the code or message — and is retried without consulting
+  # the list below. `false` is not a verdict but the absence of that signal:
+  # the CLI stamps it on Basecamp's refusals and on every failure nothing
+  # classified, which includes the three CLI-local failures the retry loop
+  # exists for (a lost keyring probe surfaces as auth_required; a token
+  # refresh that lost the race as api_error; bc3's 500 is left unclassified
+  # by the SDK). So `false` falls through to the list, which the field can
+  # widen but never narrow. That reading also covers the CLI releases before
+  # the field, whose envelopes carry only ok/error/code/hint/meta.
   #
-  # The list is the fallback for CLIs older than the one that emits the
-  # field, whose envelopes carry only ok/error/code/hint/meta. There the
-  # code and, for `api_error`, the message are all there is to key on.
-  # `api_error` is ambiguous: Basecamp's own 4xx verdicts arrive as one, but
-  # so do three failures to get an answer at all — a token refresh that lost
-  # the keyring race ("token refresh failed: …"), bc3 answering 5xx ("Server
-  # error (500)" surfaces at once; "Gateway error (502|503|504)" and the
-  # generic "API error: 5xx …" are retried inside the SDK for ~3s first and
-  # then surface as "request failed after 3 attempts: …", a prefix the SDK
-  # puts only on retryable failures), and the CLI's own circuit breaker
-  # refusing to ask ("Service temporarily unavailable": file-backed across
-  # processes, open for 30s after five consecutive network/5xx failures).
-  # A rate limit is transient too, in either spelling (the dedicated code
-  # above, or bc3's "rate limit exceeded" body relayed as an api_error):
-  # "not now" is no verdict on the recording, and the account-wide budget
-  # rolls over in seconds — so a webhook defers to redelivery and a poller
-  # to its next (backed-off) tick, rather than recording a drop.
-  # A new spelling belongs in the CLI's flag, not here.
+  # The list names what the field does not: the code and, for `api_error`,
+  # the message. `api_error` is ambiguous: Basecamp's own 4xx verdicts arrive
+  # as one, but so do three failures to get an answer at all — a token
+  # refresh that lost the keyring race ("token refresh failed: …"), bc3
+  # answering 5xx ("Server error (500)" surfaces at once; "Gateway error
+  # (502|503|504)" and the generic "API error: 5xx …" are retried inside the
+  # SDK for ~3s first and then surface as "request failed after 3 attempts:
+  # …", a prefix the SDK puts only on retryable failures), and the CLI's own
+  # circuit breaker refusing to ask ("Service temporarily unavailable":
+  # file-backed across processes, open for 30s after five consecutive
+  # network/5xx failures). A rate limit is transient too, in either spelling
+  # (the dedicated code above, or bc3's "rate limit exceeded" body relayed as
+  # an api_error): "not now" is no verdict on the recording, and the
+  # account-wide budget rolls over in seconds — so a webhook defers to
+  # redelivery and a poller to its next (backed-off) tick, rather than
+  # recording a drop. A spelling the CLI stamps `retryable: true` needs no
+  # entry here; one it leaves at `false` does, until the CLI classifies it.
   TRANSIENT_CODES = %w[auth_required network rate_limit]
   TRANSIENT_API_ERROR = /token refresh|request failed after \d+ attempts?|server error \(500\)|gateway error \(50\d\)|\bAPI error: 5\d\d\b|service temporarily unavailable|rate limit/i
 
@@ -190,17 +196,17 @@ class BasecampAgentConnector::Basecamp::Client
 
     # No envelope at all — the process died before it could answer, or its
     # output was cut off — is the CLI's failure, not Basecamp's answer. An
-    # envelope that carries `retryable` has classified itself; one from an
-    # older CLI is classified by its code and message.
+    # envelope the CLI stamped retryable is retried on its word alone; any
+    # other is classified by its code and message, `retryable: false`
+    # included, since that is where the CLI leaves the failures it never
+    # classified.
     def transient?(parsed)
-      if !envelope?(parsed)
-        true
-      elsif parsed.key?("retryable")
-        parsed["retryable"] == true
-      else
-        code = parsed["code"].to_s
-        TRANSIENT_CODES.include?(code) || (code == "api_error" && parsed["error"].to_s.match?(TRANSIENT_API_ERROR))
-      end
+      !envelope?(parsed) || parsed["retryable"] == true || listed_transient?(parsed)
+    end
+
+    def listed_transient?(parsed)
+      code = parsed["code"].to_s
+      TRANSIENT_CODES.include?(code) || (code == "api_error" && parsed["error"].to_s.match?(TRANSIENT_API_ERROR))
     end
 
     # A successful exit only gets this far when its output didn't parse.

--- a/lib/basecamp_agent_connector/basecamp/client.rb
+++ b/lib/basecamp_agent_connector/basecamp/client.rb
@@ -54,24 +54,31 @@ class BasecampAgentConnector::Basecamp::Client
   ATTEMPTS = 3
   RETRY_DELAYS = [ 0.5, 1.5 ] # seconds before the second and third attempt
 
-  # Error-envelope codes that describe the CLI's plight, not Basecamp's
-  # answer. `api_error` is ambiguous: Basecamp's own 4xx verdicts arrive as
-  # one, but so do three failures to get an answer at all — a token refresh
-  # that lost the keyring race ("token refresh failed: …"), bc3 answering 5xx
-  # ("Server error (500)" surfaces at once; "Gateway error (502|503|504)" and
-  # the generic "API error: 5xx …" are retried inside the SDK for ~3s first
-  # and then surface as "request failed after 3 attempts: …", a prefix the
-  # SDK puts only on retryable failures), and the CLI's own circuit breaker
+  # The CLI's error envelope says outright whether the failure was Basecamp's
+  # answer or the CLI's plight: a top-level boolean `retryable`, the SDK's
+  # own Retryable flag surfaced. It is on every error envelope the CLI
+  # writes (false when the CLI has no positive signal) and never on a
+  # success, and when present it decides — the code and message below are
+  # not consulted.
+  #
+  # The list is the fallback for CLIs older than the one that emits the
+  # field, whose envelopes carry only ok/error/code/hint/meta. There the
+  # code and, for `api_error`, the message are all there is to key on.
+  # `api_error` is ambiguous: Basecamp's own 4xx verdicts arrive as one, but
+  # so do three failures to get an answer at all — a token refresh that lost
+  # the keyring race ("token refresh failed: …"), bc3 answering 5xx ("Server
+  # error (500)" surfaces at once; "Gateway error (502|503|504)" and the
+  # generic "API error: 5xx …" are retried inside the SDK for ~3s first and
+  # then surface as "request failed after 3 attempts: …", a prefix the SDK
+  # puts only on retryable failures), and the CLI's own circuit breaker
   # refusing to ask ("Service temporarily unavailable": file-backed across
   # processes, open for 30s after five consecutive network/5xx failures).
-  # The envelope drops the SDK's Retryable flag, so these fixed messages are
-  # all there is to key on until the CLI emits that flag — the intended end
-  # state, after which this pattern goes.
   # A rate limit is transient too, in either spelling (the dedicated code
   # above, or bc3's "rate limit exceeded" body relayed as an api_error):
   # "not now" is no verdict on the recording, and the account-wide budget
   # rolls over in seconds — so a webhook defers to redelivery and a poller
   # to its next (backed-off) tick, rather than recording a drop.
+  # A new spelling belongs in the CLI's flag, not here.
   TRANSIENT_CODES = %w[auth_required network rate_limit]
   TRANSIENT_API_ERROR = /token refresh|request failed after \d+ attempts?|server error \(500\)|gateway error \(50\d\)|\bAPI error: 5\d\d\b|service temporarily unavailable|rate limit/i
 
@@ -182,13 +189,17 @@ class BasecampAgentConnector::Basecamp::Client
     end
 
     # No envelope at all — the process died before it could answer, or its
-    # output was cut off — is the CLI's failure, not Basecamp's answer.
+    # output was cut off — is the CLI's failure, not Basecamp's answer. An
+    # envelope that carries `retryable` has classified itself; one from an
+    # older CLI is classified by its code and message.
     def transient?(parsed)
-      if envelope?(parsed)
+      if !envelope?(parsed)
+        true
+      elsif parsed.key?("retryable")
+        parsed["retryable"] == true
+      else
         code = parsed["code"].to_s
         TRANSIENT_CODES.include?(code) || (code == "api_error" && parsed["error"].to_s.match?(TRANSIENT_API_ERROR))
-      else
-        true
       end
     end
 

--- a/test/basecamp_client_test.rb
+++ b/test/basecamp_client_test.rb
@@ -143,9 +143,9 @@ class BasecampClientTest < Minitest::Test
     end
   end
 
-  # A CLI that classifies its own failures says so in the envelope, and its
-  # word is final: a code and message the fallback list has never heard of
-  # is retried when the CLI says it is retryable.
+  # A CLI that classifies its own failures says so in the envelope, and a
+  # positive word is taken on its own: a code and message the fallback list
+  # has never heard of is retried when the CLI says it is retryable.
   def test_a_retryable_envelope_is_transient_whatever_its_code
     [
       error_envelope("timeout", "request timed out after 30s", retryable: true),
@@ -163,16 +163,43 @@ class BasecampClientTest < Minitest::Test
     end
   end
 
-  # And the same word says no: an auth_required or a 5xx-shaped api_error
-  # the fallback list would retry is a verdict when the CLI says it is not
-  # retryable — a revoked credential, not the keyring race.
-  def test_an_unretryable_envelope_is_a_verdict_whatever_its_code
+  # `retryable: false` is where the CLI leaves the failures it never
+  # classified, and those include the ones the retry loop exists for: the
+  # keyring race's auth_required and token-refresh api_error (the CLI's
+  # ErrAuth and ErrAPI constructors set no Retryable) and bc3's 500 (the
+  # SDK classifies only 502–504). A false stamp on a listed code or message
+  # must not narrow the list, or the first CLI release that emits the field
+  # turns the race into a dropped event.
+  def test_a_false_retryable_stamp_does_not_narrow_the_fallback_list
     [
       error_envelope("auth_required", "Not authenticated for profile:clawdito: credentials not found", retryable: false),
-      error_envelope("api_error", "request failed after 3 attempts: Gateway error (503)", retryable: false)
+      error_envelope("api_error", "token refresh failed: Post \"https://launchpad.localhost:3011/oauth/token\": connection refused", retryable: false),
+      error_envelope("api_error", "Server error (500)", retryable: false)
     ].each do |stdout|
       runner = FakeCommandRunner.new
-      runner.stub "basecamp show", exit_status: 3, stdout: stdout
+      stub_transient_failure runner, "basecamp show", stdout: stdout, exit_status: 3
+      delays = []
+
+      error = assert_raises(BasecampAgentConnector::Basecamp::Client::TransientError, stdout) do
+        build_cli(runner, wait: ->(seconds) { delays << seconds }).show("https://example.org/recordings/456")
+      end
+
+      assert_equal BasecampAgentConnector::Basecamp::Client::ATTEMPTS, runner.commands_matching(/basecamp show/).length, stdout
+      assert_equal BasecampAgentConnector::Basecamp::Client::RETRY_DELAYS, delays, stdout
+      assert_match(/failed on all 3 attempts/, error.message)
+    end
+  end
+
+  # A false stamp on a code and message the list does not know stays a
+  # verdict — the same reading an older CLI's envelope gets, so this holds
+  # with or without the field.
+  def test_a_false_retryable_stamp_on_an_unlisted_code_is_a_verdict
+    [
+      error_envelope("not_found", "Resource not found: https://example.org/recordings/456.json", retryable: false),
+      error_envelope("api_error", "API error: 410 Gone", retryable: false)
+    ].each do |stdout|
+      runner = FakeCommandRunner.new
+      runner.stub "basecamp show", exit_status: 2, stdout: stdout
       delays = []
 
       error = assert_raises(BasecampAgentConnector::Basecamp::Client::Error, stdout) do

--- a/test/basecamp_client_test.rb
+++ b/test/basecamp_client_test.rb
@@ -121,8 +121,8 @@ class BasecampClientTest < Minitest::Test
 
   # bc3 answering 5xx, or the CLI's own circuit breaker refusing to ask,
   # arrive as api_error too — each with a fixed message from the SDK or the
-  # CLI, since the envelope drops the SDK's Retryable flag. None is a
-  # verdict on the recording.
+  # CLI, which is all an envelope without `retryable` (an older CLI) has to
+  # key on. None is a verdict on the recording.
   def test_a_5xx_or_an_open_circuit_is_transient
     [
       "Gateway error (503)",
@@ -140,6 +140,48 @@ class BasecampClientTest < Minitest::Test
 
       assert_equal BasecampAgentConnector::Basecamp::Client::ATTEMPTS, runner.commands_matching(/basecamp show/).length, message
       assert_includes error.message, message
+    end
+  end
+
+  # A CLI that classifies its own failures says so in the envelope, and its
+  # word is final: a code and message the fallback list has never heard of
+  # is retried when the CLI says it is retryable.
+  def test_a_retryable_envelope_is_transient_whatever_its_code
+    [
+      error_envelope("timeout", "request timed out after 30s", retryable: true),
+      error_envelope("api_error", "upstream reset the connection", retryable: true)
+    ].each do |stdout|
+      runner = FakeCommandRunner.new
+      stub_transient_failure runner, "basecamp show", stdout: stdout, exit_status: 7
+
+      error = assert_raises(BasecampAgentConnector::Basecamp::Client::TransientError, stdout) do
+        build_cli(runner).show("https://example.org/recordings/456")
+      end
+
+      assert_equal BasecampAgentConnector::Basecamp::Client::ATTEMPTS, runner.commands_matching(/basecamp show/).length, stdout
+      assert_match(/failed on all 3 attempts/, error.message)
+    end
+  end
+
+  # And the same word says no: an auth_required or a 5xx-shaped api_error
+  # the fallback list would retry is a verdict when the CLI says it is not
+  # retryable — a revoked credential, not the keyring race.
+  def test_an_unretryable_envelope_is_a_verdict_whatever_its_code
+    [
+      error_envelope("auth_required", "Not authenticated for profile:clawdito: credentials not found", retryable: false),
+      error_envelope("api_error", "request failed after 3 attempts: Gateway error (503)", retryable: false)
+    ].each do |stdout|
+      runner = FakeCommandRunner.new
+      runner.stub "basecamp show", exit_status: 3, stdout: stdout
+      delays = []
+
+      error = assert_raises(BasecampAgentConnector::Basecamp::Client::Error, stdout) do
+        build_cli(runner, wait: ->(seconds) { delays << seconds }).show("https://example.org/recordings/456")
+      end
+
+      refute_kind_of BasecampAgentConnector::Basecamp::Client::TransientError, error, stdout
+      assert_equal 1, runner.commands_matching(/basecamp show/).length, stdout
+      assert_empty delays, stdout
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -206,8 +206,10 @@ module PayloadHelpers
   # The CLI's `-j` failure envelope, printed on stdout with a nonzero exit
   # (verified against production: `basecamp show <missing> -j` exits 2 with
   # {"ok": false, "error": "Resource not found: ...", "code": "not_found"}).
-  def error_envelope(code, error = code.tr("_", " "))
-    JSON.generate("ok" => false, "error" => error, "code" => code)
+  # A CLI that classifies its own failures adds a boolean `retryable`; the
+  # default, without one, is the envelope of a CLI older than that.
+  def error_envelope(code, error = code.tr("_", " "), **fields)
+    JSON.generate({ "ok" => false, "error" => error, "code" => code }.merge(fields.transform_keys(&:to_s)))
   end
 
   # Stubs a command to fail transiently on every attempt the client makes,

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -206,8 +206,9 @@ module PayloadHelpers
   # The CLI's `-j` failure envelope, printed on stdout with a nonzero exit
   # (verified against production: `basecamp show <missing> -j` exits 2 with
   # {"ok": false, "error": "Resource not found: ...", "code": "not_found"}).
-  # A CLI that classifies its own failures adds a boolean `retryable`; the
-  # default, without one, is the envelope of a CLI older than that.
+  # A CLI that classifies its own failures adds a boolean `retryable` (pending
+  # in basecamp-cli); the default, without one, is the envelope of every
+  # release before that.
   def error_envelope(code, error = code.tr("_", " "), **fields)
     JSON.generate({ "ok" => false, "error" => error, "code" => code }.merge(fields.transform_keys(&:to_s)))
   end


### PR DESCRIPTION
Follow-up from #18's Follow-ups: the transient classifier in `Basecamp::Client` takes the CLI's own word when the CLI has one — in the one direction the CLI can actually give it.

## What

The CLI's `-j` error envelope is gaining a top-level boolean `retryable` — the SDK's `Retryable` flag surfaced (pending in basecamp-cli, on the `emit-retryable-in-error-envelope` branch; no released CLI emits it yet, the installed 0.9.1 included). Its contract: present on every error envelope, never on a success; `true` when the CLI classified the failure transient, `false` for a verdict **and for any failure nothing classified**.

`Client#transient?` reads it additively:

- `retryable: true` → retried up to `ATTEMPTS`, then `TransientError` (bridge answers 503, bc3 redelivers), whatever the code or message.
- `retryable: false` or absent → the existing `TRANSIENT_CODES` / `TRANSIENT_API_ERROR` list applies unchanged.

So the field widens the transient set but never narrows it. The list stays, names what the field does not, and stops growing for spellings the CLI stamps `true`.

## Why

The list was a spelling table for a fact the CLI already held and discarded: a failure the CLI knows is retryable but spells in a way the list never learned surfaced as Basecamp's verdict — the delivery answered 200 and the event dropped. `retryable: true` closes that.

The other direction is not available. In the CLI, `ErrAuth` and `ErrAPI` set no `Retryable`, and the SDK classifies only 502–504 — so the three CLI-local failures the retry loop exists for all arrive as `retryable: false`: the lost keyring probe (`auth_required`), a token refresh that lost the race (`api_error` "token refresh failed"), and bc3's `Server error (500)`. The CLI cannot tell the race from a revoked credential, and stamps both `false`. Reading `false` as a verdict would turn the race into a dropped event on the first CLI upgrade that ships the field.

## Tests

- `test_a_retryable_envelope_is_transient_whatever_its_code`: `timeout` and an unlisted `api_error` message, `retryable: true` → `ATTEMPTS` invocations, `TransientError`. Fails against `origin/main`'s `client.rb` (checked: `Error` after one attempt).
- `test_a_false_retryable_stamp_does_not_narrow_the_fallback_list`: the race's `auth_required`, `token refresh failed`, and `Server error (500)`, each `retryable: false` → `ATTEMPTS` invocations, `RETRY_DELAYS` waited, `TransientError`. Fails against the previous head's verdict-on-false `client.rb` (checked: one attempt, plain `Error`).
- `test_a_false_retryable_stamp_on_an_unlisted_code_is_a_verdict`: `not_found` and `API error: 410 Gone`, `retryable: false` → one invocation, no delays, `Error` not `TransientError`. Same reading an older CLI's envelope gets, so it holds with or without the fix; it pins the fall-through against a future "false decides" rewrite.
- Absent key: every existing classifier test is untouched (`test_helper#error_envelope` without `retryable:` is the older-CLI envelope; `stub_transient_failure` keeps that default).
- `bundle exec rake test`: 257 runs, 835 assertions, 0 failures. `bundle exec rubocop lib test`: no offenses.

## Declined

- **Let `retryable: false` decide (the first revision of this PR).** The CLI's `false` means "no positive signal", not "verdict": it is stamped on the keyring race, the refresh failure and bc3's 500 (see Why), so trusting it drops the events #18 exists to redeliver. It also buys nothing on the revoked-credential side, since race and revocation get the same `false`. Reinstate only once the CLI stamps the race path `Retryable: true` or the race is gone (`basecamp/cli#70`).
- **Gate the merge on the CLI change.** Not needed with additive semantics: an envelope without the field behaves exactly as before, and one with it can only add retries.
- **Retire the list now.** The connector shells out to whatever `basecamp` is installed; no released binary emits the field, and even the one that will leaves the race and the 500 at `false`.
- **Fall back to the list when `retryable` is present but not a boolean.** `parsed["retryable"] == true` already does: anything but `true` falls through to the list, the same reading `false` gets.
- **Treat `retryable` on a success envelope.** Never emitted there and never consulted: `transient?` only runs on a failed or unparseable result.
- **Versioning the fallback on `basecamp --version` instead of key presence.** Presence is the exact signal; a version floor is a second thing to keep in step with the CLI.

## Follow-ups

- `auth_required` leaves `TRANSIENT_CODES`, and `token refresh` / `server error (500)` leave `TRANSIENT_API_ERROR`, when the CLI stamps those paths `retryable: true` or stops emitting the race (`basecamp/cli#70`'s per-probe keychain item). That is a CLI-side fact to verify per release, not a connector assumption.
