### PR TITLE
Back the pollers off when Basecamp rate-limits them

### DIFF
--- a/lib/basecamp_agent_connector/basecamp/boost_poller.rb
+++ b/lib/basecamp_agent_connector/basecamp/boost_poller.rb
@@ -90,6 +90,12 @@ class BasecampAgentConnector::Basecamp::BoostPoller
         warn_of_possible_overflow(ordered)
 
         ordered.each do |boost|
+          # A corroboration the budget refused ends the tick too: each
+          # further actionable boost would re-fetch the feed with more
+          # refused calls. Unprocessed boosts stay unseen, so the backed-off
+          # next tick picks them up.
+          break if @rate_limited
+
           if @seen_boost_ids.include?(boost["id"])
             # already handled
           elsif received_since_start?(boost)

--- a/lib/basecamp_agent_connector/basecamp/boost_poller.rb
+++ b/lib/basecamp_agent_connector/basecamp/boost_poller.rb
@@ -49,6 +49,7 @@ class BasecampAgentConnector::Basecamp::BoostPoller
     # and drop it for good. See received_since_start?.
     @started_at = @clock.call.floor
     @stopping = false
+    @rate_limited = false
     @backoff = nil
   end
 
@@ -80,26 +81,32 @@ class BasecampAgentConnector::Basecamp::BoostPoller
   # baseline and a pre-start boost that deletions slide back into the
   # newest-page window later — either way, history is never dispatched.
   def poll
-    return if @stopping
+    unless @stopping
+      @rate_limited = false
 
-    boosts = @basecamp_cli.received_boosts(profile: @agent.profile)
-    ordered = boosts.sort_by { |boost| boost["id"].to_i }
-    warn_of_possible_overflow(ordered)
+      begin
+        boosts = @basecamp_cli.received_boosts(profile: @agent.profile)
+        ordered = boosts.sort_by { |boost| boost["id"].to_i }
+        warn_of_possible_overflow(ordered)
 
-    ordered.each do |boost|
-      if @seen_boost_ids.include?(boost["id"])
-        # already handled
-      elsif received_since_start?(boost)
-        process(boost)
-      else
-        @seen_boost_ids << boost["id"]
+        ordered.each do |boost|
+          if @seen_boost_ids.include?(boost["id"])
+            # already handled
+          elsif received_since_start?(boost)
+            process(boost)
+          else
+            @seen_boost_ids << boost["id"]
+          end
+        end
+      rescue BasecampAgentConnector::Basecamp::Client::Error => error
+        note_rate_limit(error)
+        log "boost poll failed: #{error.message}"
+      ensure
+        # In an ensure so a tick a bug crashes still settles: it drew no
+        # refusal, so it resets, and the crash stays visible via poll_loop.
+        @rate_limited ? extend_backoff : reset_backoff
       end
     end
-
-    reset_backoff
-  rescue BasecampAgentConnector::Basecamp::Client::Error => error
-    log "boost poll failed: #{error.message}"
-    error.rate_limited? ? extend_backoff : reset_backoff
   end
 
   private
@@ -144,6 +151,7 @@ class BasecampAgentConnector::Basecamp::BoostPoller
       @seen_boost_ids.delete(boost["id"]) unless @pipeline.process(BasecampAgentConnector::Basecamp::Event.boost_payload(boost))
     rescue BasecampAgentConnector::Basecamp::Client::TransientError => error
       @seen_boost_ids.delete(boost["id"])
+      note_rate_limit(error)
       log "could not corroborate boost #{boost["id"]}: #{error.message}; retried on the next poll"
     end
 
@@ -174,10 +182,21 @@ class BasecampAgentConnector::Basecamp::BoostPoller
     # MAX_BACKOFF; the first tick that draws no rate-limit refusal — a
     # success, or any other failure — restores the configured cadence.
     # Logged when the delay changes, not on every backed-off tick.
+    def note_rate_limit(error)
+      @rate_limited ||= error.is_a?(BasecampAgentConnector::Basecamp::Client::Error) && error.rate_limited?
+    end
+
+    # Backoff only ever lengthens the delay: doubling stops at the cap, and
+    # a configured interval at or above the cap never backs off at all —
+    # min against a smaller cap would speed a slow poller *up*.
     def extend_backoff
-      extended = [ (@backoff || @interval) * 2, MAX_BACKOFF ].min
-      log "rate limited; backing off boost polls to #{extended}s" unless extended == @backoff
-      @backoff = extended
+      current = @backoff || @interval
+      extended = [ current * 2, [ @interval, MAX_BACKOFF ].max ].min
+
+      if extended > current
+        @backoff = extended
+        log "rate limited; backing off boost polls to #{extended}s"
+      end
     end
 
     def reset_backoff

--- a/lib/basecamp_agent_connector/basecamp/boost_poller.rb
+++ b/lib/basecamp_agent_connector/basecamp/boost_poller.rb
@@ -31,6 +31,8 @@ class BasecampAgentConnector::Basecamp::BoostPoller
   # overflow warning, not a request parameter.
   FEED_WINDOW = 15
 
+  MAX_BACKOFF = 300
+
   def initialize(basecamp_cli:, pipeline:, agent:, interval: DEFAULT_INTERVAL, logger: $stderr,
     wait: ->(seconds) { sleep seconds }, clock: -> { Time.now })
     @basecamp_cli = basecamp_cli
@@ -47,6 +49,7 @@ class BasecampAgentConnector::Basecamp::BoostPoller
     # and drop it for good. See received_since_start?.
     @started_at = @clock.call.floor
     @stopping = false
+    @backoff = nil
   end
 
   # Nothing is fetched or emitted until the poll thread's first pass, one
@@ -92,8 +95,11 @@ class BasecampAgentConnector::Basecamp::BoostPoller
         @seen_boost_ids << boost["id"]
       end
     end
+
+    reset_backoff
   rescue BasecampAgentConnector::Basecamp::Client::Error => error
     log "boost poll failed: #{error.message}"
+    error.rate_limited? ? extend_backoff : reset_backoff
   end
 
   private
