### PR TITLE
Emit the trigger verdicts so the watcher stops decoding mention markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,8 +370,20 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
  "creator":{"id":100,"name":"Jorge Manrubia","email_address":"jorge@…"},
  "recording":{"id":456,"type":"Comment","app_url":"…","url":"…",
    "content":"<p>… <bc-attachment content-type=\"application/vnd.basecamp.mention\">…Clawdito…</bc-attachment> fix X</p>",
-   "parent":{…},"bucket":{"id":222,"name":"BC5 Calendar"}}}
+   "parent":{…},"bucket":{"id":222,"name":"BC5 Calendar"}},
+ "trigger":{"mentioned":true,"subscribed":false}}
 ```
+
+`trigger` is the connector's own verdict on why the event targets the agent,
+settled on the re-fetched recording: `mentioned` when its content carries a
+mention attachment for the agent's Person id, `subscribed` when a
+`comment_created` fired because the agent subscribes to the commented-on
+recording. A `comment_created` is exactly one of the two. An assignment or a
+boost is a directive by `kind` alone: `subscribed` is `false` for both, and
+`mentioned` is a fact about the content (an assigned card whose description
+mentions the agent reads `true`; a boost's feed representation has no content,
+so it reads `false`). A watcher reads `trigger` to tell a directive from
+followed-thread activity instead of decoding the mention markup itself.
 
 **Teardown.** On `SIGINT`/`SIGTERM` it deletes **every** registered webhook
 (best-effort, reporting any it couldn’t) and unmounts its own funnel paths

--- a/README.md
+++ b/README.md
@@ -381,8 +381,9 @@ mention attachment for the agent's Person id, `subscribed` when a
 recording. A `comment_created` is exactly one of the two. An assignment or a
 boost is a directive by `kind` alone: `subscribed` is `false` for both, and
 `mentioned` is a fact about the content (an assigned card whose description
-mentions the agent reads `true`; a boost's feed representation has no content,
-so it reads `false`). A watcher reads `trigger` to tell a directive from
+mentions the agent reads `true`; a boost is a reaction, not content, so the
+boost path settles no mention verdict and it always reads `false`). A watcher
+reads `trigger` to tell a directive from
 followed-thread activity instead of decoding the mention markup itself.
 
 **Teardown.** On `SIGINT`/`SIGTERM` it deletes **every** registered webhook

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -296,12 +296,33 @@ One JSON object per line (NDJSON), built from the **verified** recording:
     "content": "<p>Hey <bc-attachment content-type=\"application/vnd.basecamp.mention\">…Clawdito…</bc-attachment> please ...</p>",
     "parent": { "id": 789, "type": "Kanban::Card", "app_url": "..." },
     "bucket": { "id": 222, "name": "BC5 Calendar", "type": "Project" }
-  }
+  },
+  "trigger": { "mentioned": true, "subscribed": false }
 }
 ```
 
 `app_url` / `url` and `bucket` are the handles the downstream agent uses to pull
 full context and resolve the working repo.
+
+The top-level keys mirror the webhook envelope (`id` → `event_id`, `kind`,
+`created_at`, `creator`, `details`, `recording`); `trigger` is the one key the
+connector owns, carrying the verifier's verdicts on **why** the event targets
+the agent, both settled on the re-fetched recording rather than on the POST:
+
+- `mentioned` — the authoritative content carries a mention attachment for the
+  agent's Person id (the same match the pipeline's mention gate applies).
+- `subscribed` — a `comment_created` with no mention of the agent, on a
+  recording the live subscribers API confirms the agent subscribes to (the
+  `agent_subscribed` stamp from verification step 3).
+
+Every emitted line carries both booleans. A `comment_created` is exactly one
+of the two. An assignment or a boost is a directive by `kind` alone:
+`subscribed` is `false` for both, and `mentioned` stays a fact about the
+authoritative content — an assigned card whose description mentions the agent
+reads `true`; a boost's feed representation carries no content, so it reads
+`false`. The skill reads `trigger` to decide boost vs. no-boost and directive
+vs. followed-thread activity, so it never has to decode the mention SGID
+against the agent's Person id itself.
 
 A **boost** event (`"kind": "boost_created"`) is synthesized from the agent's
 received-boosts feed rather than a webhook: `creator` is the **booster**,

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -248,7 +248,10 @@ For each delivered event:
    and content. A forged POST (the funnel URL is public, Basecamp sends no
    signature) cannot survive this — if Basecamp doesn't corroborate the event, it
    is discarded. The payload's content field is never trusted directly; the
