### PR TITLE
The README makes /basecamp-connect look like it has a syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ default and can be said in passing.
 /basecamp-connect use @Clawdito to watch https://3.basecamp.com/2914079/projects/41746046
 /basecamp-connect @Clawdito on Queenbee, with jorge as the operator
 /basecamp-connect @Clawdito on BC5.1 plus PR reviews on basecamp/bc3
+/basecamp-connect @Clawdito on On Call, poll chat every 5s, skip boosts
 /basecamp-connect watch PR reviews on basecamp/bc3
 ```
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ default and can be said in passing.
 /basecamp-connect watch BC5.1 and On Call as @Clawdito
 /basecamp-connect @Clawdito — projects BC5.1, On Call, and 20361308
 /basecamp-connect use @Clawdito to watch https://3.basecamp.com/2914079/projects/41746046
-/basecamp-connect @Clawdito on Queenbee, and let anyone at 37signals.com trigger it
+/basecamp-connect @Clawdito on Queenbee, with jorge as the operator
 /basecamp-connect @Clawdito on BC5.1 plus PR reviews on basecamp/bc3
 /basecamp-connect @Clawdito on On Call, poll chat every 5s, skip boosts
 /basecamp-connect watch PR reviews on basecamp/bc3
@@ -117,9 +117,10 @@ A few things worth knowing about what you can ask for:
 - **Several projects, one connector.** One webhook per project, all multiplexed
   onto a single funnel path, so the same `@agent` watches every project you named
   at once. Add as many as you like.
-- **Who's allowed to trigger it defaults to you alone.** Broaden it in the same
-  sentence — "let Marie trigger it too," "anyone at 37signals.com," "anyone on
-  the project" — see [Trust modes](#trust-modes) for what each one really means.
+- **Only you can trigger it.** That's the default and it's the one to stay on —
+  the agent acts with your full machine authority, so widening the trust set
+  hands that authority to someone else. It *can* be widened; read
+  [Trust modes](#trust-modes) first, including the email-redaction limit.
 - **GitHub PR reviews ride the same server.** Ask for a repo ("plus PR reviews on
   basecamp/bc3") and review events arrive on the same funnel. Only **your**
   approvals (the login `gh` is signed in as) reach the agent as `approved`;

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ default and can be said in passing.
 /basecamp-connect use @Clawdito to watch https://3.basecamp.com/2914079/projects/41746046
 /basecamp-connect @Clawdito on Queenbee, with jorge as the operator
 /basecamp-connect @Clawdito on BC5.1 plus PR reviews on basecamp/bc3
-/basecamp-connect @Clawdito on On Call, poll chat every 5s, skip boosts
+/basecamp-connect @Clawdito on On Call, poll chat every 30s, skip boosts
 /basecamp-connect watch PR reviews on basecamp/bc3
 ```
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ default and can be said in passing.
 /basecamp-connect use @Clawdito to watch https://3.basecamp.com/2914079/projects/41746046
 /basecamp-connect @Clawdito on Queenbee, with jorge as the operator
 /basecamp-connect @Clawdito on BC5.1 plus PR reviews on basecamp/bc3
-/basecamp-connect @Clawdito on On Call, poll chat every 5s, skip boosts
 /basecamp-connect watch PR reviews on basecamp/bc3
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,30 +77,54 @@ You need three things in place:
 
 ### Using it
 
-From Claude Code:
+In Claude Code, run `/basecamp-connect` and say which agent and which projects.
+**There's no syntax to memorize** — the skill reads plain English. It needs two
+things from you: the **agent** (an `@profile`) and at least one **project**.
+Everything else has a sane default and can be said in passing.
 
 ```
-/basecamp-connect @Clawdito --project "BC5 Calendar"
+/basecamp-connect @Clawdito on BC5 Calendar
+/basecamp-connect watch BC5.1 and On Call as @Clawdito
+/basecamp-connect @Clawdito — projects BC5.1, On Call, and 20361308
+/basecamp-connect use @Clawdito to watch https://3.basecamp.com/2914079/projects/41746046
+/basecamp-connect @Clawdito on Queenbee, and let anyone at 37signals.com trigger it
+/basecamp-connect @Clawdito on BC5.1 plus PR reviews on basecamp/bc3
+/basecamp-connect @Clawdito on On Call, poll chat every 5s, skip boosts
 ```
 
-That starts watching the named project(s). Now go to Basecamp and @mention
-`@Clawdito` in a comment/message/card with what you want done. Each time you do,
-the agent runs and replies.
+All of those work. The skill confirms what it understood before it starts
+anything, so a loose phrasing costs you a sentence, not a wrong connection.
 