@@ -102,7 +108,7 @@ class BasecampAgentConnector::Basecamp::BoostPoller
     # must cost one tick, not all coverage for the rest of the session.
     def poll_loop
       until @stopping
-        @wait.call(@interval)
+        @wait.call(@backoff || @interval)
 
         begin
           poll
@@ -159,6 +165,24 @@ class BasecampAgentConnector::Basecamp::BoostPoller
       else
         ordered.none? { |boost| @seen_boost_ids.include?(boost["id"]) }
       end
+    end
+
+    # The API budget is shared account-wide across every concurrent CLI
+    # process, so a rate-limited poll means the account is over budget, not
+    # that anything here is wrong — see ChatPoller's backoff for the full
+    # rationale. Each rate-limited tick doubles the effective sleep, up to
+    # MAX_BACKOFF; the first tick that draws no rate-limit refusal — a
+    # success, or any other failure — restores the configured cadence.
+    # Logged when the delay changes, not on every backed-off tick.
+    def extend_backoff
+      extended = [ (@backoff || @interval) * 2, MAX_BACKOFF ].min
+      log "rate limited; backing off boost polls to #{extended}s" unless extended == @backoff
+      @backoff = extended
+    end
+
+    def reset_backoff
+      log "no longer rate limited; resuming #{@interval}s boost polls" if @backoff
+      @backoff = nil
     end
 
     def log(message)

--- a/lib/basecamp_agent_connector/basecamp/chat_poller.rb
+++ b/lib/basecamp_agent_connector/basecamp/chat_poller.rb
@@ -169,6 +169,11 @@ class BasecampAgentConnector::Basecamp::ChatPoller
       warn_of_possible_overflow(room, ordered, seen, first_fetch)
 
       ordered.each do |line|
+        # A corroboration the budget refused ends the room too: each further
+        # actionable line would spend more refused calls. Unprocessed lines
+        # stay unseen, so the backed-off next tick picks them up.
+        break if @rate_limited
+
         if seen.include?(line["id"])
           # already handled
         elsif posted_since_start?(line)

--- a/lib/basecamp_agent_connector/basecamp/chat_poller.rb
+++ b/lib/basecamp_agent_connector/basecamp/chat_poller.rb
@@ -26,6 +26,7 @@ class BasecampAgentConnector::Basecamp::ChatPoller
   DEFAULT_INTERVAL = 15
   FETCH_LIMIT = 50
   REDISCOVER_AFTER = 600
+  MAX_BACKOFF = 300
 
   Room = Data.define(:project, :chat_id, :title)
 
@@ -47,6 +48,8 @@ class BasecampAgentConnector::Basecamp::ChatPoller
     # drop it for good. See posted_since_start?.
     @started_at = @clock.call.floor
     @stopping = false
+    @rate_limited = false
+    @backoff = nil
   end
 
   # Discovers synchronously — so the caller can report an accurate room count
@@ -75,7 +78,11 @@ class BasecampAgentConnector::Basecamp::ChatPoller
   end
 
   def poll
-    rooms.each { |room| poll_room(room) } unless @stopping
+    unless @stopping
+      @rate_limited = false
+      rooms.each { |room| poll_room(room) }
+      @rate_limited ? extend_backoff : reset_backoff
+    end
   end
 
   # Discovery is per project: a project whose listing fails keeps its stale
@@ -113,6 +120,7 @@ class BasecampAgentConnector::Basecamp::ChatPoller
         Room.new(project: project, chat_id: chat["id"], title: chat["title"])
       end
     rescue BasecampAgentConnector::Basecamp::Client::Error => error
+      note_rate_limit(error)
       log "could not list chats for project #{project}: #{error.message}"
       nil
     end
@@ -122,7 +130,7 @@ class BasecampAgentConnector::Basecamp::ChatPoller
     # not all coverage for the rest of the session.
     def poll_loop
       until @stopping
-        @wait.call(@interval)
+        @wait.call(@backoff || @interval)
 
         begin
           poll
@@ -156,6 +164,7 @@ class BasecampAgentConnector::Basecamp::ChatPoller
     rescue => error
       # Broad on purpose: one bad room (or a pipeline bug) must not kill the
       # poll thread or starve the other rooms.
+      note_rate_limit(error)
       log "chat poll failed for #{room.title.inspect} in project #{room.project}: #{error.message}"
     end
 
@@ -212,6 +221,30 @@ class BasecampAgentConnector::Basecamp::ChatPoller
       else
         ordered.none? { |line| seen.include?(line["id"]) }
       end
+    end
+
+    # The API budget is shared account-wide across every concurrent CLI
+    # process, so a rate-limited poll means the account is over budget, not
+    # that anything here is wrong — and re-asking on the regular cadence
+    # costs a failed call and a noisy log line per tick while crowding the
+    # neighbours. Ease off instead: each rate-limited tick doubles the
+    # effective sleep, up to MAX_BACKOFF, and the first tick that draws no
+    # rate-limit refusal — a success, or any other failure — restores the
+    # configured cadence. Logged when the delay changes, not on every
+    # backed-off tick.
+    def note_rate_limit(error)
+      @rate_limited ||= error.is_a?(BasecampAgentConnector::Basecamp::Client::Error) && error.rate_limited?
+    end
+
+    def extend_backoff
+      extended = [ (@backoff || @interval) * 2, MAX_BACKOFF ].min
+      log "rate limited; backing off chat polls to #{extended}s" unless extended == @backoff
+      @backoff = extended
+    end
+
+    def reset_backoff
+      log "no longer rate limited; resuming #{@interval}s chat polls" if @backoff
+      @backoff = nil
     end
 
     def log(message)

--- a/lib/basecamp_agent_connector/basecamp/chat_poller.rb
+++ b/lib/basecamp_agent_connector/basecamp/chat_poller.rb
@@ -60,6 +60,10 @@ class BasecampAgentConnector::Basecamp::ChatPoller
   # on a room's first fetch.
   def start
     discovered = rooms
+    # A refusal during this synchronous discovery already proves the budget
+    # is exhausted — let the first wait back off instead of retrying at the
+    # configured cadence.
+    extend_backoff if @rate_limited
     @thread = Thread.new { poll_loop }
     discovered
   end