-   fetched content is authoritative. For a **comment on a subscribed recording**,
+   fetched content is authoritative. The mention match against the agent's
+   Person id is also settled on that fetched content and stamped onto the
+   authoritative event as `agent_mentioned`, which is what the emitted
+   `trigger.mentioned` reports. For a **comment on a subscribed recording**,
    verification additionally re-fetches the parent's subscribers
    (`basecamp subscriptions show`) and stamps the agent's membership onto the
    authoritative event, so the subscription that triggers is the live one
@@ -310,7 +313,8 @@ connector owns, carrying the verifier's verdicts on **why** the event targets
 the agent, both settled on the re-fetched recording rather than on the POST:
 
 - `mentioned` — the authoritative content carries a mention attachment for the
-  agent's Person id (the same match the pipeline's mention gate applies).
+  agent's Person id (the `agent_mentioned` stamp from verification step 3 —
+  the same match the pipeline's mention gate applies).
 - `subscribed` — a `comment_created` with no mention of the agent, on a
   recording the live subscribers API confirms the agent subscribes to (the
   `agent_subscribed` stamp from verification step 3).
@@ -319,8 +323,10 @@ Every emitted line carries both booleans. A `comment_created` is exactly one
 of the two. An assignment or a boost is a directive by `kind` alone:
 `subscribed` is `false` for both, and `mentioned` stays a fact about the
 authoritative content — an assigned card whose description mentions the agent
-reads `true`; a boost's feed representation carries no content, so it reads
-`false`. The skill reads `trigger` to decide boost vs. no-boost and directive
+reads `true`. A boost is a reaction to the agent's own work, not content that
+could mention it: the boost path settles no mention verdict at all, so a boost
+reads `false` by construction, whatever its feed representation carries. The
+skill reads `trigger` to decide boost vs. no-boost and directive
 vs. followed-thread activity, so it never has to decode the mention SGID
 against the agent's Person id itself.
 

--- a/lib/basecamp_agent_connector/basecamp/event.rb
+++ b/lib/basecamp_agent_connector/basecamp/event.rb
@@ -187,6 +187,14 @@ class BasecampAgentConnector::Basecamp::Event
     assignment_changed? && added_person_ids.include?(agent.person_id)
   end
 
+  # True only on an authoritative event the Verifier stamped after matching the
+  # re-fetched recording's mention attachments against the agent's Person id —
+  # the same `mentions?` verdict the pipeline trusts, settled on the
+  # authoritative content rather than the forgeable webhook payload.
+  def mentioned?
+    @payload["agent_mentioned"] == true
+  end
+
   # True only on an authoritative event the Verifier stamped after confirming,
   # against the live subscribers API, that the agent subscribes to the comment's
   # parent. Reads nothing from the forgeable webhook payload.
@@ -202,6 +210,12 @@ class BasecampAgentConnector::Basecamp::Event
     @payload["agent_boosted"] == true
   end
 
+  # The top-level keys mirror the webhook envelope; `trigger` is the one
+  # connector-owned key, carrying the Verifier's verdicts on why this event
+  # targets the agent. Without it a watcher can tell a mention from a
+  # followed-thread comment only by decoding the mention markup itself against
+  # the agent's Person id. Assignments and boosts already announce themselves
+  # by `kind`, so these two are the verdicts a watcher cannot derive.
   def to_emitted_hash
     {
       "event_id" => id,
@@ -209,7 +223,8 @@ class BasecampAgentConnector::Basecamp::Event
       "created_at" => created_at,
       "creator" => creator.slice(*EMITTED_CREATOR_FIELDS),
       "details" => details.slice(*EMITTED_DETAIL_FIELDS),
-      "recording" => recording.slice(*EMITTED_RECORDING_FIELDS)
+      "recording" => recording.slice(*EMITTED_RECORDING_FIELDS),
+      "trigger" => { "mentioned" => mentioned?, "subscribed" => subscribed? }
     }
   end
 

