### PR TITLE
Emit a PR approval only when the operator's GitHub login gave it

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ onto one funnel path, so the same `@agent` watches every listed project simultan
 - `--project` takes a **name, URL, or ID** — the CLI resolves it.
 - Watch GitHub PR reviews too, over the **same** server: add `--repo <owner>/<repo>`
   (repeatable). You need at least one `--project` or `--repo`; `--project` also
-  needs an `@agent`.
+  needs an `@agent`. Only **your** approvals (the login `gh` is signed in as, or
+  `--gh-operator <login>`) reach the agent as `approved`; anyone else's approval
+  is dropped, while their requested changes and comments still come through.
 
 ### Stopping (and why it matters)
 
@@ -315,6 +317,7 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
 | `@AGENT` | Agent user / local `basecamp` profile to watch for and reply as. Leading `@` optional; lowercased to the profile name. **Required**, validated at startup. | — |
 | `--project` | Basecamp project name, URL, or ID. **Required**, repeatable. | — |
 | `--operator` | Profile whose user is allowed to trigger. | CLI default profile |
+| `--gh-operator` | GitHub login whose PR approvals are actionable (with `--repo`). Any other reviewer's `approved` review is dropped; `changes_requested` and `commented` pass from anyone. | the login `gh` is authenticated as |
 | `--trust` | Trust mode: `operator`, `allowlist`, `project`, or `domain`. Usually inferred from the value flags below. | `operator` |
 | `--allow` | Author email to trust (repeatable or comma-separated). Implies `--trust allowlist`. | — |
 | `--allow-domain` | Email domain to trust (repeatable or comma-separated). Implies `--trust domain`. | `37signals.com` under bare `--trust domain` |
@@ -331,7 +334,10 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
 1. **Resolve agent & operator.** Validates the agent name maps to a usable local
    profile (`basecamp me --profile <agent>`); if not, it aborts with
    `Run basecamp auth login --profile <agent>…`. Resolves the operator identity
-   (refreshing an expired token once). Warns if agent == operator.
+   (refreshing an expired token once). Warns if agent == operator. With
+   `--repo`, also resolves the operator's GitHub login (`gh api user`, or
+   `--gh-operator`) — the only reviewer whose PR approvals are emitted — and
+   aborts with `Run gh auth login, or pass --gh-operator LOGIN` if it can't.
 2. **Open the endpoint.** Starts a WEBrick server on `127.0.0.1:<port>` that only
    accepts `POST /bc5/<random-secret>`; everything else is 404. One server + one
    secret path serves every watched project.

--- a/docs/pr-review-loop.md
+++ b/docs/pr-review-loop.md
@@ -15,6 +15,7 @@ alongside (or instead of) Basecamp `--project`:
 ```bash
 bin/connect @Clawdito --project "BC5 Calendar" --repo basecamp/bc3   # both at once
 bin/connect --repo basecamp/bc3 --repo acme/widgets                  # GitHub only
+bin/connect --repo acme/widgets --gh-operator marie                  # approvals by @marie, not this machine's gh login
 ```
 
 It registers a `pull_request_review` webhook on each repo (against the shared
@@ -72,6 +73,24 @@ on API re-fetch). So this side gets **both**: verify the signature on receipt,
 then corroborate by re-fetching the review via the API. Only the operator's
 repos and only the operator's approvals are actionable.
 
+The signature proves GitHub sent the delivery, not that the reviewer may merge.
+An emitted `approved` review is what lets the dispatched agent land the PR, so
+`ReviewPipeline` admits an approval only when its reviewer is the **operator's
+GitHub login** — every other reviewer's approval is dropped (logged to STDERR,
+never emitted), exactly as the Basecamp side drops an unauthorized author
+rather than emitting a flagged event. `changes_requested` and `commented`
+reviews are feedback to address, not authority to merge, so they pass from any
+reviewer. The gate runs twice: on the delivery body as a cheap pre-filter, and
+again on the review re-fetched from the API, so the decision binds to the
+`user.login` GitHub recorded, not to the POST body. Logins compare
+case-insensitively, as GitHub does.
+
+The operator's login is the one this machine's `gh` is authenticated as
+(`gh api user`), resolved once at startup; `--gh-operator <login>` names
+another login instead, without consulting `gh`. The bridge logs the active set
+with the other startup lines: `Trust: approvals from @<login> only; …`. A
+signed-out `gh` with no `--gh-operator` aborts startup.
+
 ## Connector plumbing (parallels the Basecamp side)
 
 The top-level `Connector` owns the one funnel + one server and mounts each
@@ -102,7 +121,8 @@ The flow, per delivery:
    reject otherwise — `GitHub::WebhookSignature`.
 4. **Re-fetch + emit** the whole review as one NDJSON event (review id, action,
    state, repo, PR number, reviewer, body, inline comments) — `GitHub::ReviewVerifier` +
-   `Emitter`.
+   `Emitter`. An `approved` review is emitted only when the re-fetched
+   reviewer is the operator's GitHub login — `GitHub::ReviewPipeline`.
 5. **Tear down** the repo webhook on `SIGINT`/`SIGTERM`, like the Basecamp
    webhooks and the funnel.
 
@@ -123,7 +143,8 @@ orchestrator/worker split as the Basecamp flow):
 - **`changes_requested` / `commented`** → re-fetch the full review, address it in
   the task's worktree, re-green (`bin/ci` local + `gh pr checks --watch` remote),
   push, and reply.