@@ -80,8 +84,20 @@ class BasecampAgentConnector::Basecamp::ChatPoller
   def poll
     unless @stopping
       @rate_limited = false
-      rooms.each { |room| poll_room(room) }
-      @rate_limited ? extend_backoff : reset_backoff
+
+      begin
+        # One refusal is the account's shared budget saying no to everyone,
+        # so spending the rest of the tick's calls would only be refused
+        # too: stop at the first and let the backed-off next tick retry.
+        rooms.each do |room|
+          break if @rate_limited
+          poll_room(room)
+        end
+      ensure
+        # In an ensure so a tick a bug crashes still settles: it drew no
+        # refusal, so it resets, and the crash stays visible via poll_loop.
+        @rate_limited ? extend_backoff : reset_backoff
+      end
     end
   end
 
@@ -95,7 +111,7 @@ class BasecampAgentConnector::Basecamp::ChatPoller
 
   private
     def rooms_for(project)
-      refresh(project) if due_for_discovery?(project)
+      refresh(project) if due_for_discovery?(project) && !@rate_limited
       @rooms_by_project[project]
     end
 
@@ -200,6 +216,7 @@ class BasecampAgentConnector::Basecamp::ChatPoller
       seen.delete(line["id"]) unless @pipeline.process(BasecampAgentConnector::Basecamp::Event.chat_line_payload(line))
     rescue BasecampAgentConnector::Basecamp::Client::TransientError => error
       seen.delete(line["id"])
+      note_rate_limit(error)
       log "could not corroborate chat line #{line["id"]}: #{error.message}; retried on the next poll"
     end
 
@@ -236,10 +253,17 @@ class BasecampAgentConnector::Basecamp::ChatPoller
       @rate_limited ||= error.is_a?(BasecampAgentConnector::Basecamp::Client::Error) && error.rate_limited?
     end
 
+    # Backoff only ever lengthens the delay: doubling stops at the cap, and
+    # a configured interval at or above the cap never backs off at all —
+    # min against a smaller cap would speed a slow poller *up*.
     def extend_backoff
-      extended = [ (@backoff || @interval) * 2, MAX_BACKOFF ].min
-      log "rate limited; backing off chat polls to #{extended}s" unless extended == @backoff
-      @backoff = extended
+      current = @backoff || @interval
+      extended = [ current * 2, [ @interval, MAX_BACKOFF ].max ].min
+
+      if extended > current
+        @backoff = extended
+        log "rate limited; backing off chat polls to #{extended}s"
+      end
     end
 
     def reset_backoff

--- a/lib/basecamp_agent_connector/basecamp/client.rb
+++ b/lib/basecamp_agent_connector/basecamp/client.rb
@@ -20,9 +20,10 @@ class BasecampAgentConnector::Basecamp::Client
     # across every CLI process on the account. The CLI's taxonomy reserves
     # the code "rate_limit" for that refusal, but today's binary relays the
     # API's own "rate limit exceeded" body as a generic api_error — so
-    # recognize either spelling. A caller that can defer should ease off
-    # rather than keep asking on its regular cadence; see the pollers'
-    # backoff.
+    # recognize either spelling (kept in step with TRANSIENT_API_ERROR,
+    # which classifies both as no-verdict). A caller that can defer should
+    # ease off rather than keep asking on its regular cadence; see the
+    # pollers' backoff.
     def rate_limited?
       code == "rate_limit" || @envelope["error"].to_s.match?(/rate limit/i)
     end
@@ -62,8 +63,13 @@ class BasecampAgentConnector::Basecamp::Client
   # The envelope drops the SDK's Retryable flag, so these fixed messages are
   # all there is to key on until the CLI emits that flag — the intended end
   # state, after which this pattern goes.
+  # A rate limit is transient too, in either spelling (the dedicated code
+  # above, or bc3's "rate limit exceeded" body relayed as an api_error):
+  # "not now" is no verdict on the recording, and the account-wide budget
+  # rolls over in seconds — so a webhook defers to redelivery and a poller
+  # to its next (backed-off) tick, rather than recording a drop.
   TRANSIENT_CODES = %w[auth_required network rate_limit]
-  TRANSIENT_API_ERROR = /token refresh|request failed after \d+ attempts?|server error \(500\)|gateway error \(50\d\)|\bAPI error: 5\d\d\b|service temporarily unavailable/i
+  TRANSIENT_API_ERROR = /token refresh|request failed after \d+ attempts?|server error \(500\)|gateway error \(50\d\)|\bAPI error: 5\d\d\b|service temporarily unavailable|rate limit/i
 
   def initialize(command_runner: BasecampAgentConnector::CommandRunner.new, executable: "basecamp",
     wait: ->(seconds) { sleep seconds })

--- a/lib/basecamp_agent_connector/basecamp/client.rb
+++ b/lib/basecamp_agent_connector/basecamp/client.rb
@@ -25,7 +25,11 @@ class BasecampAgentConnector::Basecamp::Client
     # ease off rather than keep asking on its regular cadence; see the
     # pollers' backoff.
     def rate_limited?
-      code == "rate_limit" || @envelope["error"].to_s.match?(/rate limit/i)
+      self.class.rate_limited_envelope?(@envelope)
+    end
+
+    def self.rate_limited_envelope?(envelope)
+      envelope["code"] == "rate_limit" || envelope["error"].to_s.match?(/rate limit/i)
     end
   end
 
@@ -137,11 +141,18 @@ class BasecampAgentConnector::Basecamp::Client
     # Reads take the default, since re-asking is idempotent; a mutation
     # passes `attempts: 1`, because a lost answer is not a lost request.
     def json(*arguments, attempts: ATTEMPTS)
-      result = parsed = nil
+      result = parsed = refusal = nil
 
       attempts.times do |attempt|
         result = run(*arguments, "-j")
         parsed = parse(result.stdout)