--- a/lib/basecamp_agent_connector/basecamp/verifier.rb
+++ b/lib/basecamp_agent_connector/basecamp/verifier.rb
@@ -71,9 +71,11 @@ class BasecampAgentConnector::Basecamp::Verifier
       Array(recording["assignees"]).map { |assignee| assignee["id"] }
     end
 
-    # Both trigger verdicts are stamped from the re-fetched recording, so what
-    # the pipeline re-checks and what the watcher reads off the emitted line
-    # are one computation on the authoritative content.
+    # Both trigger verdicts are settled on the re-fetched recording — the same
+    # authoritative content the pipeline's `targets_agent?` re-check reads — so
+    # the stamps the watcher reads off the emitted line cannot disagree with
+    # the drop decision. The pipeline still runs `Event#mentions?` itself; the
+    # `agent_mentioned` stamp exists for the emitted line, not for the gate.
     def authoritative_event(event, recording)
       mentioned = mentions_agent?(recording)
 

--- a/lib/basecamp_agent_connector/basecamp/verifier.rb
+++ b/lib/basecamp_agent_connector/basecamp/verifier.rb
@@ -71,7 +71,12 @@ class BasecampAgentConnector::Basecamp::Verifier
       Array(recording["assignees"]).map { |assignee| assignee["id"] }
     end
 
+    # Both trigger verdicts are stamped from the re-fetched recording, so what
+    # the pipeline re-checks and what the watcher reads off the emitted line
+    # are one computation on the authoritative content.
     def authoritative_event(event, recording)
+      mentioned = mentions_agent?(recording)
+
       BasecampAgentConnector::Basecamp::Event.from_payload \
         "id" => event.id,
         "kind" => event.kind,
@@ -79,7 +84,8 @@ class BasecampAgentConnector::Basecamp::Verifier
         "details" => event.details,
         "creator" => event.assignment_changed? ? event.creator : recording.fetch("creator"),
         "recording" => recording,
-        "agent_subscribed" => agent_subscribed?(event, recording)
+        "agent_mentioned" => mentioned,
+        "agent_subscribed" => agent_subscribed?(event, recording, mentioned: mentioned)
     end
 
     # A comment can trigger by subscription instead of by a mention: confirm,
@@ -96,10 +102,10 @@ class BasecampAgentConnector::Basecamp::Verifier
     # claimed `comment_created` kind: otherwise a forged POST naming that kind
     # but pointing at an existing subscribed Message/Card would corroborate on
     # creator and pass the subscriber check, emitting though no comment exists.
-    def agent_subscribed?(event, recording)
+    def agent_subscribed?(event, recording, mentioned:)
       event.subscribable_comment? && \
         recording["type"] == COMMENT_RECORDING_TYPE && \
-        !mentions_agent?(recording) && \
+        !mentioned && \
         agent_subscribes_to_parent?(recording)
     end
 

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -186,9 +186,10 @@ mentions, assignments, subscriber lists, and boosts all carry (e.g. `51177542`).
 `basecamp me` reports the *global* identity id, a different number that matches
 nothing in an event; the connector resolves the Person id the same way
 (`Basecamp::Identity.account_person_id`). The front thread reads it once here
-and uses it for the dispatched agent's boost check and for the fallback mention
-discriminator under step 2a (only an older connector's event lines need it —
-current ones carry the verdict as `trigger`).
+and uses it to strip the agent's own mention from the dispatched instruction
+(step 2c — never by name) and for the fallback mention discriminator under
+step 2a (only an older connector's event lines need it there — current ones
+carry the verdict as `trigger`).
 
 If it's missing or authed as the wrong user, set it up (interactive login as the
 agent/bot account):
