### PR TITLE
Spec the ack as the front thread's, not the dispatched agent's

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -15,8 +15,9 @@ The bridge has two halves:
    webhook, filters + verifies incoming events, and prints trusted events to
    STDOUT.
 2. **`/basecamp-connect` skill** — a Claude Code skill that runs the script, watches its
-   STDOUT, and dispatches each trusted event to an in-session background agent
-   with full Basecamp context attached.
+   STDOUT, acknowledges each trusted event with an `On it!` boost as the agent
+   within seconds of receipt, and hands it to an in-session background agent
+   that gathers the Basecamp context and does the work.
 
 ## Why this shape
 
@@ -60,7 +61,8 @@ non-admin viewers** (`Person#can_see_email_address_of?` is self-or-admin), so
 a feed fetched as the (non-admin) agent shows every other author as
 `j••••@••••.•••` — there the Person id is the only usable key. The mention
 match looks for a mention attachment (`application/vnd.basecamp.mention`)
-naming the agent.
+whose SGID carries the agent's Person id — never the display name, which is
+not unique.
 
 ---
 
@@ -329,33 +331,87 @@ not just runtime glue.
 
 ### Behavior
 
+The skill's session thread — the **front thread** — is an orchestrator, not a
+worker: it watches, acknowledges, and dispatches. Everything that reads
+Basecamp beyond the event line, or touches a repo, belongs to the dispatched
+agent. The split exists because an ack that lives in the dispatched agent's
+list drifts whenever the front thread drifts into working the event itself,
+and a mention received in seconds but unacknowledged for half an hour is
+indistinguishable from a missed one (connector PR #17).
+
 1. **Launch the bridge** — run `bin/connect @Clawdito --project ...`
    and tail its STDOUT. The skill watches continuously until the user stops it
    (which triggers the teardown above).
-2. **Per trusted event** (one NDJSON line):
-   a. **Resolve working repo** — infer the local repo from the project name. Basecamp
+2. **Per trusted event** (one NDJSON line), the front thread routes by the line
+   itself. A line carrying `review_id`/`repo`/`state` and no `recording` is a
+   **GitHub review** (`--repo` runs; see [`pr-review-loop.md`](pr-review-loop.md)):
+   no boost, no bucket lookup — it is dispatched straight to the review loop in
+   the repo named by `repo`, and an `approved` review is dispatched as an
+   approval that may land the PR only when `reviewer` is the operator's GitHub
+   login; any other reviewer's approval is handled as `commented`. The skill
+   carries that gate because `GitHub::ReviewPipeline#actionable?` checks only
+   the action and the state today. A line carrying `recording` is a Basecamp
+   event; one the agent itself authored is dropped before anything else. For
+   every other Basecamp event the front thread runs exactly this checklist:
+   a. **Acknowledge** — `basecamp boost create <recording.url> "On it!"
+      --profile <agent>` on receipt, before repo resolution and before
+      dispatch, so the ack lands within seconds regardless of what dispatch
+      does. It is the single ack for every directive trigger — mentions,
+      assignments, and Campfire lines (boost the line). Exactly two kinds of
+      event get **no** boost: a comment on a subscribed thread (a
+      `comment_created` whose content carries no mention attachment with the
+      agent's Person id) and a `boost_created` event. Retry the call only on
+      the two failures that occur before any request is sent —
+      `Not authenticated for profile:` and `token refresh failed:`, the
+      credential-store failure the CLI shows under concurrent invocations —
+      a few times with a short pause; any other failure may already have
+      landed the boost, so it is not retried. Whether the boost verifiably
+      landed is recorded for the handoff.
+   b. **Resolve working repo** — infer the local repo from the project name. Basecamp
       project names carry an app token (e.g. a `BC5 …` project → the Basecamp
       repo under `~/Work/<org>/<repo>`). A configurable mapping table backs the
       heuristic. **If the project can't be mapped to a repo, ask the user
       interactively** which repo to use (do not guess, do not silently fall
-      back).
+      back). An ack must never precede an indefinite silence: before stopping
+      to ask — or when the dispatch in *c* fails — the front thread posts one
+      **holding reply** as the agent that @mentions the requester, saying the
+      event is received but held and why. It is the only reply the front
+      thread ever posts, and only on directive triggers.
+   c. **Dispatch an in-session background agent** that owns the event
+      end-to-end, running in the resolved repo. The handoff carries the
+      instruction — the recording's **raw HTML content with the agent mention
+      removed** (the rest of the markup — links, other mentions — kept intact)
+      — the recording and parent URLs, the agent profile, the requester
+      (the event `creator`), and whether the front thread's boost landed.
+      Agents appear in the current Claude session. **No concurrency cap** —
+      every trusted event is dispatched immediately.
+   d. **Return to the monitor.** The front thread never reads the recording,
+      gathers context, investigates, runs repo commands, does the work, or
+      posts the reply.
+3. **The dispatched agent**, in order:
+   a. **Fallback boost** — only when the handoff says the front thread's boost
+      did not land, post the same `On it!` boost, without listing the
+      recording's boosts first. A front-thread call that Basecamp accepted
+      but reported as failed then yields a second `On it!`; that is accepted —
+      a rare duplicate reaction over a missing ack — because a check-first
+      listing can fail the same transient way and would have to decide which
+      earlier event an older `On it!` on the same recording belonged to. The
+      same two exceptions apply: subscribed-thread comments and
+      `boost_created` events are never boosted.
    b. **Gather context** — pull the surrounding Basecamp context with the
       `basecamp` CLI: the recording itself, its `parent` (card/message), the
       thread/comments, and the project. Basecamp is the context store; the event
       is the trigger + pointer.
-   c. **Dispatch an in-session background agent** — hand the instruction plus the
-      gathered context to a background agent running in the resolved repo. The
-      instruction is the recording's **raw HTML content with the agent mention
-      removed** (the rest of the markup — links, other mentions — kept intact).
-      Agents appear in the current Claude session. **No concurrency cap** — every
-      trusted event is dispatched immediately.
+   c. **Do the work**, posting one short interim reply as the agent when it
+      runs past roughly ten minutes (what it is doing, where to follow — the PR
+      link once it exists, marked in progress, never done).
    d. **Reply as the agent** — post results to the originating recording with
       `basecamp comment <recording> "<body>" --profile <agent>` so the reply is
       authored by the agent user:
       - **Success** — a results comment where the mention was written.
       - **Failure** (agent errors / can't complete) — a short error summary
-        comment that **@mentions the operator (event creator)** so it surfaces as
-        a notification. You always learn when a dispatch failed.
+        comment that **@mentions the requester (event creator)** so it surfaces
+        as a notification. You always learn when a dispatch failed.
       Replying as the agent (a distinct user from the operator) is what stops the
       reply from re-triggering the connector.
 
@@ -531,19 +587,34 @@ Coverage the suite must include:
   its current `assignees` (the recording has no "who assigned" field, so the
   assigner identity rests on the operator-author check + the secret URL path,
   as with mentions). To receive them, the default subscribed types now include
-  `Todo` and `Kanban::Step` (`Kanban::Card` already covered cards). The dispatched
-  agent acknowledges by **boosting** the recording with `On it!` (the single ack
-  for both triggers — boosts work on todos and cards too), then works the
-  card/todo as the instruction.
+  `Todo` and `Kanban::Step` (`Kanban::Card` already covered cards). The
+  assignment is acknowledged by the same `On it!` boost as a mention (boosts
+  work on todos and cards too); the dispatched agent then works the card/todo
+  as the instruction.
+- Ack: the **front thread** boosts the recording `On it!` as the agent on
+  receipt — before repo resolution and dispatch — retrying only the two
+  pre-request credential failures (`Not authenticated for profile:`, `token
+  refresh failed:`). The dispatched agent boosts only as a fallback, when the
+  handoff says the front thread's boost did not land, and without listing
+  first: a rare duplicate reaction is accepted over a missing ack.
+  Subscribed-thread comments and `boost_created` events get no boost from
+  either (connector PR #17).
 - Reply: post results back **as the agent** (`basecamp comment --profile
-  <agent>`). On failure, post an error summary that @mentions the operator.
-- Dedup: in-memory, keyed on `event.id`; 200 once settled, 503 to ask for
-  redelivery.
+  <agent>`). On failure, post an error summary that @mentions the requester
+  (the event creator — under a broadened trust mode not necessarily the
+  operator).
+- Dedup: in-memory, keyed on `event.id`; 200 once settled (emitted, dropped,
+  or a duplicate), 503 only when Basecamp could not be asked — a transient CLI
+  failure that outlasts `Basecamp::Client`'s own retries — so bc3's delivery
+  job redelivers with backoff instead of settling a real mention as
+  uncorroborated (connector PR #18). A delivery is never answered before its
+  verdict.
 - Working dir: infer from project name (app token → repo); **ask interactively**
   on miss.
 - Triggers: both `*_created` and `*_content_changed`.
-- Mention match: a mention attachment (`application/vnd.basecamp.mention`) naming
-  the agent — not a plain-text token.
+- Mention match: a mention attachment (`application/vnd.basecamp.mention`)
+  whose SGID carries the agent's Person id — not a plain-text token, and not
+  the display name, which is not unique.
 - Instruction form: raw HTML content with the agent mention removed.
 - Scope: `--project` is required (BC3 has no global webhook); repeatable for
   several projects. One funnel + one server + one secret path; one webhook

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -15,8 +15,9 @@ The bridge has two halves:
    webhook, filters + verifies incoming events, and prints trusted events to
    STDOUT.
 2. **`/basecamp-connect` skill** — a Claude Code skill that runs the script, watches its
-   STDOUT, acknowledges each trusted event with an `On it!` boost as the agent
-   within seconds of receipt, and hands it to an in-session background agent
+   STDOUT, acknowledges each **directive** event — a mention, an assignment, a
+   Campfire line — with an `On it!` boost as the agent within seconds of
+   receipt, and hands every trusted event to an in-session background agent
    that gathers the Basecamp context and does the work.
 
 ## Why this shape
@@ -351,8 +352,11 @@ indistinguishable from a missed one (connector PR #17).
    login; any other reviewer's approval is handled as `commented`. The skill
    carries that gate because `GitHub::ReviewPipeline#actionable?` checks only
    the action and the state today. A line carrying `recording` is a Basecamp
-   event; one the agent itself authored is dropped before anything else. For
-   every other Basecamp event the front thread runs exactly this checklist:
+   event; one whose `creator` is the agent is dropped before anything else.
+   `creator` is the only checkable key — the emitted `recording` carries no
+   author, and a `boost_created` line's `recording` is the agent's own work by
+   definition, which is not what this test reads. For every other Basecamp
+   event the front thread runs exactly this checklist:
    a. **Acknowledge** — `basecamp boost create <recording.url> "On it!"
       --profile <agent>` on receipt, before repo resolution and before
       dispatch, so the ack lands within seconds regardless of what dispatch
@@ -378,11 +382,20 @@ indistinguishable from a missed one (connector PR #17).
       event is received but held and why. It is the only reply the front
       thread ever posts, and only on directive triggers.
    c. **Dispatch an in-session background agent** that owns the event
-      end-to-end, running in the resolved repo. The handoff carries the
-      instruction — the recording's **raw HTML content with the agent mention
-      removed** (the rest of the markup — links, other mentions — kept intact)
-      — the recording and parent URLs, the agent profile, the requester
-      (the event `creator`), and whether the front thread's boost landed.
+      end-to-end, running in the resolved repo. The handoff carries the event
+      `kind`, the instruction as that kind defines it, the recording and
+      parent URLs, the agent profile, the requester (the event `creator`), and
+      whether the front thread's boost landed. The instruction per trigger:
+      - **mention** (comment, message, Campfire line) — the recording's **raw
+        HTML content with the agent mention removed** (the rest of the markup
+        — links, other mentions — kept intact);
+      - **assignment** (`*_assignment_changed`) — the recording itself; the
+        card/todo's `title`/`content` is the task, and there is no mention to
+        strip;
+      - **`boost_created`** — `details.boost.content` (the signal) plus the
+        boosted `recording`, which has no `content` in this representation;
+      - **subscribed-thread comment** — the comment as context on a followed
+        thread, not a directive.
       Agents appear in the current Claude session. **No concurrency cap** —
       every trusted event is dispatched immediately.
    d. **Return to the monitor.** The front thread never reads the recording,
@@ -402,18 +415,27 @@ indistinguishable from a missed one (connector PR #17).
       `basecamp` CLI: the recording itself, its `parent` (card/message), the
       thread/comments, and the project. Basecamp is the context store; the event
       is the trigger + pointer.
-   c. **Do the work**, posting one short interim reply as the agent when it
-      runs past roughly ten minutes (what it is doing, where to follow — the PR
-      link once it exists, marked in progress, never done).
-   d. **Reply as the agent** — post results to the originating recording with
-      `basecamp comment <recording> "<body>" --profile <agent>` so the reply is
-      authored by the agent user:
+   c. **Do the work** a directive trigger asks for, posting one short interim
+      reply as the agent when it runs past roughly ten minutes (what it is
+      doing, where to follow — the PR link once it exists, marked in progress,
+      never done).
+   d. **Reply as the agent** on a directive trigger — post results to the
+      originating recording with `basecamp comment <recording> "<body>"
+      --profile <agent>` so the reply is authored by the agent user:
       - **Success** — a results comment where the mention was written.
       - **Failure** (agent errors / can't complete) — a short error summary
         comment that **@mentions the requester (event creator)** so it surfaces
         as a notification. You always learn when a dispatch failed.
       Replying as the agent (a distinct user from the operator) is what stops the
       reply from re-triggering the connector.
+   e. **Non-directive events are read, not worked.** A subscribed-thread
+      comment and a `boost_created` signal are dispatched the same way but
+      default to silence: no interim reply, no results comment, no card moves.
+      The agent replies only when a response adds value — a question it can
+      answer on the followed thread, or a corrective boost (`redo`, `wrong`,
+      `👎`) that sends it back to the boosted work; an approving boost (`👍`,
+      `🔥`) is applause and gets nothing. Both policies are provisional until
+      real traffic tunes them.
 
 ---
 

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -296,8 +296,10 @@ watching for new mentions, acknowledge each one, and dispatch it.
   background agent in that repo to handle it per *Review / approval loop*
   below, and return to the monitor.
 - A line carrying `recording` is a **Basecamp event** — the checklist below.
-  Drop it outright if the recording is a comment the agent itself authored
-  (`bin/connect` already refuses agent-authored events in every trust mode, and
+  Drop it outright if its `creator` is the agent — the only checkable key: the
+  emitted `recording` carries no author, and a `boost_created` line's
+  `recording` is the agent's own work by definition, which is not what this
+  test reads (`bin/connect` already refuses agent-authored events in every trust mode, and
   posting as the agent — a distinct user from the operator — keeps replies
   from authorizing anyway; this is cheap defense in depth, and it comes
   *before* the boost so a slipped-through self-comment is never acked).
@@ -416,8 +418,13 @@ acked task nobody holds.
 tool with `run_in_background: true`, running in the resolved repo. Give it
 everything it needs to finish **without the front thread**:
 
-- the **instruction** — `recording.content` with the agent mention removed, the
-  rest of the raw HTML (links, other mentions) intact;
+- the event **`kind`** and the **instruction** as that kind defines it: for a
+  mention, `recording.content` with the agent mention removed, the rest of the
+  raw HTML (links, other mentions) intact; for an assignment, the recording
+  itself (its `title`/`content` is the task); for a `boost_created`,
+  `details.boost.content` plus the boosted recording, which carries no
+  `content`; for a subscribed-thread comment, the comment as context, not a
+  directive;
 - the **recording** URL/id and its parent URL;
 - the **agent profile name** (its reply identity);
 - the **requester's** name/id — i.e. the event `creator` (to @mention on
@@ -506,7 +513,7 @@ should, in order:
    instruction; gather context and resolve the repo as usual; if it's a PR task,
    follow the green-first lifecycle below).
 4. **Reply with the result** on the same recording as the agent — and on failure,
-   a short error summary that @mentions the operator.
+   a short error summary that @mentions the requester (the event `creator`).
 
 The instruction here is the **card/todo content**, not a comment body. Everything
 else (resolve repo, one background agent owns it end-to-end, front thread returns


### PR DESCRIPTION
## What was stale

`docs/spec.md` still described the acknowledgement the way the skill worked before #17: the *dispatched* agent boosts the recording `On it!` (Component 2 step list; Decisions resolved → Assignment trigger). #17 moved the boost to the front thread because an ack that lives in the dispatched agent's list drifts whenever the orchestrator drifts into working the event itself — a mention received in 2 seconds went unacknowledged for 30+ minutes. #17's own body deferred the spec ("Editing `docs/spec.md`, which still says the dispatched agent acks … left for a follow-up"). This is that follow-up. Docs only — no code, no test changes. Review round 1 widened it to three one-paragraph edits in `skills/basecamp-connect/SKILL.md` where the operative doc carried the same divergence (see *What changed → SKILL.md*).

## What changed (`docs/spec.md`)

- **Purpose** — the skill acknowledges each trusted event with an `On it!` boost within seconds of receipt, then hands it to a background agent that gathers context and does the work.
- **Component 2 → Behavior**, rewritten to match the merged skill (#17):
  - the front thread is an orchestrator, not a worker: boost → resolve repo → dispatch → return to the monitor; it never reads the recording, gathers context, or runs repo commands;
  - routes by the event line first: a GitHub review line (`review_id`/`repo`/`state`, no `recording`) gets no boost and no bucket lookup, and an `approved` review dispatches as an approval only when `reviewer` is the operator's GitHub login — stated together with why the skill carries that gate (`GitHub::ReviewPipeline#actionable?` checks only action and state today);
  - the boost is retried only on the two pre-request credential failures (`Not authenticated for profile:` / `token refresh failed:`); anything else may have landed and is not retried;
  - exactly two kinds of event get no boost: subscribed-thread comments (no mention attachment carrying the agent's Person id) and `boost_created`;
  - the holding reply before the front thread blocks on repo resolution or a failed dispatch;
  - the handoff carries whether the boost landed; the dispatched agent boosts only as a fallback, without listing first — a rare duplicate reaction is accepted over a missing ack;
  - the dispatched agent's ~10-minute interim reply; the failure reply @mentions the requester (event creator), not "the operator".
- **Identity model / Decisions → Mention match** — the mention attachment's SGID carries the agent's Person id; never the display name, which is not unique (#17 states the discriminator this way; the connector's `Event#mentioned_person_ids` matches the same way).
- **Decisions → Assignment trigger / new Ack bullet / Reply** — the ack decision stated once, with its exceptions and the accepted duplicate; the assignment bullet no longer says the dispatched agent acks; the failure reply goes to the requester.
- **Decisions → Dedup** — names the #18 contract: 200 once settled, 503 only when Basecamp could not be asked after `Basecamp::Client`'s own retries, so bc3 redelivers instead of settling a real mention as uncorroborated; a delivery is never answered before its verdict.

- **Review round 1** (Copilot + Codex, and the reviewer findings):
  - **Purpose** now names the boosted set as the *directive* triggers (mention, assignment, Campfire line); every trusted event is still handed to a background agent. Before, the top-level promise contradicted the two exceptions (subscribed-thread comments, `boost_created`) and the GitHub review lines stated three times below it.
  - **Self-authored drop** keys on the top-level `creator`, stated as the only checkable key: the emitted `recording` carries no author (`EMITTED_RECORDING_FIELDS`), and on a `boost_created` line the recording *is* the agent's work, so "one the agent itself authored" read literally would drop every boost trigger. Matches `Authorizer#agent_authored?`.
  - **Handoff (2c)** carries the event `kind` and the instruction per trigger: mention → `recording.content` minus the mention; assignment → the recording itself (card/todo `title`/`content`); `boost_created` → `details.boost.content` plus the boosted recording (which has no `content` in this representation); subscribed-thread comment → context, not a directive. The universal "content minus mention" left a boost agent with an empty instruction.
  - **Dispatched agent (3c/3d)** — do-the-work, the ~10-minute interim reply and the results reply are scoped to directive triggers; new **3e** states the read-not-worked default for followed-thread comments and boosts (reply only when it adds value; corrective boost → back to the work; approving boost → nothing), mirroring the skill's two provisional policies the spec never described.

### `skills/basecamp-connect/SKILL.md`

Three edits, each closing a divergence the spec true-up would otherwise have written down as a follow-up:

- step 2 self-authored drop: "the recording is a comment the agent itself authored" → "its `creator` is the agent", with the same reason as the spec (the only checkable key; a `boost_created` recording is the agent's work by definition);
- step 2c dispatch list: the instruction bullet now carries `kind` and the per-trigger instruction (the per-kind sections below already read `details.boost.content` and the card/todo, but the handoff list only ever named `recording.content`);
- assignment section step 4: failure reply @mentions the requester (the event `creator`), not "the operator" — #17 moved the mention path (step 5) and the PR-lifecycle path to the requester and missed this one; under `--allow-assignments-from-authorized` the coworker who assigned the card never learned it failed.

Because `SKILL.md` changed, the installed snapshot needs `npx skills update -g` after this merges (AGENTS.md).

## Swept and found current

- README flow diagram and driver summary (front-thread boost, #17), README step 5 and spec §7 Listen + the dedup step (verdict / 503 / 10-attempt deactivation remedy, #18) — already updated by those PRs.
- `docs/pr-review-loop.md:99` "respond 200 fast" is the **GitHub** bridge, which still answers 200 at once (#18 left it that way) — accurate, untouched.
- The event-shape section (`## Emitted event format` and the payload reference) is untouched: another change is adding `agent_subscribed` there.

## Declined

- **Copying the skill's followed-thread and boost sections into the spec.** Round 1 asked for the two non-directive policies to be stated; the spec gets one step (3e) with the default and the valence rule, and the operative judgment (which signals count as corrective, when a followed thread is "taken on") stays in `SKILL.md`, which marks both policies provisional.
- **Fixing the Purpose by dropping the ack sentence.** The ack within seconds is the point of #17 and belongs at the top; qualifying the set is the fix, not removing the promise.

- **Copying the skill's retry snippet and full checklist into the spec.** The spec states the contract (which two failures retry, why nothing else does, who owns the fallback); the operative instruction with the shell loop stays in `SKILL.md`, so the two cannot drift on wording.
- **Annotating `docs/pr-review-loop.md#trust` with "not enforced yet".** The gap is `GitHub::ReviewPipeline#actionable?`, a connector follow-up already named in #17; the spec's Component 2 now records that the skill carries the gate in the meantime. Editing the design doc to describe a code gap would need reverting when the code catches up.
- **Fixing the pre-existing email-only wording in the pipeline pre-filter (`creator.email_address matches the operator … Email, not id`) and the payload reference (`email_address is the match key`).** Those contradict the Identity model section (email *or* Person id), but the drift predates #17/#18 (it dates to the boost poller); left for a separate docs pass so this PR stays a #17/#18 true-up.

## Verification

`bundle exec rake test`: 254 runs, 802 assertions, 0 failures (unchanged; no behaviour changed, so no regression test — the tests cover `bin/connect`, not the skill text). Markdown only. Every relative link and anchor in `docs/spec.md` and `README.md` resolves (`pr-review-loop.md`, `#trust-modes` ×4, `config/project_repos.toml`, `docs/spec.md`, `LICENSE.txt`); Component 2 re-read top to bottom; the diff is `docs/spec.md` and `skills/basecamp-connect/SKILL.md` only (`git diff --stat`).