+        # Rate-limit evidence survives the retries: under concurrent load
+        # the budget refusal and the keyring race co-occur, and a final
+        # attempt failing the other way must not erase a refusal an earlier
+        # one drew — the pollers pace themselves off it. A later verdict
+        # still stands unflagged below: an answered verdict proves the
+        # budget answered.
+        refusal ||= parsed if envelope?(parsed) && Error.rate_limited_envelope?(parsed)
 
         if result.success? && !parsed.nil?
           return unwrap(parsed)
@@ -152,7 +163,7 @@ class BasecampAgentConnector::Basecamp::Client
         end
       end
 
-      raise failure(TransientError, arguments, result, parsed, tried: attempts)
+      raise failure(TransientError, arguments, result, refusal || parsed, tried: attempts)
     end
 
     def parse(stdout)

--- a/lib/basecamp_agent_connector/basecamp/client.rb
+++ b/lib/basecamp_agent_connector/basecamp/client.rb
@@ -3,7 +3,30 @@ require "json"
 class BasecampAgentConnector::Basecamp::Client
   # Basecamp answered, and the answer was no: not found, forbidden, invalid.
   # Asking again cannot change it.
-  class Error < StandardError; end
+  class Error < StandardError
+    def initialize(message = nil, envelope: nil)
+      super(message)
+      @envelope = envelope.to_h
+    end
+
+    # The failure envelope's machine-readable code — "not_found",
+    # "rate_limit", "api_error", ... — or nil when the command produced no
+    # envelope at all.
+    def code
+      @envelope["code"]
+    end
+
+    # bc3 refuses an over-budget account with 429, and the budget is shared
+    # across every CLI process on the account. The CLI's taxonomy reserves
+    # the code "rate_limit" for that refusal, but today's binary relays the
+    # API's own "rate limit exceeded" body as a generic api_error — so
+    # recognize either spelling. A caller that can defer should ease off
+    # rather than keep asking on its regular cadence; see the pollers'
+    # backoff.
+    def rate_limited?
+      code == "rate_limit" || @envelope["error"].to_s.match?(/rate limit/i)
+    end
+  end
 
   # The CLI never got an answer out of Basecamp — on any of ATTEMPTS tries.
   # Asking again later may well succeed, so a caller that can defer (a webhook
@@ -117,19 +140,28 @@ class BasecampAgentConnector::Basecamp::Client
         if result.success? && !parsed.nil?
           return unwrap(parsed)
         elsif !transient?(parsed)
-          raise Error, "`basecamp #{arguments.join(' ')}` #{outcome(result)}: #{detail(result)}"
+          raise failure(Error, arguments, result, parsed)
         elsif attempt < attempts - 1
           @wait.call(RETRY_DELAYS.fetch(attempt))
         end
       end
 
-      raise TransientError, "`basecamp #{arguments.join(' ')}` #{outcome(result)}#{" on all #{attempts} attempts" if attempts > 1}: #{detail(result)}"
+      raise failure(TransientError, arguments, result, parsed, tried: attempts)
     end
 
     def parse(stdout)
       JSON.parse(stdout)
     rescue JSON::ParserError
       nil
+    end
+
+    # The refusal keeps its envelope (when the CLI produced one) so callers
+    # can key behavior off the machine-readable code rather than the prose —
+    # see Error#code and Error#rate_limited?.
+    def failure(kind, arguments, result, parsed, tried: 1)
+      attempts_note = " on all #{tried} attempts" if tried > 1
+      kind.new "`basecamp #{arguments.join(' ')}` #{outcome(result)}#{attempts_note}: #{detail(result)}",
+        envelope: (parsed if envelope?(parsed))
     end
 
     # No envelope at all — the process died before it could answer, or its

--- a/test/basecamp_client_test.rb
+++ b/test/basecamp_client_test.rb
@@ -253,6 +253,36 @@ class BasecampClientTest < Minitest::Test
     assert_equal "api_error", error.code
   end
 
+  # Under concurrent load the budget refusal and the keyring race co-occur:
+  # an early attempt's rate-limit envelope must survive a final attempt that
+  # fails the other transient way, or the caller would pace as if no refusal
+  # happened.
+  def test_rate_limit_evidence_survives_mixed_transient_retries
+    runner = FakeCommandRunner.new
+    runner.stub "chat messages", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded"), once: true
+    runner.stub "chat messages", exit_status: 3, stdout: error_envelope("auth_required", "Not authenticated"), times: 2
+
+    error = assert_raises(BasecampAgentConnector::Basecamp::Client::TransientError) do
+      build_cli(runner).chat_lines(project: 222, chat: 333, limit: 50)
+    end
+
+    assert_predicate error, :rate_limited?
+  end
+
+  # A verdict on a later attempt proves the budget answered — it stands as
+  # itself, unflagged by the earlier refusal.
+  def test_a_verdict_after_a_rate_limited_attempt_stands_unflagged
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded"), once: true
+    runner.stub "basecamp show", exit_status: 2, stdout: error_envelope("not_found", "Resource not found: 456")
+
+    error = assert_raises(BasecampAgentConnector::Basecamp::Client::Error) { build_cli(runner).show("456") }
+
+    refute_kind_of BasecampAgentConnector::Basecamp::Client::TransientError, error
+    refute_predicate error, :rate_limited?
+    assert_equal "not_found", error.code
+  end
+
   def test_a_non_rate_limit_failure_is_not_mistaken_for_one
     runner = FakeCommandRunner.new
     runner.stub "basecamp show", exit_status: 2, stdout: error_envelope("not_found", "Resource not found: 456")

--- a/test/basecamp_client_test.rb
+++ b/test/basecamp_client_test.rb
@@ -230,6 +230,48 @@ class BasecampClientTest < Minitest::Test
 
     assert_equal BasecampAgentConnector::Basecamp::Client::ATTEMPTS, runner.commands.length
     assert_match(/failed on all 3 attempts: .*rate_limit/, error.message)