@@ -272,7 +273,8 @@ verdict on **why** the event fired, settled on the re-fetched recording:
 id) or `subscribed` (a `comment_created` on a recording the agent follows, with
 no mention of it). A `comment_created` is exactly one of the two; an assignment
 or a boost is a directive by `kind` alone (`subscribed` is `false` for both;
-`mentioned` just reports whether the content mentions the agent). STDERR
+`mentioned` reports whether an assigned recording's content mentions the
+agent, and is always `false` on a boost — a reaction is not content). STDERR
 carries diagnostics (dropped/uncorroborated events, registration notices) —
 surface them but don't act on them.
 

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -186,8 +186,9 @@ mentions, assignments, subscriber lists, and boosts all carry (e.g. `51177542`).
 `basecamp me` reports the *global* identity id, a different number that matches
 nothing in an event; the connector resolves the Person id the same way
 (`Basecamp::Identity.account_person_id`). The front thread reads it once here
-and uses it for the mention discriminator under step 2a and for the dispatched
-agent's boost check.
+and uses it for the dispatched agent's boost check and for the fallback mention
+discriminator under step 2a (only an older connector's event lines need it —
+current ones carry the verdict as `trigger`).
 
 If it's missing or authed as the wrong user, set it up (interactive login as the
 agent/bot account):
@@ -256,7 +257,8 @@ Each STDOUT line is one trusted event as NDJSON:
  "creator":{"id":100,"name":"Jorge Manrubia","email_address":"jorge@..."},
  "recording":{"id":456,"type":"Comment","app_url":"...","url":"...",
    "content":"<p>Hey <bc-attachment content-type=\"application/vnd.basecamp.mention\">…@Clawdito…</bc-attachment> do X</p>",
-   "parent":{...},"bucket":{"id":222,"name":"BC5 Calendar"}}}
+   "parent":{...},"bucket":{"id":222,"name":"BC5 Calendar"}},
+ "trigger":{"mentioned":true,"subscribed":false}}
 ```
 
 `creator` is the **triggering author** — the person whose mention/assignment
@@ -264,9 +266,15 @@ drove this event. In the default operator-only mode that is always you; under a
 broadened trust mode (`--allow`, `--allow-domain`, `--allow-project`) it may be
 an authorized coworker instead. Treat `creator` as *the requester* — that is who
 to @mention on failure — not as "the operator." The mention of the agent lives
-in `recording.content` as a mention attachment. STDERR carries diagnostics
-(dropped/uncorroborated events, registration notices) — surface them but don't
-act on them.
+in `recording.content` as a mention attachment. `trigger` is the connector's
+verdict on **why** the event fired, settled on the re-fetched recording:
+`mentioned` (its content carries a mention attachment for the agent's Person
+id) or `subscribed` (a `comment_created` on a recording the agent follows, with
+no mention of it). A `comment_created` is exactly one of the two; an assignment
+or a boost is a directive by `kind` alone (`subscribed` is `false` for both;
+`mentioned` just reports whether the content mentions the agent). STDERR
+carries diagnostics (dropped/uncorroborated events, registration notices) —
+surface them but don't act on them.
 
 Keep watching until the user stops the skill (see Cleanup).
 
@@ -343,10 +351,16 @@ todos) — and for Campfire mentions (boost the chat line; see *When the mention
 arrives in Campfire*). Exactly two kinds of Basecamp event get **no** boost
 (see their sections below):
 
-- **subscribed-thread comments** — a `comment_created` whose `recording.content`
-  has no `<bc-attachment content-type="application/vnd.basecamp.mention">`
-  carrying **the agent's Person id**. The id is the **only** discriminator:
-  the attachment's embedded `content` markup names it as
+- **subscribed-thread comments** — an event line whose `trigger.subscribed` is
+  `true`. Read `trigger` **first**: it is the connector's own verdict, settled
+  on the re-fetched recording against the agent's Person id, so a line that
+  carries it needs no markup inspection at all (`trigger.mentioned` true means
+  a directive — boost it). Fall back to the markup match **only when the line
+  has no `trigger` key** — an older connector — and then it is a
+  `comment_created` whose `recording.content` has no `<bc-attachment
+  content-type="application/vnd.basecamp.mention">` carrying **the agent's
+  Person id**. There the id is the **only** discriminator: the attachment's
+  embedded `content` markup names it as
   `<bc-mention … gid="gid://bc3/Person/<id>">`, and the attachment's own
   `sgid` attribute encodes the same `gid://bc3/Person/<id>` (base64 in the
   segment before `--`, which is what the connector's own matcher decodes —