-- **`approved`** → land per the repo's policy, reply done.
+- **`approved`** → land per the repo's policy, reply done. Only the operator's
+  approvals reach the agent; the connector drops everyone else's.
 
 ## Open questions
 

--- a/docs/pr-review-loop.md
+++ b/docs/pr-review-loop.md
@@ -135,6 +135,11 @@ The flow, per delivery:
  "comments":[{"path":"lib/x.rb","line":3,"body":"rename this"}]}
 ```
 
+`state` is always the lowercase form above. GitHub's webhook delivers it
+lowercase but the REST re-fetch returns `APPROVED` / `CHANGES_REQUESTED` /
+`COMMENTED`; `ReviewEvent` normalizes both, so the reviewer gate and the
+emitted line read the same value.
+
 ## What the dispatched agent does
 
 Per emitted review event, the front thread dispatches a fresh agent (same

--- a/lib/basecamp_agent_connector/connector.rb
+++ b/lib/basecamp_agent_connector/connector.rb
@@ -49,9 +49,10 @@ class BasecampAgentConnector::Connector
       parser.on("--repo OWNER/REPO", "GitHub repo to watch for reviews (repeatable)") { |value| repos << value }
       parser.on("--operator PROFILE", "Profile whose user is allowed to trigger (default: CLI default profile)") { |value| operator = value }
       parser.on("--gh-operator LOGIN", "GitHub login whose PR approvals are actionable (default: the login `gh` is authenticated as)") do |value|
-        raise ArgumentError, "--gh-operator needs a GitHub login" if value.strip.empty?
+        login = value.strip.delete_prefix("@")
+        raise ArgumentError, "--gh-operator needs a GitHub login" if login.empty?
 
-        gh_operator = value.strip
+        gh_operator = login
       end
       parser.on("--trust MODE", TRUST_MODES, "Who may trigger the agent: #{TRUST_MODES.join(", ")} (default: operator only; " \
         "value flags below imply their mode)") do |value|

--- a/lib/basecamp_agent_connector/connector.rb
+++ b/lib/basecamp_agent_connector/connector.rb
@@ -15,7 +15,7 @@ class BasecampAgentConnector::Connector
   DEFAULT_EVENTS = "pull_request_review"
   TRUST_MODES = %w[operator allowlist project domain]
 
-  Options = Data.define(:agent, :operator, :projects, :types, :repos, :events, :port,
+  Options = Data.define(:agent, :operator, :projects, :types, :repos, :events, :gh_operator, :port,
     :trust, :allowed_emails, :allowed_domains, :allow_assignments, :chat_poll, :boost_poll)
 
   def self.start(argv)
@@ -29,6 +29,7 @@ class BasecampAgentConnector::Connector
     projects = []
     repos = []
     operator = nil
+    gh_operator = nil
     types = DEFAULT_TYPES
     events = DEFAULT_EVENTS
     port = nil
@@ -41,12 +42,17 @@ class BasecampAgentConnector::Connector
     boost_poll = BasecampAgentConnector::Basecamp::BoostPoller::DEFAULT_INTERVAL
 
     OptionParser.new do |parser|
-      parser.banner = "Usage: connect [@AGENT] [--project PROJECT]... [--repo OWNER/REPO]... [--operator PROFILE] " \
+      parser.banner = "Usage: connect [@AGENT] [--project PROJECT]... [--repo OWNER/REPO]... [--operator PROFILE] [--gh-operator LOGIN] " \
         "[--trust MODE] [--allow EMAIL]... [--allow-domain DOMAIN]... [--allow-project] " \
         "[--allow-assignments-from-authorized] [--types TYPES] [--chat-poll SECONDS] [--boost-poll SECONDS] [--no-boosts] [--events EVENTS] [--port PORT]"
       parser.on("--project PROJECT", "Basecamp project name, URL, or ID (repeatable)") { |value| projects << value }
       parser.on("--repo OWNER/REPO", "GitHub repo to watch for reviews (repeatable)") { |value| repos << value }
       parser.on("--operator PROFILE", "Profile whose user is allowed to trigger (default: CLI default profile)") { |value| operator = value }
+      parser.on("--gh-operator LOGIN", "GitHub login whose PR approvals are actionable (default: the login `gh` is authenticated as)") do |value|
+        raise ArgumentError, "--gh-operator needs a GitHub login" if value.strip.empty?
+
+        gh_operator = value.strip
+      end
       parser.on("--trust MODE", TRUST_MODES, "Who may trigger the agent: #{TRUST_MODES.join(", ")} (default: operator only; " \
         "value flags below imply their mode)") do |value|
         raise ArgumentError, "--trust given twice with different modes (#{trust} then #{value})" if !trust.nil? && trust != value.to_sym
@@ -87,7 +93,8 @@ class BasecampAgentConnector::Connector
 
     trust = resolve_trust(trust, emails: allowed_emails, domains: allowed_domains, project: allow_project)
 
-    Options.new(agent: normalize_agent(agent), operator: operator, projects: projects, types: types, repos: repos, events: events_list(events), port: port,
+    Options.new(agent: normalize_agent(agent), operator: operator, projects: projects, types: types, repos: repos, events: events_list(events),
+      gh_operator: gh_operator, port: port,
       trust: trust, allowed_emails: allowed_emails, allowed_domains: allowed_domains, allow_assignments: allow_assignments,
       chat_poll: chat_poll, boost_poll: boost_poll)
   end
@@ -177,7 +184,7 @@ class BasecampAgentConnector::Connector
 
     def github_bridge
       BasecampAgentConnector::GitHub::Bridge.new \
-        repos: @options.repos, events: @options.events,
+        repos: @options.repos, events: @options.events, operator: resolve_github_operator,
         github_cli: github_cli, emitter: emitter
     end
 
@@ -202,6 +209,15 @@ class BasecampAgentConnector::Connector
 
     def operator_label
       @options.operator ? " (profile #{@options.operator})" : ""
+    end
+
+    # The operator's GitHub login gates PR approvals. This machine's `gh` is
+    # the operator's, so its authenticated login is the default; `--gh-operator`
+    # names another login without consulting `gh` at all.
+    def resolve_github_operator
+      @options.gh_operator || github_cli.authenticated_login
+    rescue BasecampAgentConnector::GitHub::Client::Error => error
+      abort "Could not resolve the operator's GitHub login: #{error.message}\nRun `gh auth login`, or pass --gh-operator LOGIN, and try again."
     end
 
     def warn_if_same_user(agent, operator)

--- a/lib/basecamp_agent_connector/github/bridge.rb
+++ b/lib/basecamp_agent_connector/github/bridge.rb
@@ -6,10 +6,15 @@ require "securerandom"
 # review event. Its endpoint + secret are logged so additional repos can be
 # registered against the running connector on the fly (one webhook per PR's repo,
 # all multiplexed onto this single funnel).
+#
+# `operator` is the GitHub login whose approvals are actionable; every other
+# reviewer's approval is dropped, since an emitted approval lets the dispatched
+# agent land the PR.
 class BasecampAgentConnector::GitHub::Bridge
-  def initialize(repos:, events:, github_cli:, emitter:, logger: $stderr)
+  def initialize(repos:, events:, operator:, github_cli:, emitter:, logger: $stderr)
     @repos = repos
     @events = events
+    @operator = operator
     @github_cli = github_cli
     @emitter = emitter
     @logger = logger
@@ -27,6 +32,7 @@ class BasecampAgentConnector::GitHub::Bridge
     @webhooks.register_all(repos: @repos, url: endpoint, secret: @hmac_secret, events: @events)
     log "Listening for #{@events.join(', ')} on #{@repos.length} repo(s) at #{endpoint}"
     log "To watch another repo on the fly, register a webhook to #{endpoint} (secret #{@hmac_secret})."
+    log "Trust: approvals from @#{@operator} only; changes_requested and commented reviews from any reviewer"
   end
 
   # Answers 200 at once (nil, to the server) and verifies off the request
@@ -52,6 +58,7 @@ class BasecampAgentConnector::GitHub::Bridge
     def pipeline
       @pipeline ||= BasecampAgentConnector::GitHub::ReviewPipeline.new \
         secret: @hmac_secret,
+        operator: @operator,
         verifier: BasecampAgentConnector::GitHub::ReviewVerifier.new(github_cli: @github_cli),
         emitter: @emitter
     end

--- a/lib/basecamp_agent_connector/github/client.rb
+++ b/lib/basecamp_agent_connector/github/client.rb
@@ -26,6 +26,11 @@ class BasecampAgentConnector::GitHub::Client
     run("api", "-X", "DELETE", "repos/#{repo}/hooks/#{id}").success?
   end
 
+  # The login `gh` is authenticated as.
+  def authenticated_login
+    json("api", "user").fetch("login")
+  end
+
   def review(repo:, pull_number:, id:)
     json "api", "repos/#{repo}/pulls/#{pull_number}/reviews/#{id}"
   end

--- a/lib/basecamp_agent_connector/github/review_event.rb
+++ b/lib/basecamp_agent_connector/github/review_event.rb
@@ -22,8 +22,12 @@ class BasecampAgentConnector::GitHub::ReviewEvent
   end
   alias_method :id, :review_id
 
+  # The webhook delivers `state` lowercase (`approved`); the REST API returns
+  # it uppercase (`APPROVED`). Both collapse to the documented lowercase form,
+  # so the gates and the emitted line read the same whichever source built
+  # the event.
   def review_state
-    review["state"]
+    review["state"]&.downcase
   end
 
   def review_body

--- a/lib/basecamp_agent_connector/github/review_event.rb
+++ b/lib/basecamp_agent_connector/github/review_event.rb
@@ -66,6 +66,15 @@ class BasecampAgentConnector::GitHub::ReviewEvent
     ACTIONABLE_STATES.include?(review_state)
   end
 
+  def approved?
+    review_state == "approved"
+  end
+
+  # GitHub logins are case-insensitive.
+  def reviewed_by?(login)
+    !reviewer.nil? && !login.nil? && reviewer.casecmp?(login)
+  end
+
   def to_emitted_hash
     {
       "review_id" => review_id,

--- a/lib/basecamp_agent_connector/github/review_pipeline.rb
+++ b/lib/basecamp_agent_connector/github/review_pipeline.rb
@@ -1,8 +1,19 @@
 require "json"
 
+# Turns one signed `pull_request_review` delivery into one emitted review:
+# verify the HMAC, filter, dedup, re-fetch the review from the API, emit.
+#
+# Approvals are the trust boundary: an emitted `approved` review is what lets
+# the dispatched agent land the PR, so only the operator's approvals pass.
+# `changes_requested` and `commented` reviews are feedback to address, not
+# authority to merge, and pass from any reviewer. The reviewer gate runs
+# twice — on the claimed delivery as a cheap pre-filter, and again on the
+# verified review so the decision binds to the reviewer GitHub actually
+# recorded, not to the delivery body.
 class BasecampAgentConnector::GitHub::ReviewPipeline
-  def initialize(secret:, verifier:, emitter:, logger: $stderr)
+  def initialize(secret:, operator:, verifier:, emitter:, logger: $stderr)
     @secret = secret
+    @operator = operator
     @verifier = verifier
     @emitter = emitter
     @logger = logger
@@ -30,7 +41,11 @@ class BasecampAgentConnector::GitHub::ReviewPipeline
     end
 
     def actionable?(event)
-      event.actionable_action? && event.actionable_state?
+      event.actionable_action? && event.actionable_state? && authorized?(event)
+    end
+
+    def authorized?(event)
+      !event.approved? || event.reviewed_by?(@operator)
     end
 
     def fresh?(event)
@@ -45,10 +60,12 @@ class BasecampAgentConnector::GitHub::ReviewPipeline
     def emit_if_verified(event)
       verified = @verifier.verify(event)
 
-      if verified
-        @emitter.emit(verified)
-      else
+      if verified.nil?
         log "dropped review #{event.id}: not corroborated by GitHub"
+      elsif !authorized?(verified)
+        log "dropped review #{event.id}: approved by #{verified.reviewer.inspect}, not by the operator (#{@operator})"
+      else
+        @emitter.emit(verified)
       end
     end
 

--- a/lib/basecamp_agent_connector/github/review_pipeline.rb
+++ b/lib/basecamp_agent_connector/github/review_pipeline.rb
@@ -28,8 +28,12 @@ class BasecampAgentConnector::GitHub::ReviewPipeline
 
     event = BasecampAgentConnector::GitHub::ReviewEvent.from_payload(JSON.parse(body))
 
-    if actionable?(event) && fresh?(event)
-      emit_if_verified(event)
+    if actionable?(event)
+      if !authorized?(event)
+        log_unauthorized(event)
+      elsif fresh?(event)
+        emit_if_verified(event)
+      end
     end
   rescue JSON::ParserError => error
     log "ignored malformed payload: #{error.message}"
@@ -41,7 +45,7 @@ class BasecampAgentConnector::GitHub::ReviewPipeline
     end
 
     def actionable?(event)
-      event.actionable_action? && event.actionable_state? && authorized?(event)
+      event.actionable_action? && event.actionable_state?
     end
 
     def authorized?(event)
@@ -63,10 +67,14 @@ class BasecampAgentConnector::GitHub::ReviewPipeline
       if verified.nil?
         log "dropped review #{event.id}: not corroborated by GitHub"
       elsif !authorized?(verified)
-        log "dropped review #{event.id}: approved by #{verified.reviewer.inspect}, not by the operator (#{@operator})"
+        log_unauthorized(verified)
       else
         @emitter.emit(verified)
       end
+    end
+
+    def log_unauthorized(event)
+      log "dropped review #{event.id}: approved by #{event.reviewer.inspect}, not by the operator (#{@operator})"
     end
 
     def log(message)

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -280,21 +280,18 @@ watching for new mentions, acknowledge each one, and dispatch it.
 - A line carrying `review_id`/`repo`/`state` and **no `recording`** is a
   **GitHub review** (only when `bin/connect` runs with `--repo`). It gets no
   boost and no bucket lookup — the repo is `repo`, the PR is `pull_number`.
-  **Gate on `reviewer` before dispatching:** an `approved` review dispatches as
-  an approval — the agent may land the PR — only when `reviewer` is the
-  operator's GitHub login (`gh api user --jq .login` — this machine's `gh`
-  auth is the operator's — read once at launch; the operator is the same
-  person who authorizes Basecamp triggers). Any other reviewer's `approved` is dispatched as `commented` at
-  most: read and address the feedback, never merge. The HMAC signature proves
-  GitHub sent the delivery, not that the reviewer may merge, and `bin/connect`
-  does not enforce this yet — `GitHub::ReviewPipeline#actionable?`
-  (`lib/basecamp_agent_connector/github/review_pipeline.rb`) checks only the
-  action and the state, although
-  [`docs/pr-review-loop.md`](../../docs/pr-review-loop.md#trust) (lines 72–73)
-  states that only the operator's approvals are actionable. Until the
-  connector grows that filter, this gate is the only one. Then dispatch one
-  background agent in that repo to handle it per *Review / approval loop*
-  below, and return to the monitor.
+  An `approved` line is the operator's approval — the agent may land the PR:
+  `bin/connect` enforces this (`GitHub::ReviewPipeline`, see
+  [`docs/pr-review-loop.md`](../../docs/pr-review-loop.md#trust)) by emitting
+  an approval only when the reviewer GitHub recorded, re-fetched from the API,
+  is the operator's GitHub login, and dropping every other reviewer's approval
+  before it reaches this stream. That login is the one this machine's `gh` is
+  signed in as (`gh api user`), read once at startup, or `--gh-operator
+  <login>` passed through to `bin/connect`; the connector logs it at startup
+  as `Trust: approvals from @<login> only; …`. `changes_requested` and
+  `commented` lines arrive from any reviewer: feedback to address, never a
+  reason to merge. Dispatch one background agent in that repo to handle it
+  per *Review / approval loop* below, and return to the monitor.
 - A line carrying `recording` is a **Basecamp event** — the checklist below.
   Drop it outright if the recording is a comment the agent itself authored
   (`bin/connect` already refuses agent-authored events in every trust mode, and
@@ -691,9 +688,8 @@ per PR's repo, all multiplexed onto the single funnel). Branch on `state`:
   inline comments) from the API (the webhook is a trigger + pointer, exactly like
   the Basecamp side), address the feedback in the worktree, re-green (steps 2–4),
   push, and reply.
-- **`approved`** — **from the operator** (the router's `reviewer` gate): land
-  per the repo's policy and reply done. Anyone else's approval arrives here as
-  `commented` — read it, address it, never merge on it.
+- **`approved`** — the operator's approval (`bin/connect` emits no other):
+  land per the repo's policy and reply done.
 
 GitHub webhooks carry an HMAC secret (`X-Hub-Signature-256`), so unlike Basecamp
 deliveries they are verified cryptographically *and* corroborated by an API

--- a/test/connector_test.rb
+++ b/test/connector_test.rb
@@ -127,6 +127,17 @@ class ConnectorTest < Minitest::Test
     assert_equal 4567, options.port
   end
 
+  def test_parses_the_github_operator_login
+    assert_nil parse("--repo", "acme/a").gh_operator
+    assert_equal "octocat", parse("--repo", "acme/a", "--gh-operator", " octocat ").gh_operator
+  end
+
+  def test_refuses_an_empty_github_operator_login
+    assert_raises ArgumentError do
+      parse "--repo", "acme/a", "--gh-operator", " "
+    end
+  end
+
   def test_parses_comma_separated_github_events
     options = BasecampAgentConnector::Connector.parse_options([ "--repo", "acme/a", "--events", "pull_request_review, issue_comment" ])
 
@@ -151,11 +162,7 @@ class ConnectorTest < Minitest::Test
   end
 
   def test_start_mounts_only_its_own_bridge_paths_on_the_shared_funnel
-    runner = FakeCommandRunner.new
-    runner.stub "tailscale funnel", exit_status: 0
-    runner.stub "tailscale status --json", stdout: JSON.generate("Self" => { "DNSName" => "desktop.example.ts.net." })
-    runner.stub "/hooks", stdout: '{"id":888}'
-    runner.stub "-X DELETE", exit_status: 0
+    runner = github_runner
 
     start_connector [ "--repo", "acme/a", "--port", "4567" ], runner
 
@@ -166,6 +173,40 @@ class ConnectorTest < Minitest::Test
     assert_equal [ "tailscale", "funnel", "--bg", "--set-path", path, "http://127.0.0.1:4567#{path}" ], mounted.first
     assert_equal [ [ "tailscale", "funnel", "--set-path", path, "off" ] ], runner.commands_matching(/funnel --set-path/)
     assert_empty runner.commands_matching(/reset/)
+  end
+
+  def test_start_trusts_the_login_gh_is_signed_in_as_by_default
+    runner = github_runner
+
+    _out, err = start_connector [ "--repo", "acme/a", "--port", "4567" ], runner
+
+    assert_equal 1, runner.commands_matching(/\Agh api user\z/).length
+    assert_match(/^Trust: approvals from @octocat only/, err)
+  end
+
+  def test_start_trusts_the_given_github_operator_without_asking_gh
+    runner = github_runner
+
+    _out, err = start_connector [ "--repo", "acme/a", "--gh-operator", "marie", "--port", "4567" ], runner
+
+    assert_empty runner.commands_matching(/\Agh api user\z/)
+    assert_match(/^Trust: approvals from @marie only/, err)
+  end
+
+  def test_start_aborts_when_gh_is_signed_out_and_no_github_operator_is_given
+    runner = FakeCommandRunner.new
+    runner.stub "gh api user", exit_status: 4, stderr: "gh: not logged in"
+    connector = BasecampAgentConnector::Connector.new(parse("--repo", "acme/a", "--port", "4567"))
+    connector.instance_variable_set(:@command_runner, runner)
+
+    _out, err = capture_io do
+      assert_raises(SystemExit) { connector.start }
+    end
+
+    assert_match(/Could not resolve the operator's GitHub login: .*not logged in/, err)
+    assert_match(/--gh-operator LOGIN/, err)
+    assert_empty runner.commands_matching(%r{/hooks})
+    assert_empty runner.commands_matching(/\Atailscale/)
   end
 
   def test_start_skips_the_funnel_entirely_for_a_chat_only_run
@@ -185,6 +226,17 @@ class ConnectorTest < Minitest::Test
   private
     def parse(*argv)
       BasecampAgentConnector::Connector.parse_options(argv)
+    end
+
+    # Everything a `--repo` run shells out for, with `gh` signed in as octocat.
+    def github_runner
+      runner = FakeCommandRunner.new
+      runner.stub "tailscale funnel", exit_status: 0
+      runner.stub "tailscale status --json", stdout: JSON.generate("Self" => { "DNSName" => "desktop.example.ts.net." })
+      runner.stub "/hooks", stdout: '{"id":888}'
+      runner.stub "-X DELETE", exit_status: 0
+      runner.stub "gh api user", stdout: JSON.generate("login" => "octocat")
+      runner
     end
 
     def start_connector(argv, runner)

--- a/test/connector_test.rb
+++ b/test/connector_test.rb
@@ -130,11 +130,15 @@ class ConnectorTest < Minitest::Test
   def test_parses_the_github_operator_login
     assert_nil parse("--repo", "acme/a").gh_operator
     assert_equal "octocat", parse("--repo", "acme/a", "--gh-operator", " octocat ").gh_operator
+    assert_equal "octocat", parse("--repo", "acme/a", "--gh-operator", "@octocat").gh_operator
   end
 
   def test_refuses_an_empty_github_operator_login
     assert_raises ArgumentError do
       parse "--repo", "acme/a", "--gh-operator", " "
+    end
+    assert_raises ArgumentError do
+      parse "--repo", "acme/a", "--gh-operator", "@"
     end
   end
 

--- a/test/github_bridge_test.rb
+++ b/test/github_bridge_test.rb
@@ -18,6 +18,16 @@ class GithubBridgeTest < Minitest::Test
     assert_includes created.first.join(" "), "events[]=pull_request_review"
   end
 
+  def test_register_logs_whose_approvals_are_trusted
+    runner = FakeCommandRunner.new
+    runner.stub "/hooks", stdout: '{"id":888}'
+    logs = StringIO.new
+
+    bridge(runner, logger: logs).register(base_url: "https://host.ts.net")
+
+    assert_match(/^Trust: approvals from @octocat only; changes_requested and commented reviews from any reviewer$/, logs.string)
+  end
+
   def test_teardown_deletes_registered_webhooks
     runner = FakeCommandRunner.new
     runner.stub "/hooks -X POST", stdout: '{"id":888}'
@@ -31,12 +41,13 @@ class GithubBridgeTest < Minitest::Test
   end
 
   private
-    def bridge(runner, repos: [ "acme/a" ])
+    def bridge(runner, repos: [ "acme/a" ], logger: StringIO.new)
       BasecampAgentConnector::GitHub::Bridge.new \
         repos: repos,
         events: [ "pull_request_review" ],
+        operator: "octocat",
         github_cli: build_github_cli(runner),
         emitter: BasecampAgentConnector::Emitter.new(output: StringIO.new),
-        logger: StringIO.new
+        logger: logger
     end
 end

--- a/test/github_client_test.rb
+++ b/test/github_client_test.rb
@@ -22,6 +22,23 @@ class GithubClientTest < Minitest::Test
     assert build_github_cli(runner).delete_webhook(repo: "acme/widgets", id: 888)
   end
 
+  def test_authenticated_login_reads_the_login_gh_is_signed_in_as
+    runner = FakeCommandRunner.new
+    runner.stub "api user", stdout: JSON.generate("login" => "octocat", "id" => 1)
+
+    assert_equal "octocat", build_github_cli(runner).authenticated_login
+    assert_equal [ [ "gh", "api", "user" ] ], runner.commands
+  end
+
+  def test_authenticated_login_raises_when_gh_is_signed_out
+    runner = FakeCommandRunner.new
+    runner.stub "api user", exit_status: 4, stderr: "gh: To use GitHub CLI in automation, set GH_TOKEN"
+
+    assert_raises BasecampAgentConnector::GitHub::Client::Error do
+      build_github_cli(runner).authenticated_login
+    end
+  end
+
   def test_review_fetches_the_review
     runner = FakeCommandRunner.new
     runner.stub "pulls/12/reviews/7001", stdout: JSON.generate(review_hash)

--- a/test/review_event_test.rb
+++ b/test/review_event_test.rb
@@ -11,6 +11,16 @@ class ReviewEventTest < Minitest::Test
     assert_equal "acme/widgets", event.repo
   end
 
+  # The webhook delivers `state` lowercase; the REST API returns it uppercase.
+  def test_reads_the_api_uppercase_state_as_the_documented_lowercase_form
+    event = BasecampAgentConnector::GitHub::ReviewEvent.from_payload(review_payload("review" => review_hash("state" => "APPROVED")))
+
+    assert_equal "approved", event.review_state
+    assert event.actionable_state?
+    assert event.approved?
+    assert_equal "approved", event.to_emitted_hash["state"]
+  end
+
   def test_dedup_id_is_the_review_id
     assert_equal 7001, BasecampAgentConnector::GitHub::ReviewEvent.from_payload(review_payload).id
   end

--- a/test/review_event_test.rb
+++ b/test/review_event_test.rb
@@ -34,6 +34,20 @@ class ReviewEventTest < Minitest::Test
     refute event.actionable_state?
   end
 
+  def test_reviewed_by_matches_the_login_case_insensitively
+    event = BasecampAgentConnector::GitHub::ReviewEvent.from_payload(review_payload("review" => review_hash("user" => { "login" => "OctoCat" })))
+
+    assert event.reviewed_by?("octocat")
+    refute event.reviewed_by?("someone-else")
+    refute event.reviewed_by?(nil)
+  end
+
+  def test_reviewed_by_is_false_without_a_reviewer
+    event = BasecampAgentConnector::GitHub::ReviewEvent.from_payload(review_payload("review" => review_hash("user" => nil)))
+
+    refute event.reviewed_by?("octocat")
+  end
+
   def test_emitted_hash_carries_review_and_comments
     payload = review_payload("comments" => [ { "path" => "lib/x.rb", "line" => 3, "body" => "rename this" } ])
 

--- a/test/review_pipeline_test.rb
+++ b/test/review_pipeline_test.rb
@@ -84,6 +84,7 @@ class ReviewPipelineTest < Minitest::Test
 
     assert_empty @output.string
     assert_empty runner.commands
+    assert_match(/dropped review 7001: approved by "someone-else", not by the operator \(octocat\)/, @logs.string)
   end
 
   # The delivery body claims the operator approved; the review GitHub actually
@@ -131,9 +132,11 @@ class ReviewPipelineTest < Minitest::Test
   end
 
   private
+    # GitHub's REST API answers with the state upcased (`APPROVED`), unlike the
+    # lowercase webhook delivery, so the corroboration stub takes the API's shape.
     def corroborating_runner(review = review_hash)
       runner = FakeCommandRunner.new
-      runner.stub(%r{reviews/7001$}, stdout: JSON.generate(review))
+      runner.stub(%r{reviews/7001$}, stdout: JSON.generate(review.merge("state" => review["state"].upcase)))
       runner.stub "reviews/7001/comments", stdout: "[]"
       runner
     end

--- a/test/review_pipeline_test.rb
+++ b/test/review_pipeline_test.rb
@@ -56,10 +56,84 @@ class ReviewPipelineTest < Minitest::Test
     assert_match(/not corroborated/, @logs.string)
   end
 
+  def test_emits_the_operators_approval
+    approval = review_hash("state" => "approved", "body" => "LGTM")
+    body = JSON.generate(review_payload("review" => approval))
+
+    pipeline(corroborating_runner(approval)).process(body: body, signature: sign(body, @secret))
+
+    emitted = JSON.parse(@output.string)
+    assert_equal "approved", emitted["state"]
+    assert_equal "octocat", emitted["reviewer"]
+  end
+
+  def test_matches_the_operator_login_case_insensitively
+    approval = review_hash("state" => "approved", "user" => { "login" => "OctoCat" })
+    body = JSON.generate(review_payload("review" => approval))
+
+    pipeline(corroborating_runner(approval)).process(body: body, signature: sign(body, @secret))
+
+    assert_equal 1, @output.string.lines.length
+  end
+
+  def test_drops_another_reviewers_approval_without_asking_github
+    runner = FakeCommandRunner.new
+    body = JSON.generate(review_payload("review" => review_hash("state" => "approved", "user" => { "login" => "someone-else" })))
+
+    pipeline(runner).process(body: body, signature: sign(body, @secret))
+
+    assert_empty @output.string
+    assert_empty runner.commands
+  end
+
+  # The delivery body claims the operator approved; the review GitHub actually
+  # recorded says otherwise. The authoritative reviewer decides.
+  def test_drops_an_approval_whose_authoritative_reviewer_is_not_the_operator
+    claimed = review_hash("state" => "approved")
+    recorded = review_hash("state" => "approved", "user" => { "login" => "someone-else" })
+    body = JSON.generate(review_payload("review" => claimed))
+
+    pipeline(corroborating_runner(recorded)).process(body: body, signature: sign(body, @secret))
+
+    assert_empty @output.string
+    assert_match(/dropped review 7001: approved by "someone-else", not by the operator \(octocat\)/, @logs.string)
+  end
+
+  def test_drops_an_approval_whose_authoritative_reviewer_is_missing
+    claimed = review_hash("state" => "approved")
+    recorded = review_hash("state" => "approved", "user" => nil)
+    body = JSON.generate(review_payload("review" => claimed))
+
+    pipeline(corroborating_runner(recorded)).process(body: body, signature: sign(body, @secret))
+
+    assert_empty @output.string
+    assert_match(/approved by nil, not by the operator/, @logs.string)
+  end
+
+  def test_emits_another_reviewers_requested_changes
+    review = review_hash("state" => "changes_requested", "user" => { "login" => "someone-else" })
+    body = JSON.generate(review_payload("review" => review))
+
+    pipeline(corroborating_runner(review)).process(body: body, signature: sign(body, @secret))
+
+    emitted = JSON.parse(@output.string)
+    assert_equal "changes_requested", emitted["state"]
+    assert_equal "someone-else", emitted["reviewer"]
+  end
+
+  def test_emits_another_reviewers_comment
+    review = review_hash("state" => "commented", "user" => { "login" => "someone-else" })
+    body = JSON.generate(review_payload("review" => review))
+
+    pipeline(corroborating_runner(review)).process(body: body, signature: sign(body, @secret))
+
+    assert_equal "commented", JSON.parse(@output.string)["state"]
+  end
+
   private
-    def corroborating_runner
+    def corroborating_runner(review = review_hash)
       runner = FakeCommandRunner.new
-      runner.stub(%r{reviews/7001$}, stdout: JSON.generate(review_hash))
+      runner.stub(%r{reviews/7001$}, stdout: JSON.generate(review))
       runner.stub "reviews/7001/comments", stdout: "[]"
       runner
     end
@@ -67,6 +141,7 @@ class ReviewPipelineTest < Minitest::Test
     def pipeline(runner)
       BasecampAgentConnector::GitHub::ReviewPipeline.new \
         secret: @secret,
+        operator: "octocat",
         verifier: BasecampAgentConnector::GitHub::ReviewVerifier.new(github_cli: build_github_cli(runner)),
         emitter: BasecampAgentConnector::Emitter.new(output: @output),
         logger: @logs


### PR DESCRIPTION
## What

`docs/pr-review-loop.md` (Trust) says only the operator's approvals are actionable, but `GitHub::ReviewPipeline#actionable?` checked only the action and the state: a signed `approved` review from any collaborator was corroborated and emitted, and an emitted approval is what lets the dispatched agent land the PR. The HMAC proves GitHub sent the delivery, not that the reviewer may merge, so the gate lived only in the skill's router text (#17), where an LLM had to remember to honor it.

Now the connector enforces it:

- **Operator identity.** With `--repo`, startup resolves the operator's GitHub login: the login `gh` is authenticated as (`gh api user` → `Client#authenticated_login`), or an explicit `--gh-operator LOGIN` that skips `gh` entirely. Signed-out `gh` with no `--gh-operator` aborts with `Run gh auth login, or pass --gh-operator LOGIN`, before any funnel or webhook is touched. The bridge logs it with the other startup lines, like the Basecamp trust set: `Trust: approvals from @<login> only; changes_requested and commented reviews from any reviewer`.
- **The gate.** `ReviewPipeline` admits an `approved` review only when its reviewer is the operator's login (case-insensitive, as GitHub logins are). It runs twice, mirroring `Basecamp::Pipeline`: on the delivery body as a cheap pre-filter (a non-operator approval never hits the API), and again on the review re-fetched by `ReviewVerifier`, so the decision binds to the `user.login` GitHub recorded rather than the POST body. `ReviewEvent#review_state` downcases at the accessor: the webhook delivers `approved`, the REST re-fetch returns `APPROVED`, and both gates plus the emitted `state` read the documented lowercase form.
- **Non-operator approvals are dropped**, logged to STDERR from whichever gate stops them (`dropped review 7001: approved by "someone-else", not by the operator (octocat)`), never emitted. `changes_requested` / `commented` keep today's behaviour and pass from any reviewer.
- Docs: `docs/pr-review-loop.md` Trust section, README flag table + "What it does", and the two GitHub paragraphs in `skills/basecamp-connect/SKILL.md` that said the connector does not enforce this yet. Nothing else in SKILL.md is touched (the mention-matching edit is in flight separately).

## Why drop rather than emit a downgraded "commented"

- The STDOUT contract is "trusted, actionable events". The Basecamp side drops an unauthorized author outright rather than emitting a flagged line; a "here's an approval but don't act on it" line reintroduces exactly the reliance on the LLM honoring a flag that moving the gate into the connector exists to remove.
- Emitting the review with `state: "commented"` would misreport GitHub's authoritative state; the agent re-fetches the review anyway and would see `APPROVED`.
- Nothing actionable is lost: a collaborator who wants changes requests them or comments, and those still flow. An approval body is by definition "nothing to change".

## Declined alternatives

- **Emitting non-operator approvals with an `actionable: false` (or `approval: "operator"`) field.** Rejected for the reasons above: the connector's job is to make the stream trustworthy, not to annotate untrusted lines for a downstream LLM to filter.
- **Gating `changes_requested` / `commented` on the operator too.** The spec scopes the trust statement to approvals; requested changes from a collaborator are feedback the agent should address and carry no merge authority. Left as-is.
- **A `GitHub::Authorizer` class with modes, mirroring `Basecamp::Authorizer`.** One predicate (`!approved? || reviewed_by?(operator)`) does not warrant a mode system; the trust line is logged from the bridge instead. Easy to grow later if approvals ever need an allowlist.
- **Resolving the login from `gh auth status`.** Its output is for humans and varies by version; `gh api user` returns JSON with `login` and goes through the existing `Client#json` path.
- **Forgetting a dropped-at-re-check id so a redelivery is re-verified.** The verdict is deterministic (the recorded reviewer does not change), so the id stays seen, exactly like "not corroborated" today.
- **Fixing the re-check with `review_state&.casecmp?("approved")` in `approved?` alone.** Narrower, but leaves the emitted `state` as `APPROVED` in production while the docs and SKILL.md router key on lowercase `approved`; normalizing once at the accessor fixes both readers with one line.
- **Marking a pre-filter-dropped approval as seen.** It costs no API call, and a GitHub redelivery re-logging the drop is an honest signal; `fresh?` stays where it was (after the reviewer gate).
- **Accepting `--gh-operator @marie` verbatim.** The agent handle and `--allow-domain` both strip a leading `@`, and every log line renders the login as `@<login>`, so the flag strips it too.

## Declined

None of the round-one findings were declined: the uppercase API state (reported three times) is one bug, fixed at the accessor; the silent pre-filter drop and the `@`-prefixed login are both applied.

## Tests

`bundle exec rake test` — 272 runs, 856 assertions, 0 failures; `rubocop lib test` clean.

New: operator approval emitted; case-insensitive login match; non-operator approval dropped without asking GitHub; delivery claims the operator but the re-fetched reviewer is someone else → dropped with the log line (the corroboration path); missing authoritative reviewer → dropped; non-operator `changes_requested` and `commented` still emitted; `Client#authenticated_login`; `--gh-operator` parsing (+ empty refused); connector start resolves via `gh api user` by default, skips it under `--gh-operator`, aborts before funnel/webhooks when `gh` is signed out; bridge logs the trust line.

Fails-without-fix: with `authorized?` stubbed to `true`, the three drop tests in `review_pipeline_test.rb` fail (two assertion failures, one "no stub for command" error because the pre-filter no longer stops the API fetch). The pipeline's corroboration stub now answers in the API's uppercase shape; against the pre-normalization code the authoritative-reviewer drop test emits `{"state":"APPROVED","reviewer":"someone-else",…}` with an empty log, the operator-approval test sees `APPROVED`, the pre-filter test finds no drop log line, and `--gh-operator @octocat` parses as `@octocat` (9 failures observed before the fix, 0 after).

## Installed skill

`~/.agents/skills/basecamp-connect/SKILL.md` currently equals `main`; this PR's SKILL.md edit is the only diff, so it will be copied over once this is open (per AGENTS.md), and re-synced by whoever merges last.