+    assert_predicate error, :rate_limited?
+  end
+
+  # Production evidence (project 48672814's 15s chat poll): today's binary
+  # relays bc3's 429 body as a generic api_error — {"ok": false, "error":
+  # "rate limit exceeded", "code": "api_error"} on stdout, nonzero exit —
+  # rather than the taxonomy's dedicated rate_limit code. That is Basecamp's
+  # refusal, not a lost answer: it surfaces at once (one attempt — re-asking
+  # within the same limiting window only burns more budget) and is
+  # recognizable, so a poller can ease off.
+  def test_a_rate_limited_api_error_surfaces_at_once_and_is_recognizable
+    runner = FakeCommandRunner.new
+    runner.stub "chat messages", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded")
+
+    error = assert_raises(BasecampAgentConnector::Basecamp::Client::Error) do
+      build_cli(runner).chat_lines(project: 222, chat: 333, limit: 50)
+    end
+
+    refute_kind_of BasecampAgentConnector::Basecamp::Client::TransientError, error
+    assert_equal 1, runner.commands.length
+    assert_predicate error, :rate_limited?
+    assert_equal "api_error", error.code
+  end
+
+  def test_a_non_rate_limit_failure_is_not_mistaken_for_one
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp show", exit_status: 2, stdout: error_envelope("not_found", "Resource not found: 456")
+
+    error = assert_raises(BasecampAgentConnector::Basecamp::Client::Error) { build_cli(runner).show("456") }
+
+    refute_predicate error, :rate_limited?
+    assert_equal "not_found", error.code
+  end
+
+  def test_a_failure_without_an_envelope_carries_no_code
+    runner = FakeCommandRunner.new
+    stub_transient_failure runner, "basecamp show", stdout: "", exit_status: 1
+
+    error = assert_raises(BasecampAgentConnector::Basecamp::Client::TransientError) { build_cli(runner).show("456") }
+
+    assert_nil error.code
+    refute_predicate error, :rate_limited?
   end
 
   def test_chats_lists_a_projects_chats

--- a/test/basecamp_client_test.rb
+++ b/test/basecamp_client_test.rb
@@ -236,20 +236,19 @@ class BasecampClientTest < Minitest::Test
   # Production evidence (project 48672814's 15s chat poll): today's binary
   # relays bc3's 429 body as a generic api_error — {"ok": false, "error":
   # "rate limit exceeded", "code": "api_error"} on stdout, nonzero exit —
-  # rather than the taxonomy's dedicated rate_limit code. That is Basecamp's
-  # refusal, not a lost answer: it surfaces at once (one attempt — re-asking
-  # within the same limiting window only burns more budget) and is
-  # recognizable, so a poller can ease off.
-  def test_a_rate_limited_api_error_surfaces_at_once_and_is_recognizable
+  # rather than the taxonomy's dedicated rate_limit code. Either spelling is
+  # "not now", not a verdict: retried through like any transient failure
+  # (the budget window rolls over in seconds) and recognizable on the way
+  # out, so a caller that can defer eases off instead of recording a drop.
+  def test_a_rate_limited_api_error_is_transient_and_recognizable
     runner = FakeCommandRunner.new
-    runner.stub "chat messages", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded")
+    stub_transient_failure runner, "chat messages", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded")
 
-    error = assert_raises(BasecampAgentConnector::Basecamp::Client::Error) do
+    error = assert_raises(BasecampAgentConnector::Basecamp::Client::TransientError) do
       build_cli(runner).chat_lines(project: 222, chat: 333, limit: 50)
     end
 
-    refute_kind_of BasecampAgentConnector::Basecamp::Client::TransientError, error
-    assert_equal 1, runner.commands.length
+    assert_equal BasecampAgentConnector::Basecamp::Client::ATTEMPTS, runner.commands.length
     assert_predicate error, :rate_limited?
     assert_equal "api_error", error.code
   end

--- a/test/boost_poller_test.rb
+++ b/test/boost_poller_test.rb
@@ -406,6 +406,19 @@ class BoostPollerTest < Minitest::Test
     assert_match(/no longer rate limited; resuming 15s boost polls/, @logs.string)
   end
 
+  def test_stops_processing_boosts_after_a_rate_limited_corroboration
+    second = received_boost("id" => 88002)
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost, second ]), once: true
+    runner.stub "api get /my/boosts.json", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded")
+
+    poller(runner).poll
+
+    # The feed fetch plus one refused corroboration (three client attempts);
+    # the second boost's verification waits for the backed-off next tick.
+    assert_equal 1 + BasecampAgentConnector::Basecamp::Client::ATTEMPTS, runner.commands_matching(%r{api get /my/boosts\.json}).length
+  end
+
   private
     def poller(runner, clock: -> { BEFORE_THE_BOOST }, wait: ->(_seconds) { }, trust_authorizer: authorizer, interval: 15)
       BasecampAgentConnector::Basecamp::BoostPoller.new \

--- a/test/boost_poller_test.rb
+++ b/test/boost_poller_test.rb
@@ -277,6 +277,92 @@ class BoostPollerTest < Minitest::Test
     refute poller.instance_variable_get(:@thread)
   end
 