@@ -544,12 +558,14 @@ with these differences:
 
 ### When a comment lands on a thread the agent follows
 
-If the event `kind` is `comment_created` and `recording.content` carries **no
-mention attachment naming the agent** (the discriminator under step 2a — a
-mention of someone else, or a plain-text `@name`, does not count), the connector
-fired because the agent **subscribes** to the commented-on recording (a
-card/thread it participates in), not because it was addressed. Treat this as
-*activity on a followed thread*, not a directive:
+If the event line's `trigger.subscribed` is `true` — or, on an older
+connector's line with no `trigger` key, the `kind` is `comment_created` and
+`recording.content` carries **no mention attachment naming the agent** (the
+fallback discriminator under step 2a — a mention of someone else, or a
+plain-text `@name`, does not count) — the connector fired because the agent
+**subscribes** to the commented-on recording (a card/thread it participates
+in), not because it was addressed. Treat this as *activity on a followed
+thread*, not a directive:
 
 1. **Read for context** — the comment (`recording.content`) and, as needed, its
    parent (`recording.parent`) and neighbours. This is the same non-blocking

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -37,6 +37,20 @@ class EventTest < Minitest::Test
     refute BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload("agent_subscribed" => "true")).subscribed?
   end
 
+  def test_mentioned_reflects_only_the_verifier_stamp
+    # the sample content mentions the agent, but the stamp is the verdict
+    refute BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload).mentioned?
+    assert BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload("agent_mentioned" => true)).mentioned?
+    # strictly boolean true — a truthy stand-in must not read as mentioned
+    refute BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload("agent_mentioned" => "true")).mentioned?
+  end
+
+  def test_to_emitted_hash_carries_the_trigger_verdicts
+    assert_equal({ "mentioned" => false, "subscribed" => false }, BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload).to_emitted_hash["trigger"])
+    assert_equal({ "mentioned" => true, "subscribed" => false }, BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload("agent_mentioned" => true)).to_emitted_hash["trigger"])
+    assert_equal({ "mentioned" => false, "subscribed" => true }, BasecampAgentConnector::Basecamp::Event.from_payload(sample_payload("agent_subscribed" => true)).to_emitted_hash["trigger"])
+  end
+
   def test_boost_kind
     assert from_kind("boost_created").boost?
     refute from_kind("comment_created").boost?

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -515,7 +515,79 @@ class PipelineTest < Minitest::Test
     assert_equal 1, @output.string.lines.length
   end
 