-**Watch several projects at once** — repeat `--project` (name, URL, or ID).
-A single connector run registers one webhook per project and multiplexes them all
-onto one funnel path, so the same `@agent` watches every listed project simultaneously:
+The flag form still works too, if you prefer typing it that way —
+`/basecamp-connect @Clawdito --project "BC5 Calendar" --project "On Call"` — and
+it's what gets handed to `bin/connect` underneath either way. Skip it: say what
+you want.
 
-```
-/basecamp-connect @Clawdito --project "BC5.1" --project "On Call" --project 20361308
-```
+Then go to Basecamp and @mention `@Clawdito` in a comment, message, or card with
+what you want done. Each time you do, the agent runs and replies.
 
-- `--project` takes a **name, URL, or ID** — the CLI resolves it.
-- Watch GitHub PR reviews too, over the **same** server: add `--repo <owner>/<repo>`
-  (repeatable). You need at least one `--project` or `--repo`; `--project` also
-  needs an `@agent`. Only **your** approvals (the login `gh` is signed in as, or
-  `--gh-operator <login>`) reach the agent as `approved`; anyone else's approval
-  is dropped, while their requested changes and comments still come through.
+**Invoked bare, `/basecamp-connect` reuses your last connection** — agent,
+projects, trust, and polling, from `~/.config/basecamp-connect/last.json`. It
+shows you those and asks before reconnecting, so the usual second session is
+just `/basecamp-connect` and a yes.
+
+A few things worth knowing about what you can ask for:
+
+- **A project can be a name, a URL, or an ID.** Any of the three resolves; a
+  partial name is fine if it's unambiguous.
+- **Several projects, one connector.** One webhook per project, all multiplexed
+  onto a single funnel path, so the same `@agent` watches every project you named
+  at once. Add as many as you like.
+- **Who's allowed to trigger it defaults to you alone.** Broaden it in the same
+  sentence — "let Marie trigger it too," "anyone at 37signals.com," "anyone on
+  the project" — see [Trust modes](#trust-modes) for what each one really means.
+- **GitHub PR reviews ride the same server.** Ask for a repo ("plus PR reviews on
+  basecamp/bc3") and review events arrive on the same funnel. Only **your**
+  approvals (the login `gh` is signed in as) reach the agent as `approved`;
+  someone else's approval is dropped, while their requested changes and comments
+  still come through.
+- **You need an agent and at least one project** — or a repo, for a
+  GitHub-only run. That's the whole requirement.
 
 ### Stopping (and why it matters)
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ You need three things in place:
 
 ### Using it
 
-In Claude Code, run `/basecamp-connect` and say which agent and which projects.
-**There's no syntax to memorize** — the skill reads plain English. It needs two
-things from you: the **agent** (an `@profile`) and at least one **project**.
-Everything else has a sane default and can be said in passing.
+In Claude Code, run `/basecamp-connect` and say who should watch what.
+**There's no syntax to memorize** — the skill reads plain English. It needs an
+**agent** (an `@profile`) and at least one **project** — or, for a GitHub-only
+run, just a **repo**, with no agent and no project. Everything else has a sane
+default and can be said in passing.
 
 ```
 /basecamp-connect @Clawdito on BC5 Calendar
@@ -90,6 +91,7 @@ Everything else has a sane default and can be said in passing.
 /basecamp-connect @Clawdito on Queenbee, and let anyone at 37signals.com trigger it
 /basecamp-connect @Clawdito on BC5.1 plus PR reviews on basecamp/bc3
 /basecamp-connect @Clawdito on On Call, poll chat every 5s, skip boosts
+/basecamp-connect watch PR reviews on basecamp/bc3
 ```
 
 All of those work. The skill confirms what it understood before it starts
@@ -123,8 +125,9 @@ A few things worth knowing about what you can ask for:
   approvals (the login `gh` is signed in as) reach the agent as `approved`;
   someone else's approval is dropped, while their requested changes and comments
   still come through.
-- **You need an agent and at least one project** — or a repo, for a
-  GitHub-only run. That's the whole requirement.
+- **Two shapes are valid, and that's the whole requirement.** An agent and at
+  least one project, for watching Basecamp; or a repo on its own, for a
+  GitHub-only run — no agent, no project. You can also have both at once.
 
 ### Stopping (and why it matters)
 

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -90,16 +90,18 @@ run `bin/setup` (see the repo README).
 ## Invocation
 
 **The arguments are natural language, not a grammar.** Read whatever the user
-wrote and pull out the agent, the projects, and any trust or polling wishes —
-`@Clawdito on BC5 Calendar`, `watch BC5.1 and On Call as @Clawdito`, `use
-@Clawdito on Queenbee and let anyone at 37signals.com trigger it` all mean what
-they say. Never make the user restate it as flags. The flags below are the
-**canonical form you translate into** before calling `bin/connect`, and they're
-also accepted verbatim when the user types them.
+wrote and pull out the agent, the projects, the repositories, and any trust or
+polling wishes — `@Clawdito on BC5 Calendar`, `watch BC5.1 and On Call as
+@Clawdito`, `use @Clawdito on Queenbee and let anyone at 37signals.com trigger
+it`, `watch reviews on basecamp/bc3` all mean what they say. Never make the user
+restate it as flags. The flags below are the **canonical form you translate
+into** before calling `bin/connect`, and they're also accepted verbatim when the
+user types them.
 
-Ask only for what's genuinely missing (an agent, or a project), and confirm the
-resolved connection before launching — the same confirmation the no-args path
-does.
+Ask only for what's genuinely missing: something to watch (a project or a repo),
+plus an agent whenever Basecamp projects are in play — a repo-only run needs
+neither an agent nor a project. Confirm the resolved connection before
+launching — the same confirmation the no-args path does.
 
 ```
 /basecamp-connect                                                     # reuse last connection (confirm first)
@@ -108,11 +110,13 @@ does.
 /basecamp-connect @Clawdito --project "BC5 Calendar" --operator jorge # explicit operator
 /basecamp-connect @Clawdito --project "BC5 Calendar" --allow marie@37signals.com  # + a named coworker
 /basecamp-connect @Clawdito --project "BC5 Calendar" --allow-domain 37signals.com # any 37signals author
+/basecamp-connect --repo basecamp/bc3                                 # GitHub-only, no agent
 ```
 
 `<agent>` is a real Basecamp user backed by a local CLI profile (the leading `@`
-is optional; it's lowercased to the profile name). `--project` is **required**
-(Basecamp has no global webhook) — pass a name, URL, or ID. The connector
+is optional; it's lowercased to the profile name). Every run needs at least one
+`--project` or `--repo`, and `--project` needs an `<agent>` (Basecamp has no
+global webhook) — pass a project as a name, URL, or ID. The connector
 **validates the agent profile exists locally at startup** and aborts with setup
 guidance if not.
 
@@ -182,8 +186,9 @@ The skill remembers the last successful connection in
   `--no-boosts` for a stored `null`) when present; missing fields (older
   stores) mean the defaults.
 
-Project ids are stored (not just names) because name lookup is exact-match;
-launching from the store passes ids.
+Project ids are stored (not just names) because a name is only resolved against
+the project list as it stands at launch — a rename, or a newly ambiguous name,
+would resolve elsewhere or not at all; launching from the store passes ids.
 
 ## Prerequisite: the agent must be a local profile authed as that user
 

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -89,6 +89,18 @@ run `bin/setup` (see the repo README).
 
 ## Invocation
 
+**The arguments are natural language, not a grammar.** Read whatever the user
+wrote and pull out the agent, the projects, and any trust or polling wishes —
+`@Clawdito on BC5 Calendar`, `watch BC5.1 and On Call as @Clawdito`, `use
+@Clawdito on Queenbee and let anyone at 37signals.com trigger it` all mean what
+they say. Never make the user restate it as flags. The flags below are the
+**canonical form you translate into** before calling `bin/connect`, and they're
+also accepted verbatim when the user types them.
+
+Ask only for what's genuinely missing (an agent, or a project), and confirm the
+resolved connection before launching — the same confirmation the no-args path
+does.
+
 ```
 /basecamp-connect                                                     # reuse last connection (confirm first)
 /basecamp-connect @Clawdito --project "BC5 Calendar"                 # one project


### PR DESCRIPTION
Someone reads "Using it," sees this as the first thing on the page —

```
/basecamp-connect @Clawdito --project "BC5 Calendar"
```

— and concludes that's the syntax. So they copy it and edit it in place,
quoting project names carefully, repeating `--project`, wondering what happens
if they get a flag wrong.

None of that is real. The skill is a prompt handed to a model. `watch BC5.1 and
On Call as @Clawdito` works exactly as well, and so does mentioning trust or a
repo in the same breath. The flags are what the skill translates *into* before
it calls `bin/connect` — an implementation detail that had been promoted to the
interface.

So the section now leads with the two things actually required, the agent
`@profile` and at least one project, and shows a spread of phrasings that all
work — plain, list-form, a project URL, a trust broadening said in passing, a
GitHub repo, polling tweaks. The flag form stays, one paragraph down, as an
alternative rather than the entrance. The bare `/basecamp-connect` reuse path
gets a mention too, since it's the common second session and wasn't described
here at all.

The skill's own Invocation section opened with the same block of flags, so it's
told the same thing: the arguments are natural language, the flags are the
canonical form you translate into, and never make the user restate a request as
flags.

Follows [Write Basecamp replies as rich text, not flat prose](https://github.com/basecamp/basecamp-local-agent-connector/pull/26).