+  # Same account-wide budget pressure as the chat poll: a rate-limited tick
+  # doubles the effective sleep, a clean one restores the cadence.
+  def test_rate_limited_polls_back_off_doubling_until_a_clean_poll_resets_the_cadence
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded"), times: 3
+    runner.stub "api get /my/boosts.json", stdout: envelope([])
+    delays = Queue.new
+    ticks = Queue.new
+    poller = poller(runner, wait: ->(seconds) { delays << seconds; ticks.pop })
+
+    poller.start
+    waited = [ delays.pop ]
+    4.times do
+      ticks << true
+      waited << delays.pop
+    end
+
+    assert_equal [ 15, 30, 60, 120, 15 ], waited
+    assert_equal 3, @logs.string.scan(/backing off boost polls/).length
+    assert_match(/no longer rate limited; resuming 15s boost polls/, @logs.string)
+  ensure
+    poller&.stop
+  end
+
+  def test_backoff_stops_doubling_at_the_cap
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded")
+    delays = Queue.new
+    ticks = Queue.new
+    poller = poller(runner, wait: ->(seconds) { delays << seconds; ticks.pop })
+
+    poller.start
+    waited = [ delays.pop ]
+    6.times do
+      ticks << true
+      waited << delays.pop
+    end
+
+    assert_equal [ 15, 30, 60, 120, 240, 300, 300 ], waited
+    assert_equal 5, @logs.string.scan(/backing off boost polls/).length
+  ensure
+    poller&.stop
+  end
+
+  # The taxonomy's dedicated rate_limit code takes the client's transient
+  # path — retried through before surfacing — and still eases the poller off.
+  def test_the_dedicated_rate_limit_code_backs_off_too
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", exit_status: 5, stdout: error_envelope("rate_limit", "Rate limit exceeded")
+    delays = Queue.new
+    ticks = Queue.new
+    poller = poller(runner, wait: ->(seconds) { delays << seconds; ticks.pop })
+
+    poller.start
+    waited = [ delays.pop ]
+    ticks << true
+    waited << delays.pop
+
+    assert_equal [ 15, 30 ], waited
+  ensure
+    poller&.stop
+  end
+
+  # While backed off, any tick that draws no rate-limit refusal restores the
+  # cadence: whatever else went wrong, the budget stopped refusing.
+  def test_a_non_rate_limit_failure_resets_an_active_backoff
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded"), once: true
+    stub_transient_failure runner, "api get /my/boosts.json", stdout: "", exit_status: 6
+    delays = Queue.new
+    ticks = Queue.new
+    poller = poller(runner, wait: ->(seconds) { delays << seconds; ticks.pop })
+
+    poller.start
+    waited = [ delays.pop ]
+    2.times do
+      ticks << true
+      waited << delays.pop
+    end
+
+    assert_equal [ 15, 30, 15 ], waited
+    assert_match(/no longer rate limited; resuming 15s boost polls/, @logs.string)
+  ensure
+    poller&.stop
+  end
+
   private
     def poller(runner, clock: -> { BEFORE_THE_BOOST }, wait: ->(_seconds) { }, trust_authorizer: authorizer)
       BasecampAgentConnector::Basecamp::BoostPoller.new \

--- a/test/boost_poller_test.rb
+++ b/test/boost_poller_test.rb
@@ -281,7 +281,8 @@ class BoostPollerTest < Minitest::Test
   # doubles the effective sleep, a clean one restores the cadence.
   def test_rate_limited_polls_back_off_doubling_until_a_clean_poll_resets_the_cadence
     runner = FakeCommandRunner.new
-    runner.stub "api get /my/boosts.json", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded"), times: 3
+    # Three rate-limited ticks, each retried through by the client (3 attempts).
+    runner.stub "api get /my/boosts.json", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded"), times: 9
     runner.stub "api get /my/boosts.json", stdout: envelope([])
     delays = Queue.new
     ticks = Queue.new
@@ -344,7 +345,7 @@ class BoostPollerTest < Minitest::Test
   # cadence: whatever else went wrong, the budget stopped refusing.
   def test_a_non_rate_limit_failure_resets_an_active_backoff
     runner = FakeCommandRunner.new
-    runner.stub "api get /my/boosts.json", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded"), once: true
+    runner.stub "api get /my/boosts.json", exit_status: 7, stdout: error_envelope("api_error", "rate limited"), times: 3
     stub_transient_failure runner, "api get /my/boosts.json", stdout: "", exit_status: 6
     delays = Queue.new
     ticks = Queue.new
@@ -363,13 +364,55 @@ class BoostPollerTest < Minitest::Test
     poller&.stop
   end
 
+  # A configured interval at or above the cap is already slower than any
+  # backoff could make it — rate limiting must not speed the poller up.
+  def test_an_interval_beyond_the_cap_never_backs_off
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded")
+    delays = Queue.new
+    ticks = Queue.new
+    poller = poller(runner, interval: 600, wait: ->(seconds) { delays << seconds; ticks.pop })
+
+    poller.start
+    waited = [ delays.pop ]
+    2.times do
+      ticks << true
+      waited << delays.pop
+    end
+
+    assert_equal [ 600, 600, 600 ], waited
+    refute_match(/backing off/, @logs.string)
+  ensure
+    poller&.stop
+  end
+
+  # A rate-limited corroborating re-fetch is the same budget refusing: the
+  # boost is forgotten for the next tick (as with any transient failure) and
+  # the tick still backs off.
+  def test_a_rate_limited_corroboration_backs_off_and_retries_the_boost
+    runner = FakeCommandRunner.new
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ]), once: true
+    runner.stub "api get /my/boosts.json", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded"), times: 3
+    runner.stub "api get /my/boosts.json", stdout: envelope([ received_boost ])
+    poller = poller(runner)
+
+    poller.poll
+    assert_empty @output.string
+    assert_match(/could not corroborate boost 88001/, @logs.string)
+    assert_match(/rate limited; backing off boost polls to 30s/, @logs.string)
+
+    poller.poll
+    assert_equal 1, @output.string.lines.length
+    assert_match(/no longer rate limited; resuming 15s boost polls/, @logs.string)
+  end
+
   private
-    def poller(runner, clock: -> { BEFORE_THE_BOOST }, wait: ->(_seconds) { }, trust_authorizer: authorizer)
+    def poller(runner, clock: -> { BEFORE_THE_BOOST }, wait: ->(_seconds) { }, trust_authorizer: authorizer, interval: 15)
       BasecampAgentConnector::Basecamp::BoostPoller.new \
         basecamp_cli: build_cli(runner),
         pipeline: pipeline(runner, trust_authorizer),
         agent: @agent,
-        interval: 15,
+        interval: interval,
         logger: @logs,
         wait: wait,
         clock: clock

--- a/test/chat_poller_test.rb
+++ b/test/chat_poller_test.rb
@@ -288,6 +288,94 @@ class ChatPollerTest < Minitest::Test
     assert_equal 1, @output.string.lines.length
   end
 