+  # The emitted line carries the verifier's own verdict on why the event
+  # targets the agent, so the watcher never decodes mention markup itself.
+  def test_a_mention_emits_a_mentioned_trigger
+    pipeline(corroborating_runner).process(sample_payload)
+
+    assert_equal({ "mentioned" => true, "subscribed" => false }, emitted_trigger)
+  end
+
+  def test_a_comment_on_a_subscribed_recording_emits_a_subscribed_trigger
+    recording = sample_recording("content" => "<p>no mention, just an update</p>")
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(recording)
+    runner.stub "subscriptions show", stdout: subscribers_envelope(200)
+
+    pipeline(runner).process(sample_payload("recording" => recording))
+
+    assert_equal({ "mentioned" => false, "subscribed" => true }, emitted_trigger)
+  end
+
+  def test_an_assignment_emits_neither_trigger_verdict
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(assigned_recording)
+
+    pipeline(runner).process(assignment_payload)
+
+    assert_equal({ "mentioned" => false, "subscribed" => false }, emitted_trigger)
+  end
+
+  def test_mentioned_is_a_fact_about_the_content_whatever_the_kind
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(assigned_recording("content" => "<p>#{mention_html(person_id: 200)} owns this</p>"))
+
+    pipeline(runner).process(assignment_payload)
+
+    assert_equal({ "mentioned" => true, "subscribed" => false }, emitted_trigger)
+  end
+
+  def test_a_chat_line_mention_emits_a_mentioned_trigger
+    runner = FakeCommandRunner.new
+    runner.stub "chat line ", stdout: envelope(chat_line)
+
+    pipeline(runner).process(chat_line_payload)
+
+    assert_equal({ "mentioned" => true, "subscribed" => false }, emitted_trigger)
+  end
+
+  def test_a_boost_emits_neither_trigger_verdict
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ])
+
+    pipeline(runner).process(boost_payload)
+
+    assert_equal({ "mentioned" => false, "subscribed" => false }, emitted_trigger)
+  end
+
+  def test_the_emitted_trigger_is_the_verifiers_verdict_not_a_claim_in_the_payload
+    # The POST claims agent_mentioned=true on a comment whose authoritative
+    # content mentions nobody; it emits only by subscription, and says so.
+    recording = sample_recording("content" => "<p>no mention</p>")
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(recording)
+    runner.stub "subscriptions show", stdout: subscribers_envelope(200)
+
+    pipeline(runner).process(sample_payload("agent_mentioned" => true, "recording" => recording))
+
+    assert_equal({ "mentioned" => false, "subscribed" => true }, emitted_trigger)
+  end
+
   private
+    def emitted_trigger
+      JSON.parse(@output.string)["trigger"]
+    end
+
     def colleague
       { "id" => 300, "name" => "Marie", "email_address" => "marie@example.com", "client" => false }
     end

--- a/test/verifier_test.rb
+++ b/test/verifier_test.rb
@@ -124,6 +124,29 @@ class VerifierTest < Minitest::Test
     assert_empty runner.commands_matching(/subscriptions show/)
   end
 
+  def test_stamps_mentioned_from_the_authoritative_recording_not_the_claim
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(sample_recording)
+
+    # the POST's content mentions nobody; the re-fetched recording does
+    verified = verifier(runner).verify(event(sample_payload("recording" => sample_recording("content" => "<p>no mention</p>"))))
+
+    refute_nil verified
+    assert verified.mentioned?
+  end
+
+  def test_does_not_stamp_mentioned_when_the_authoritative_recording_mentions_someone_else
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", stdout: envelope(sample_recording("content" => "<p>#{mention_html(person_id: 999)}</p>"))
+    runner.stub "subscriptions show", stdout: subscribers_envelope(200)
+
+    verified = verifier(runner).verify(event(sample_payload))
+
+    refute_nil verified
+    refute verified.mentioned?
+    assert verified.subscribed?
+  end
+
   def test_does_not_stamp_subscribed_when_the_recording_is_not_a_comment
     # A forged comment_created pointing at a subscribed Message/Card: creator
     # corroborates, but the authoritative recording is not a Comment, so it is


### PR DESCRIPTION
## The failure

