### PR TITLE
Chat replies: forbid raw HTML, require prose/Markdown

### DIFF
--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -580,15 +580,16 @@ with these differences:
   ```
   The CLI resolves @mentions (`@Name`, or `[@Name](person:<creator.id>)` to
   pin by Person id); a reply containing one posts as rich text with its
-  Markdown converted. A mention-free reply posts as plain text — Markdown
-  renders literally, so keep those replies plain prose. **Author the body as
-  plain prose or Markdown only — never raw HTML.** The CLI converts Markdown
-  and resolves mentions; it does not accept hand-written HTML, so tags like
-  `<p>`, `<strong>`, or `<a href>` post literally instead of formatting the
-  line (a `<strong>` headline lands as visible `<strong>…</strong>` text, not
-  bold). Write `**bold**`, `- bullets`, and bare URLs (which autolink on their
-  own); the `[@Name](person:<id>)` mention syntax above is the only
-  non-Markdown markup the CLI understands. Keep replies
+  Markdown converted — so format those with Markdown (`**bold**`, `- bullets`,
+  and bare URLs, which autolink on their own). A mention-free reply posts as
+  plain text — Markdown renders literally, so keep those replies plain prose.
+  **Never hand-write HTML in either case.** The CLI converts Markdown and
+  resolves mentions; it does not accept raw HTML, so tags like `<p>`,
+  `<strong>`, or `<a href>` are wrong in the Markdown path (write the Markdown
+  instead) and post literally in the plain-text path — a `<strong>` headline
+  lands as visible `<strong>…</strong>` text, not bold. The
+  `[@Name](person:<id>)` mention syntax above is the only non-Markdown markup
+  the CLI understands. Keep replies
   chat-sized; spill long results into a Basecamp doc or comment and link
   them. On failure, @mention the requester so it notifies:
   `[@Name](person:<creator.id>)`.

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -581,7 +581,14 @@ with these differences:
   The CLI resolves @mentions (`@Name`, or `[@Name](person:<creator.id>)` to
   pin by Person id); a reply containing one posts as rich text with its
   Markdown converted. A mention-free reply posts as plain text — Markdown
-  renders literally, so keep those replies plain prose. Keep replies
+  renders literally, so keep those replies plain prose. **Author the body as
+  plain prose or Markdown only — never raw HTML.** The CLI converts Markdown
+  and resolves mentions; it does not accept hand-written HTML, so tags like
+  `<p>`, `<strong>`, or `<a href>` post literally instead of formatting the
+  line (a `<strong>` headline lands as visible `<strong>…</strong>` text, not
+  bold). Write `**bold**`, `- bullets`, and bare URLs (which autolink on their
+  own); the `[@Name](person:<id>)` mention syntax above is the only
+  non-Markdown markup the CLI understands. Keep replies
   chat-sized; spill long results into a Basecamp doc or comment and link
   them. On failure, @mention the requester so it notifies:
   `[@Name](person:<creator.id>)`.


### PR DESCRIPTION
## What

Strengthens the **Reply in the chat as the agent** guidance in `skills/basecamp-connect/SKILL.md` to name the raw-HTML failure mode explicitly.

## Why

A recent Campfire reply in the MCP project posted with raw HTML structure because an agent authored the body in HTML (`<p>`, `<strong>`, and hand-written `<a href>…thread</a>` anchors) instead of Markdown. The basecamp CLI's `chat post` converts **Markdown** and resolves mentions; it does not want hand-written HTML. The guidance previously only said "keep replies plain prose" for the mention-free case, which didn't cover the failure.

## Change

The section now states plainly: author chat bodies as **plain prose or Markdown only — never raw HTML**. Write `**bold**`, `- bullets`, and bare autolinking URLs; the `[@Name](person:<id>)` mention syntax is the only non-Markdown markup the CLI understands.