+  # Live evidence for the backoff: repeated {"ok": false, "error": "rate
+  # limit exceeded", "code": "api_error"} failures on the 15s chat poll —
+  # the account's API budget is shared across many concurrent CLI processes,
+  # and every hammered tick cost a failed call and a noisy log line.
+  def test_rate_limited_polls_back_off_doubling_until_a_clean_poll_resets_the_cadence
+    runner = FakeCommandRunner.new
+    runner.stub "chat list", stdout: envelope([ chat_hash ])
+    runner.stub "chat messages", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded"), times: 3
+    runner.stub "chat messages", stdout: empty_envelope
+    delays = Queue.new
+    ticks = Queue.new
+    poller = poller(runner, wait: ->(seconds) { delays << seconds; ticks.pop })
+
+    poller.start
+    waited = [ delays.pop ]
+    4.times do
+      ticks << true
+      waited << delays.pop
+    end
+
+    assert_equal [ 15, 30, 60, 120, 15 ], waited
+    assert_equal 3, @logs.string.scan(/backing off chat polls/).length
+    assert_match(/rate limited; backing off chat polls to 120s/, @logs.string)
+    assert_match(/no longer rate limited; resuming 15s chat polls/, @logs.string)
+  ensure
+    poller&.stop
+  end
+
+  def test_backoff_stops_doubling_at_the_cap
+    runner = FakeCommandRunner.new
+    runner.stub "chat list", stdout: envelope([ chat_hash ])
+    runner.stub "chat messages", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded")
+    delays = Queue.new
+    ticks = Queue.new
+    poller = poller(runner, wait: ->(seconds) { delays << seconds; ticks.pop })
+
+    poller.start
+    waited = [ delays.pop ]
+    6.times do
+      ticks << true
+      waited << delays.pop
+    end
+
+    assert_equal [ 15, 30, 60, 120, 240, 300, 300 ], waited
+    # One log line per change of delay; the tick already at the cap adds none.
+    assert_equal 5, @logs.string.scan(/backing off chat polls/).length
+  ensure
+    poller&.stop
+  end
+
+  def test_a_rate_limited_chat_listing_backs_off_too
+    runner = FakeCommandRunner.new
+    runner.stub "chat list", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded")
+    delays = Queue.new
+    ticks = Queue.new
+    poller = poller(runner, wait: ->(seconds) { delays << seconds; ticks.pop })
+
+    poller.start
+    waited = [ delays.pop ]
+    ticks << true
+    waited << delays.pop
+
+    assert_equal [ 15, 30 ], waited
+  ensure
+    poller&.stop
+  end
+
+  def test_a_non_rate_limit_failure_keeps_the_regular_cadence
+    runner = FakeCommandRunner.new
+    runner.stub "chat list", stdout: envelope([ chat_hash ])
+    runner.stub "chat messages", exit_status: 7, stdout: error_envelope("api_error", "API error: 410 Gone")
+    delays = Queue.new
+    ticks = Queue.new
+    poller = poller(runner, wait: ->(seconds) { delays << seconds; ticks.pop })
+
+    poller.start
+    waited = [ delays.pop ]
+    2.times do
+      ticks << true
+      waited << delays.pop
+    end
+
+    assert_equal [ 15, 15, 15 ], waited
+    refute_match(/backing off/, @logs.string)
+  ensure
+    poller&.stop
+  end
+
   def test_warns_when_the_fetch_window_may_have_overflowed
     stranger = { "id" => 400, "name" => "Sam", "email_address" => "sam@elsewhere.net" }
     window = Array.new(BasecampAgentConnector::Basecamp::ChatPoller::FETCH_LIMIT) do |index|

--- a/test/chat_poller_test.rb
+++ b/test/chat_poller_test.rb
@@ -295,7 +295,8 @@ class ChatPollerTest < Minitest::Test
   def test_rate_limited_polls_back_off_doubling_until_a_clean_poll_resets_the_cadence
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: envelope([ chat_hash ])
-    runner.stub "chat messages", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded"), times: 3
+    # Three rate-limited ticks, each retried through by the client (3 attempts).
+    runner.stub "chat messages", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded"), times: 9
     runner.stub "chat messages", stdout: empty_envelope
     delays = Queue.new
     ticks = Queue.new
@@ -338,7 +339,9 @@ class ChatPollerTest < Minitest::Test
     poller&.stop
   end
 
-  def test_a_rate_limited_chat_listing_backs_off_too
+  # A refusal during start's synchronous discovery already proves the budget
+  # is exhausted, so even the first wait backs off.
+  def test_a_rate_limited_chat_listing_backs_off_from_the_start
     runner = FakeCommandRunner.new
     runner.stub "chat list", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded")
     delays = Queue.new
@@ -350,7 +353,7 @@ class ChatPollerTest < Minitest::Test
     ticks << true
     waited << delays.pop
 
-    assert_equal [ 15, 30 ], waited
+    assert_equal [ 30, 60 ], waited
   ensure
     poller&.stop
   end
@@ -374,6 +377,64 @@ class ChatPollerTest < Minitest::Test
     refute_match(/backing off/, @logs.string)
   ensure
     poller&.stop
+  end
+
+  # A configured interval at or above the cap is already slower than any
+  # backoff could make it — rate limiting must not speed the poller up.
+  def test_an_interval_beyond_the_cap_never_backs_off
+    runner = FakeCommandRunner.new
+    runner.stub "chat list", stdout: envelope([ chat_hash ])
+    runner.stub "chat messages", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded")
+    delays = Queue.new
+    ticks = Queue.new
+    poller = poller(runner, interval: 600, wait: ->(seconds) { delays << seconds; ticks.pop })
+
+    poller.start
+    waited = [ delays.pop ]
+    2.times do
+      ticks << true
+      waited << delays.pop
+    end
+
+    assert_equal [ 600, 600, 600 ], waited
+    refute_match(/backing off/, @logs.string)
+  ensure
+    poller&.stop
+  end
+
+  def test_polls_only_until_the_first_rate_limited_room
+    runner = FakeCommandRunner.new
+    runner.stub "chat list", stdout: envelope([ chat_hash, chat_hash("id" => 444, "title" => "Ops") ])
+    runner.stub "chat messages", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded")
+
+    poller(runner).poll
+
+    # One refused fetch (three client attempts) for the first room; the
+    # second room's fetch waits for the backed-off next tick.
+    assert_equal BasecampAgentConnector::Basecamp::Client::ATTEMPTS, runner.commands_matching(/chat messages/).length
+  end
+
+  # A rate-limited corroborating re-fetch is the same budget refusing: the
+  # line is forgotten for the next tick (as with any transient failure) and
+  # the tick still backs off.
+  def test_a_rate_limited_corroboration_backs_off_and_retries_the_line
+    runner = FakeCommandRunner.new
+    runner.stub "chat list", stdout: envelope([ chat_hash ])
+    runner.stub "chat messages", stdout: empty_envelope, once: true
+    runner.stub "chat messages", stdout: envelope([ chat_line ])
+    runner.stub "chat line ", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded"), times: 3
+    runner.stub "chat line ", stdout: envelope(chat_line)
+    poller = poller(runner)
+
+    poller.poll
+    poller.poll
+    assert_empty @output.string
+    assert_match(/could not corroborate chat line 91001/, @logs.string)
+    assert_match(/rate limited; backing off chat polls to 30s/, @logs.string)
+
+    poller.poll
+    assert_equal 1, @output.string.lines.length
+    assert_match(/no longer rate limited; resuming 15s chat polls/, @logs.string)
   end
 
   def test_warns_when_the_fetch_window_may_have_overflowed