The verifier already settles *why* an event targets the agent — a mention attachment carrying the agent's Person id on the re-fetched recording, or a `comment_created` on a recording the live subscribers API says the agent follows — and stamps `agent_subscribed` onto the authoritative event. But `Event#to_emitted_hash` never emitted that stamp, and there was no mention verdict on the event at all. So the skill's front thread (#17) re-derived the mention-vs-followed-thread decision — boost or no boost, directive or activity — by decoding the `bc-attachment` SGID against a Person id it captured at startup: a second copy of `Event#mentioned_person_ids`, in prose, where any slip turns a followed thread into a boosted, dispatched directive (or a real mention into silence).

## The change

Every emitted line now carries a `trigger` object:

```json
"trigger": {"mentioned": true, "subscribed": false}
```

- `mentioned` — the verifier's `mentions?` verdict on the re-fetched recording (stamped as `agent_mentioned`, read by `Event#mentioned?`).
- `subscribed` — the existing `agent_subscribed` stamp.

Both are stamped in `Verifier#authoritative_event` on the same re-fetched recording the pipeline's `targets_agent?` re-check reads (the pipeline still runs `Event#mentions?` itself; the stamp serves the emitted line), so the emitted verdict cannot disagree with the drop decision — and a claimed `agent_mentioned` in a POST never reaches the line (test included). A `comment_created` is exactly one of the two; assignments and boosts are directives by `kind` alone (`subscribed` false; `mentioned` is a fact about the content — an assigned card whose description mentions the agent reads `true`; the boost path settles no mention verdict at all, so a boost reads `false` by construction; both pinned by tests).

`docs/spec.md` and the README document the shape. `SKILL.md`'s two classification passages (the no-boost discriminator under step 2a, and *When a comment lands on a thread the agent follows*) now read `trigger` first and fall back to the Person-id markup match only when a line has no `trigger` key (an older connector). The GitHub-review/operator bullet is untouched — it is being edited separately.

## Why a `trigger` object rather than two top-level booleans

The emitted line's top level mirrors the webhook envelope (`id` → `event_id`, `kind`, `created_at`, `creator`, `details`, `recording`) — every top-level key is something Basecamp said. The verdicts are the one thing the connector says, so they get one connector-owned key: the top level stays a webhook mirror, and the skill's "older connector" check is a single key presence rather than two. It also leaves room to add a verdict later without another top-level key.

## Declined

- **Emitting `assigned` / `boosted` verdicts too.** Both are already unambiguous from the line: an `*_assignment_changed` line is emitted only when the agent is a corroborated assignee, a `boost_created` line only when the boost is in the agent's own feed. `mentioned` and `subscribed` are the two a watcher cannot derive without the agent's Person id.
- **Computing `mentioned` at emit time with the agent's identity** (`to_emitted_hash(agent)` / an agent-aware `Emitter`). The emitter is shared with GitHub `ReviewEvent` lines and knows no agent; stamping in the verifier keeps the house pattern (`agent_subscribed`, `agent_boosted`) and guarantees the emitted verdict is the verified one.
- **Suppressing `mentioned` on assignment events** so "assignments carry both false" reads cleanly. That hides a true fact about the content for the sake of a sentence; the docs state the actual semantics instead.
- **Fixing `docs/spec.md`'s Component 2 note that the *dispatched* agent acknowledges by boosting** (the skill moved that to the front thread in #17). Real drift, but outside this change's shape section — left for a follow-up.
- **Stamping `agent_mentioned` on the boost path** (`mentions_agent?(boost["recording"] || {})` in `authoritative_boost_event`, review round 2) so `mentioned` is "a content fact for every kind" by construction. A boost is a reaction to the agent's *own* recording; evaluating a mention verdict there yields a meaningless `true` should the feed ever carry the recording's content (the agent's own comment mentioning itself), and the skill routes boosts by `kind`, never by `trigger`. The docs now say what the code does — the boost path settles no mention verdict — instead of attributing the `false` to the feed's shape.
- **Reading the `agent_mentioned` stamp in `Pipeline#targets_agent?`** instead of re-running `Event#mentions?`. `targets_agent?` also runs on the raw, unstamped event as the pre-filter (`worth_verifying?`), so it would need two forms; the comment and docs were reworded to stop claiming a single computation instead.
- **Dropping the markup-match fallback from the skill.** An installed skill can run against an older `bin/connect`; the fallback stays until every deployment emits `trigger`.

## Tests

`bundle exec rake test`: 265 runs, 820 assertions, green. With `lib/` reverted the ten new tests fail (7 failures, 3 errors). `bundle exec rubocop lib test`: clean.