@@ -539,13 +600,15 @@ class ChatPollerTest < Minitest::Test
     # The canonical chat_line is created at 12:00; the default clock starts the
     # poller before that, so fetched lines count as live traffic. Tests about
     # history/baselining override the clock to after 12:00 instead.
-    def poller(runner, projects: [ "A" ], wait: ->(_seconds) { flunk "no waiting in direct-poll tests" }, clock: -> { Time.utc(2026, 6, 28, 11, 0, 0) })
+    def poller(runner, projects: [ "A" ], wait: ->(_seconds) { flunk "no waiting in direct-poll tests" }, clock: -> { Time.utc(2026, 6, 28, 11, 0, 0) },
+      interval: BasecampAgentConnector::Basecamp::ChatPoller::DEFAULT_INTERVAL)
       cli = build_cli(runner)
 
       BasecampAgentConnector::Basecamp::ChatPoller.new \
         basecamp_cli: cli,
         pipeline: pipeline(cli),
         projects: projects,
+        interval: interval,
         logger: @logs,
         wait: wait,
         clock: clock

--- a/test/chat_poller_test.rb
+++ b/test/chat_poller_test.rb
@@ -437,6 +437,24 @@ class ChatPollerTest < Minitest::Test
     assert_match(/no longer rate limited; resuming 15s chat polls/, @logs.string)
   end
 
+  def test_stops_processing_lines_after_a_rate_limited_corroboration
+    second = chat_line("id" => 91002, "app_url" => "https://3.basecamp.com/000/buckets/222/chats/333@91002",
+      "url" => "https://3.basecamp.com/000/buckets/222/chats/333/lines/91002.json")
+    runner = FakeCommandRunner.new
+    runner.stub "chat list", stdout: envelope([ chat_hash ])
+    runner.stub "chat messages", stdout: empty_envelope, once: true
+    runner.stub "chat messages", stdout: envelope([ chat_line, second ])
+    runner.stub "chat line ", exit_status: 7, stdout: error_envelope("api_error", "rate limit exceeded")
+    poller = poller(runner)
+
+    poller.poll
+    poller.poll
+
+    # One refused corroboration (three client attempts); the second line's
+    # verification waits for the backed-off next tick.
+    assert_equal BasecampAgentConnector::Basecamp::Client::ATTEMPTS, runner.commands_matching(/chat line /).length
+  end
+
   def test_warns_when_the_fetch_window_may_have_overflowed
     stranger = { "id" => 400, "name" => "Sam", "email_address" => "sam@elsewhere.net" }
     window = Array.new(BasecampAgentConnector::Basecamp::ChatPoller::FETCH_LIMIT) do |index|


### PR DESCRIPTION
## Why

Live evidence: three `rate limit exceeded` failures within ~an hour on the 15s chat poll against project 48672814. The account's API budget is shared across many concurrent CLI processes, so a rate-limited poll means the account is over budget — and re-asking on the regular cadence costs a failed call and a noisy log line per tick while crowding the very budget the poller is waiting on.

## What

**Rate-limited refusals are transient, in either spelling.** The CLI's `-j` failure envelope now rides along on the raised error, exposing `code` and a `rate_limited?` predicate. The taxonomy's dedicated `rate_limit` code (exit 5) was already classified transient; bc3's `rate limit exceeded` body relayed as a generic `api_error` — the spelling seen live — now matches `TRANSIENT_API_ERROR` too. "Not now" is no verdict: a rate-limited corroboration re-fetch is forgotten and retried instead of silently dropped, and the webhook path defers to redelivery via 503.

**`ChatPoller` and `BoostPoller` ease off on that signal.** Each rate-limited tick doubles the effective sleep — 15s → 30 → 60 → 120 → 240 → capped at 300s — and the first tick that draws no rate-limit refusal (a success, or any other failure — the tick settles in an `ensure`, so even a crashed tick settles) restores the configured cadence. The backoff only ever lengthens the delay: a configured interval at or above the cap is never sped up. A refusal seen anywhere counts — the poll fetch, chat discovery (including `start`'s synchronous pass, which backs the first wait off), or a corroborating re-fetch — and one refusal ends the tick: remaining rooms and due rediscoveries wait for the backed-off next tick instead of burning more refused calls. The backoff logs once per change of delay, not on every backed-off tick. Non-rate-limit failures keep their current behavior: immediate retry on the next tick.

## Tests

Reality-shaped fixtures (`{"ok": false, "error": "rate limit exceeded", "code": "api_error"}` on stdout, exit 7, matching the CLI's error envelope and exit-code taxonomy): backoff progression, cap (with log-once-per-change asserted), reset on a clean poll, reset on a non-rate-limit failure, startup-discovery refusal backing off the first wait, stop-at-first-refused-room, rate-limited corroboration feeding the backoff and retrying the event, intervals above the cap never sped up, the dedicated `rate_limit` code, and non-rate-limit failures unaffected. Full suite (270 runs) and rubocop green.

## Deploy note

The running connector is not restarted by this merge — the coordinator should cycle it after merging to pick up the backoff.