### PR TITLE
A second connector runs unnoticed, and its webhooks look like litter

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,41 @@ A few things worth knowing about what you can ask for:
   least one project, for watching Basecamp; or a repo on its own, for a
   GitHub-only run — no agent, no project. You can also have both at once.
 
+### More than one connector
+
+Two connectors on the same agent and project is always a mistake: Basecamp
+delivers each event to both, so one mention dispatches two agents and gets two
+replies. `bin/connect` now refuses to start beside a live run that overlaps,
+names the other run's pid, and exits. `--allow-duplicate` overrides it if you
+really mean to.
+
+Each run records itself in `~/.config/basecamp-connect/runs/<pid>.json` — what it
+watches, and the funnel paths it owns — and removes that file at teardown. So
+you can always ask what's running:
+
+```bash
+bin/connect --status
+```
+
+That is also the answer to *"is this leftover webhook safe to delete?"* — a
+question that used to be a guess, and once cost a running connector eleven of
+its webhooks. If a registration's `payload_url` ends in a path `--status` names,
+it belongs to a live run. **Don't delete a webhook you can't attribute:** it may
+be another session's, another machine's, or an older build's (those register
+under `/hook/<secret>` rather than `/bc5/<secret>`), and deleting one leaves that
+connector silently deaf to Basecamp while it goes on polling chat.
+
+`--status` also consults the process table, because the registry only knows runs
+that started with it. A connector from an older build records nothing, so it
+would otherwise read as "nothing running" while holding live webhooks — which is
+exactly how the damage happened. Any `bin/connect` process the registry can't
+account for is now called out by pid, with its paths marked unknown.
+
+Genuine orphans clean themselves up. A run killed with `SIGKILL` never tears
+down, so its entry stays behind with the paths it owned — and the next
+`bin/connect` start prunes the entry and deletes exactly those webhooks. A path
+nobody recorded is never touched.
+
 ### Stopping (and why it matters)
 
 While running, the connector exposes a **public URL** (via Tailscale Funnel) and

--- a/lib/basecamp_agent_connector/basecamp/bridge.rb
+++ b/lib/basecamp_agent_connector/basecamp/bridge.rb
@@ -40,7 +40,13 @@ class BasecampAgentConnector::Basecamp::Bridge
     "/bc5/#{@secret}" if @webhook_types.any?
   end
 
-  def register(base_url:)
+  # Paths this bridge owns, for the run registry to record. Same list the
+  # server mounts; a chat-only bridge owns none.
+  def paths
+    [ path ].compact
+  end
+
+  def register(base_url:, orphan_paths: [])
     # Chat first: webhook registration opens deliveries toward a server that
     # isn't listening yet, so don't widen that window by discovering chats
     # after it. The poller emits nothing until its thread's first interval
@@ -52,6 +58,11 @@ class BasecampAgentConnector::Basecamp::Bridge
     end
 
     if @webhook_types.any?
+      # Before adding ours, reap the registrations a dead run of ours left
+      # pointing at a path nothing serves any more. Only paths the registry
+      # attributed to an exited run reach here.
+      @webhooks.delete_orphans(projects: @projects, paths: orphan_paths)
+
       url = "#{base_url}#{path}"
       @webhooks.register_all(projects: @projects, url: url, types: @webhook_types.join(","))
       log "Listening for mentions of @#{agent_name} on #{@projects.length} project(s) at #{url}"

--- a/lib/basecamp_agent_connector/basecamp/client.rb
+++ b/lib/basecamp_agent_connector/basecamp/client.rb
@@ -146,6 +146,13 @@ class BasecampAgentConnector::Basecamp::Client
     run("webhooks", "delete", id.to_s, "--project", project.to_s).success?
   end
 
+  # Every webhook registered on the project, whoever owns it. Read so a startup
+  # sweep can recognize the ones a dead run of ours left behind — and leave
+  # every other registration alone.
+  def webhooks(project:)
+    Array json("webhooks", "list", "--project", project.to_s)
+  end
+
   private
     # A command either answers (its envelope is handed back), is refused
     # (Error, at once — Basecamp's verdict doesn't improve with repetition),

--- a/lib/basecamp_agent_connector/basecamp/webhooks.rb
+++ b/lib/basecamp_agent_connector/basecamp/webhooks.rb
@@ -23,7 +23,32 @@ class BasecampAgentConnector::Basecamp::Webhooks
     end
   end
 
+  # Reaps registrations left behind by a connector run that died without
+  # tearing down — identified by the funnel paths that run recorded, so
+  # ownership is a fact rather than a guess. A path nobody recorded is nobody's
+  # business here: it may belong to a live connector, another machine, or an
+  # older build, and deleting one of those silently makes it deaf.
+  def delete_orphans(projects:, paths:)
+    return if paths.empty?
+
+    projects.each do |project|
+      orphans_in(project, paths).each do |id|
+        log "deleting webhook #{id} on project #{project} left by an exited connector"
+        delete Registration.new(project: project, id: id)
+      end
+    end
+  end
+
   private
+    def orphans_in(project, paths)
+      @basecamp_cli.webhooks(project: project).filter_map do |webhook|
+        webhook["id"] if paths.any? { |path| webhook["payload_url"].to_s.end_with?(path) }
+      end
+    rescue BasecampAgentConnector::Basecamp::Client::Error => error
+      log "could not list webhooks for project #{project}: #{error.message}"
+      []
+    end
+
     def register(project:, url:, types:)
       webhook = create_with_retries(project: project, url: url, types: types)
       @registrations << Registration.new(project: project, id: webhook.fetch("id"))

--- a/lib/basecamp_agent_connector/connector.rb
+++ b/lib/basecamp_agent_connector/connector.rb
@@ -16,12 +16,73 @@ class BasecampAgentConnector::Connector
   TRUST_MODES = %w[operator allowlist project domain]
 
   Options = Data.define(:agent, :operator, :projects, :types, :repos, :events, :gh_operator, :port,
-    :trust, :allowed_emails, :allowed_domains, :allow_assignments, :chat_poll, :boost_poll)
+    :trust, :allowed_emails, :allowed_domains, :allow_assignments, :chat_poll, :boost_poll, :allow_duplicate)
 
   def self.start(argv)
+    return print_status if argv.include?("--status")
+
     new(parse_options(argv)).start
   rescue ArgumentError => error
     abort error.message
+  end
+
+  # What is already running on this machine, and which funnel paths each run
+  # owns. The one authoritative answer to "is this webhook a leftover?" — read
+  # it before deleting any registration by hand.
+  def self.print_status(registry: BasecampAgentConnector::RunRegistry.new, command_runner: BasecampAgentConnector::CommandRunner.new)
+    registry.prune
+    runs = registry.live
+
+    if runs.empty?
+      puts "No connector recorded as running on this machine."
+    else
+      puts "#{runs.length} connector(s) running on this machine:"
+      runs.each do |run|
+        puts "  #{run.description}"
+        puts "    projects: #{run.projects.join(', ')}" if run.projects.any?
+        puts "    repos:    #{run.repos.join(', ')}" if run.repos.any?
+        puts "    paths:    #{run.paths.any? ? run.paths.join(', ') : "(none — chat-only, no webhooks)"}"
+        puts "    boosts:   #{run.boosts ? "polling" : "off"}"
+      end
+      puts "A webhook whose payload_url ends in one of those paths belongs to a LIVE run. Don't delete it."
+    end
+
+    report_unrecorded_processes(runs, command_runner)
+  end
+
+  # The registry only knows runs that started with it. A connector launched by
+  # an older build — or by another user — records nothing, so it would read as
+  # "nothing running" while holding live webhooks nobody can attribute. That is
+  # precisely how a running connector once lost eleven of its registrations to a
+  # cleanup, so the process table gets consulted too and any pid the registry
+  # doesn't cover is called out rather than passed over in silence.
+  def self.report_unrecorded_processes(runs, command_runner)
+    pids = running_connector_pids(command_runner) - runs.map(&:pid) - [ Process.pid ]
+    return if pids.empty?
+
+    puts
+    puts "#{pids.length} connector process(es) running but NOT recorded: #{pids.join(', ')}."
+    puts "Their funnel paths are unknown, so their webhooks cannot be attributed — do not delete a"
+    puts "registration you cannot account for. Inspect with: ps -fp #{pids.join(',')}"
+  end
+
+  def self.running_connector_pids(command_runner)
+    result = command_runner.run("pgrep", "-f", "bin/connect")
+    result.stdout.split.map(&:to_i).reject(&:zero?).select { |pid| watching_process?(pid) }
+  rescue SystemCallError, Errno::ENOENT
+    []
+  end
+
+  # `pgrep -f` matches the whole command line, so it also catches the shell that
+  # launched a connector (bin/connect buried inside its `-c` string) and this
+  # very `--status` run. A real watcher has `bin/connect` as an argument of its
+  # own and no `--status` among them. An unreadable cmdline errs toward
+  # reporting: an unattributable connector is worth one false positive.
+  def self.watching_process?(pid)
+    arguments = File.read("/proc/#{pid}/cmdline").split("\u0000")
+    arguments.any? { |argument| argument.end_with?("bin/connect") } && !arguments.include?("--status")
+  rescue SystemCallError
+    true
   end
 
   def self.parse_options(argv)
@@ -38,6 +99,7 @@ class BasecampAgentConnector::Connector
     allowed_domains = []
     allow_project = false
     allow_assignments = false
+    allow_duplicate = false
     chat_poll = BasecampAgentConnector::Basecamp::ChatPoller::DEFAULT_INTERVAL
     boost_poll = BasecampAgentConnector::Basecamp::BoostPoller::DEFAULT_INTERVAL
 
@@ -82,6 +144,9 @@ class BasecampAgentConnector::Connector
         boost_poll = value
       end
       parser.on("--no-boosts", "Don't poll the agent's received-boosts feed") { boost_poll = nil }
+      parser.on("--allow-duplicate", "Start even though another connector is already watching this agent " \
+        "on these projects (default: refuse — every event would dispatch twice)") { allow_duplicate = true }
+      parser.on("--status", "List the connectors running on this machine and the funnel paths they own, then exit") { }
       parser.on("--events EVENTS", "Comma-separated GitHub webhook events") { |value| events = value }
       parser.on("--port PORT", Integer, "Local port for the webhook server") { |value| port = value }
     end.parse!(arguments)
@@ -97,7 +162,7 @@ class BasecampAgentConnector::Connector
     Options.new(agent: normalize_agent(agent), operator: operator, projects: projects, types: types, repos: repos, events: events_list(events),
       gh_operator: gh_operator, port: port,
       trust: trust, allowed_emails: allowed_emails, allowed_domains: allowed_domains, allow_assignments: allow_assignments,
-      chat_poll: chat_poll, boost_poll: boost_poll)
+      chat_poll: chat_poll, boost_poll: boost_poll, allow_duplicate: allow_duplicate)
   end
 
   # `--trust MODE` picks the mode explicitly; otherwise the value flags imply
@@ -131,13 +196,22 @@ class BasecampAgentConnector::Connector
     events.split(",").map(&:strip)
   end
 
-  def initialize(options)
+  def initialize(options, registry: BasecampAgentConnector::RunRegistry.new)
     @options = options
+    @registry = registry
   end
 
   def start
+    # Runs that died without tearing down are pruned first: their files would
+    # otherwise read as live connectors and refuse this one, and the paths they
+    # leave behind are exactly what the orphan sweep needs.
+    orphan_paths = @registry.prune.flat_map(&:paths)
+    refuse_duplicate_run
+    warn_of_same_agent_elsewhere
+
     @bridges = build_bridges
     port = @options.port || free_port
+    record_run
 
     # Chat-only watching has no inbound paths, so it needs no funnel at all —
     # Tailscale isn't required unless something actually receives webhooks.
@@ -147,7 +221,7 @@ class BasecampAgentConnector::Connector
         @tunnel = BasecampAgentConnector::Tunnel.new(port: port, paths: paths, command_runner: command_runner)
         @tunnel.start
       end
-    @bridges.each { |bridge| bridge.register(base_url: base_url) }
+    @bridges.each { |bridge| bridge.register(base_url: base_url, orphan_paths: orphan_paths) }
 
     @server = BasecampAgentConnector::Server.new(port: port, routes: routes)
     install_signal_handlers
@@ -238,7 +312,47 @@ class BasecampAgentConnector::Connector
       @server&.stop
       @bridges&.each(&:teardown)
       @tunnel&.stop
+      @registry.forget
     end
+
+    # Two connectors on one agent and one project is never what anyone wanted:
+    # both register a webhook per project, so Basecamp delivers every event to
+    # both, and both poll the same campfires — one mention, two dispatched
+    # agents, two replies. Refuse by default and name the other run, since the
+    # symptom (duplicated work) is far harder to read than this message.
+    def refuse_duplicate_run
+      duplicates = @registry.duplicates_of(agent: @options.agent, projects: @options.projects, repos: @options.repos)
+      return if duplicates.empty? || @options.allow_duplicate
+
+      abort <<~MESSAGE
+        Another connector is already watching @#{@options.agent} on something you asked for:
+        #{duplicates.map { |run| "  #{run.description}" }.join("\n")}
+        Every event would dispatch twice. Stop it first (kill #{duplicates.map(&:pid).join(" ")}), watch
+        different projects, or pass --allow-duplicate if you really mean to run both.
+        `bin/connect --status` lists every run and the funnel paths it owns.
+      MESSAGE
+    end
+
+    # Same agent, no overlap detected. Not fatal, but worth saying: the
+    # received-boosts feed is per-agent, so two boost pollers double every
+    # boost whatever the projects — and project tokens are compared as
+    # written, so a name here and an id there hides a real overlap.
+    def warn_of_same_agent_elsewhere
+      others = @registry.same_agent_elsewhere(agent: @options.agent, projects: @options.projects, repos: @options.repos)
+      return if others.empty?
+
+      warn "Warning: @#{@options.agent} is already being watched by #{others.map(&:description).join("; ")}. " \
+        "No project overlap detected, but project names and ids don't compare, so check `bin/connect --status`."
+      warn "Both runs poll the same received-boosts feed, so every boost dispatches twice — " \
+        "pass --no-boosts to one of them." if @options.boost_poll && others.any?(&:boosts)
+    end
+
+    def record_run
+      @registry.record agent: @options.agent, operator: @options.operator,
+        projects: @options.projects, repos: @options.repos,
+        paths: @bridges.flat_map(&:paths), boosts: !@options.boost_poll.nil?
+    end
+
 
     def free_port
       socket = TCPServer.new("127.0.0.1", 0)

--- a/lib/basecamp_agent_connector/github/bridge.rb
+++ b/lib/basecamp_agent_connector/github/bridge.rb
@@ -27,7 +27,14 @@ class BasecampAgentConnector::GitHub::Bridge
     "/gh/#{@path_secret}"
   end
 
-  def register(base_url:)
+  # Paths this bridge owns, for the run registry to record.
+  def paths
+    [ path ].compact
+  end
+
+  def register(base_url:, orphan_paths: [])
+    @webhooks.delete_orphans(repos: @repos, paths: orphan_paths)
+
     endpoint = "#{base_url}#{path}"
     @webhooks.register_all(repos: @repos, url: endpoint, secret: @hmac_secret, events: @events)
     log "Listening for #{@events.join(', ')} on #{@repos.length} repo(s) at #{endpoint}"

--- a/lib/basecamp_agent_connector/github/client.rb
+++ b/lib/basecamp_agent_connector/github/client.rb
@@ -26,6 +26,12 @@ class BasecampAgentConnector::GitHub::Client
     run("api", "-X", "DELETE", "repos/#{repo}/hooks/#{id}").success?
   end
 
+  # Every hook on the repo, whoever owns it — read so a startup sweep can
+  # recognize the ones a dead run of ours left behind.
+  def webhooks(repo:)
+    Array json("api", "repos/#{repo}/hooks")
+  end
+
   # The login `gh` is authenticated as.
   def authenticated_login
     json("api", "user").fetch("login")

--- a/lib/basecamp_agent_connector/github/webhooks.rb
+++ b/lib/basecamp_agent_connector/github/webhooks.rb
@@ -23,7 +23,29 @@ class BasecampAgentConnector::GitHub::Webhooks
     end
   end
 
+  # The Basecamp side's orphan sweep, for repos: reap hooks pointing at a path
+  # a dead run of ours recorded, and touch nothing else.
+  def delete_orphans(repos:, paths:)
+    return if paths.empty?
+
+    repos.each do |repo|
+      orphans_in(repo, paths).each do |id|
+        log "deleting webhook #{id} on repo #{repo} left by an exited connector"
+        delete Registration.new(repo: repo, id: id)
+      end
+    end
+  end
+
   private
+    def orphans_in(repo, paths)
+      @github_cli.webhooks(repo: repo).filter_map do |hook|
+        hook["id"] if paths.any? { |path| hook.dig("config", "url").to_s.end_with?(path) }
+      end
+    rescue BasecampAgentConnector::GitHub::Client::Error => error
+      log "could not list webhooks for repo #{repo}: #{error.message}"
+      []
+    end
+
     def register(repo:, url:, secret:, events:)
       hook = create_with_retries(repo: repo, url: url, secret: secret, events: events)
       @registrations << Registration.new(repo: repo, id: hook.fetch("id"))

--- a/lib/basecamp_agent_connector/run_registry.rb
+++ b/lib/basecamp_agent_connector/run_registry.rb
@@ -1,0 +1,162 @@
+require "json"
+require "fileutils"
+require "time"
+
+# Which connectors are running on this machine, and which funnel paths each one
+# owns. Two failures made this necessary, both observed in practice:
+#
+# 1. Nothing stopped a second connector starting on the same agent and
+#    projects. Both registered webhooks, both polled the same campfires, both
+#    polled the same received-boosts feed — so one mention dispatched twice,
+#    and the agent replied twice.
+# 2. Nothing could tell a live connector's webhook from a leftover. A cleanup
+#    that read unrecognized `/hook/<secret>` registrations as orphans deleted
+#    eleven belonging to a *running* connector, leaving it deaf to Basecamp
+#    while it went on polling chat, with no error anywhere to say so.
+#
+# So each run records one file naming its pid and the paths it owns, and
+# removes it at teardown. Liveness is a pid probe, which makes a SIGKILLed
+# run's file prunable rather than permanent — and a webhook whose path belongs
+# to a pruned run is provably an orphan, the one case a sweep may delete
+# without asking. An unrecognized path is never touched: it may be another
+# machine's, another tool's, or an older build's, and none of those are ours
+# to reap.
+class BasecampAgentConnector::RunRegistry
+  DEFAULT_DIRECTORY = File.expand_path("~/.config/basecamp-connect/runs")
+
+  # The process start time, in clock ticks since boot, from /proc/<pid>/stat
+  # field 22. Recorded alongside the pid because a pid alone is ambiguous once
+  # it is recycled, and reading a live run as dead is the expensive direction:
+  # the sweep would delete its webhooks. `comm` may itself contain spaces and
+  # parens, so the fields are counted from the last ')'.
+  def self.process_start(pid)
+    stat = File.read("/proc/#{pid}/stat")
+    stat[(stat.rindex(")") + 2)..].split[19]
+  rescue SystemCallError, NoMethodError, TypeError
+    nil
+  end
+
+  Run = Data.define(:pid, :process_start, :started_at, :agent, :operator, :projects, :repos, :paths, :boosts) do
+    def self.from_json(json)
+      new(pid: json["pid"], process_start: json["process_start"], started_at: json["started_at"],
+        agent: json["agent"], operator: json["operator"],
+        projects: Array(json["projects"]), repos: Array(json["repos"]), paths: Array(json["paths"]),
+        boosts: json["boosts"] != false)
+    end
+
+    def alive?
+      Process.kill(0, pid)
+      same_process?
+    rescue Errno::ESRCH
+      false
+    rescue Errno::EPERM
+      # Another user's process: alive enough that pruning it would be a lie.
+      true
+    end
+
+    def description
+      watching = [ projects.any? ? "#{projects.length} project(s)" : nil, repos.any? ? "#{repos.length} repo(s)" : nil ]
+      "pid #{pid}, @#{agent}, #{watching.compact.join(" + ")}, started #{started_at}"
+    end
+
+    private
+      # Only a recorded start time that disagrees with the live one proves the
+      # pid was recycled. Either side missing (no /proc, an older entry) leaves
+      # the bare pid probe as the answer, which errs toward "alive".
+      def same_process?
+        live = BasecampAgentConnector::RunRegistry.process_start(pid)
+        process_start.nil? || live.nil? || process_start == live
+      end
+  end
+
+  def initialize(directory: DEFAULT_DIRECTORY, logger: $stderr)
+    @directory = directory
+    @logger = logger
+  end
+
+  def live
+    entries.map(&:last).select(&:alive?)
+  end
+
+  # Deletes the files of runs that are no longer running and returns those
+  # runs, so the caller can reap what they left behind.
+  def prune
+    entries.filter_map do |file, run|
+      next if run.alive?
+
+      remove(file)
+      run
+    end
+  end
+
+  # Runs of the same agent that overlap on a watched project or repo: two of
+  # those means every event arrives twice.
+  def duplicates_of(agent:, projects:, repos:)
+    same_agent(agent).select do |run|
+      overlap?(run.projects, projects) || overlap?(run.repos, repos)
+    end
+  end
+
+  # Same agent, no detected overlap. Still worth saying out loud: project
+  # tokens are compared as written, so a name in one run and an id in the
+  # other hides a real duplicate — and the received-boosts feed is per-agent,
+  # so two boost pollers on one agent double every boost regardless of
+  # projects.
+  def same_agent_elsewhere(agent:, projects:, repos:)
+    same_agent(agent) - duplicates_of(agent: agent, projects: projects, repos: repos)
+  end
+
+  def record(agent:, operator:, projects:, repos:, paths:, boosts:)
+    FileUtils.mkdir_p @directory
+    File.write file_for(Process.pid), JSON.generate(
+      pid: Process.pid, process_start: self.class.process_start(Process.pid),
+      started_at: Time.now.utc.iso8601, agent: agent, operator: operator,
+      projects: projects, repos: repos, paths: paths, boosts: boosts)
+  rescue SystemCallError => error
+    # Bookkeeping must never take the connector down with it.
+    log "could not record this run in #{@directory}: #{error.message}"
+  end
+
+  def forget
+    remove file_for(Process.pid)
+  end
+
+  private
+    def entries
+      Dir.glob(File.join(@directory, "*.json")).filter_map { |file| read(file) }
+    end
+
+    def same_agent(agent)
+      live.select { |run| run.agent == agent }
+    end
+
+    def overlap?(recorded, requested)
+      (normalize(recorded) & normalize(requested)).any?
+    end
+
+    def normalize(tokens)
+      Array(tokens).map { |token| token.to_s.strip.downcase }.reject(&:empty?)
+    end
+
+    def read(file)
+      [ file, Run.from_json(JSON.parse(File.read(file))) ]
+    rescue JSON::ParserError, SystemCallError, TypeError
+      # An unreadable or half-written file says nothing; leaving it costs one
+      # skipped entry, deleting it could drop a live run's paths.
+      nil
+    end
+
+    def remove(file)
+      File.delete file
+    rescue SystemCallError
+      nil
+    end
+
+    def file_for(pid)
+      File.join(@directory, "#{pid}.json")
+    end
+
+    def log(message)
+      @logger.puts message
+    end
+end

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -239,7 +239,21 @@ wake you per event. You therefore need **two** steps: run the connector in the
 background, then arm a persistent monitor on its output so each new event
 notifies you automatically — with no user prompting in between.
 
-**a. Run the connector in the background** and note the output-file path the
+**a. Check what is already running, then start.** A second connector on the
+same agent and project makes Basecamp deliver every event twice, so ask first:
+
+```bash
+cd ~/Work/basecamp/basecamp-local-agent-connector && bin/connect --status
+```
+
+That lists every connector running on this machine, what it watches, and the
+funnel paths it owns. If one already covers what the user asked for, **say so
+and stop** — don't start a second. `bin/connect` refuses the duplicate on its
+own, and its message names the other run's pid; read that as the answer, not as
+an error to work around. `--allow-duplicate` exists but is the user's call, never
+yours.
+
+Then run the connector in the background and note the output-file path the
 harness reports (you need it for the monitor):
 
 ```bash
@@ -835,11 +849,35 @@ tailscale funnel status                            # expect no /bc5/… or /gh/�
 ```
 
 If the process was killed un-gracefully (e.g. `SIGKILL`) and teardown didn't run,
-delete the leftover webhook(s) manually with `basecamp webhooks delete <id>
---project "<project>"` and unmount each leftover path with `tailscale funnel
---set-path /bc5/<secret> off`. Never run `tailscale funnel reset` — it tears
-down every path on this host's funnel, including ones other tools mounted. Never
-leave a registered webhook or a mounted path behind.
+it leaves webhooks behind. **Never delete a webhook you cannot attribute.** A
+registration you don't recognize may belong to a *live* connector — another
+session's, an older build's (those use `/hook/<secret>`, not `/bc5/<secret>`),
+or another machine's — and deleting one makes that connector silently deaf to
+Basecamp while it goes on polling chat. This has actually happened: eleven of a
+running connector's webhooks were deleted as presumed orphans.
+
+So attribute first:
+
+```bash
+bin/connect --status   # every live run, and the funnel paths each one owns
+```
+
+A webhook whose `payload_url` ends in a path that listing names is **live** —
+leave it. `--status` also reports any running `bin/connect` process the registry
+can't account for (an older build recorded nothing): treat those pids as live
+connectors whose webhooks are **unattributable**, and delete none of them. A path belonging to a run that has exited is an orphan, and the **next
+`bin/connect` start sweeps those automatically**: it prunes the dead run's entry
+from `~/.config/basecamp-connect/runs/` and deletes the webhooks pointing at the
+paths that run recorded. So the normal answer to a leftover is "start the
+connector again," not a manual delete.
+
+Delete by hand only what `--status` proves is unowned, with `basecamp webhooks
+delete <id> --project "<project>"`, and unmount each leftover path with
+`tailscale funnel --set-path /bc5/<secret> off`. If a webhook's path appears in
+no live run *and* in no registry entry, it predates the registry or came from
+elsewhere — **ask the user before deleting it**. Never run `tailscale funnel
+reset` — it tears down every path on this host's funnel, including ones other
+tools mounted.
 
 ## Notes
 

--- a/test/connector_test.rb
+++ b/test/connector_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "tmpdir"
 
 class ConnectorTest < Minitest::Test
   def test_parses_basecamp_only_with_defaults
@@ -227,7 +228,143 @@ class ConnectorTest < Minitest::Test
     assert_match(/Polling 0 Campfire\(s\)/, err)
   end
 
+  def test_parses_the_duplicate_opt_in
+    refute parse("@clawdito", "--project", "A").allow_duplicate
+    assert parse("@clawdito", "--project", "A", "--allow-duplicate").allow_duplicate
+  end
+
+  # The failure this prevents: two connectors on one agent and project, so
+  # Basecamp delivers every event to both and the agent answers twice.
+  def test_refuses_to_start_beside_a_live_run_on_the_same_agent_and_project
+    with_registry do |registry|
+      registry.record(agent: "clawdito", operator: "jorge", projects: [ "Queenbee" ], repos: [], paths: [ "/bc5/live" ], boosts: true)
+      connector = connector(registry, "@clawdito", "--project", "Queenbee")
+
+      error = assert_raises SystemExit do
+        capture_stderr { connector.send(:refuse_duplicate_run) }
+      end
+
+      refute_equal 0, error.status
+    end
+  end
+
+  def test_allow_duplicate_starts_anyway
+    with_registry do |registry|
+      registry.record(agent: "clawdito", operator: "jorge", projects: [ "Queenbee" ], repos: [], paths: [], boosts: true)
+      connector = connector(registry, "@clawdito", "--project", "Queenbee", "--allow-duplicate")
+
+      connector.send(:refuse_duplicate_run)
+    end
+  end
+
+  def test_a_live_run_on_another_agent_is_not_a_duplicate
+    with_registry do |registry|
+      registry.record(agent: "chef", operator: "jorge", projects: [ "Queenbee" ], repos: [], paths: [], boosts: true)
+
+      connector(registry, "@clawdito", "--project", "Queenbee").send(:refuse_duplicate_run)
+    end
+  end
+
+  # Same agent, no overlap: legal, but the received-boosts feed is per-agent,
+  # so both runs would dispatch every boost.
+  def test_warns_when_the_same_agent_runs_elsewhere_with_boosts_on
+    with_registry do |registry|
+      registry.record(agent: "clawdito", operator: "jorge", projects: [ "Queenbee" ], repos: [], paths: [], boosts: true)
+
+      warnings = capture_stderr do
+        connector(registry, "@clawdito", "--project", "BC5.1").send(:warn_of_same_agent_elsewhere)
+      end
+
+      assert_match(/already being watched/, warnings)
+      assert_match(/--no-boosts/, warnings)
+    end
+  end
+
+  def test_status_names_the_paths_a_live_run_owns
+    with_registry do |registry|
+      registry.record(agent: "clawdito", operator: "jorge", projects: [ "Queenbee" ], repos: [ "basecamp/bc3" ],
+        paths: [ "/bc5/abc", "/gh/def" ], boosts: false)
+
+      output = capture_stdout { BasecampAgentConnector::Connector.print_status(registry: registry) }
+
+      assert_match(/1 connector\(s\) running/, output)
+      assert_match(%r{/bc5/abc, /gh/def}, output)
+      assert_match(/belongs to a LIVE run/, output)
+    end
+  end
+
+  def test_status_with_nothing_running
+    with_registry do |registry|
+      output = capture_stdout { BasecampAgentConnector::Connector.print_status(registry: registry, command_runner: no_processes) }
+
+      assert_match(/No connector recorded as running/, output)
+    end
+  end
+
+  # The transition case, and the one that caused the damage: a connector from
+  # an older build records nothing, so silence here would read as "nothing
+  # running" while its webhooks sit unattributable in Basecamp.
+  def test_status_calls_out_a_running_connector_the_registry_does_not_know
+    with_registry do |registry|
+      output = capture_stdout do
+        BasecampAgentConnector::Connector.print_status(registry: registry, command_runner: processes(4_194_302))
+      end
+
+      assert_match(/NOT recorded: 4194302/, output)
+      assert_match(/cannot be attributed/, output)
+    end
+  end
+
+  def test_status_does_not_report_a_recorded_run_as_unrecorded
+    with_registry do |registry|
+      registry.record(agent: "clawdito", operator: "jorge", projects: [ "Queenbee" ], repos: [], paths: [], boosts: true)
+
+      output = capture_stdout do
+        BasecampAgentConnector::Connector.print_status(registry: registry, command_runner: processes(Process.pid))
+      end
+
+      refute_match(/NOT recorded/, output)
+    end
+  end
+
   private
+    def with_registry
+      Dir.mktmpdir do |directory|
+        yield BasecampAgentConnector::RunRegistry.new(directory: directory, logger: StringIO.new)
+      end
+    end
+
+    def connector(registry, *arguments)
+      BasecampAgentConnector::Connector.new(parse(*arguments), registry: registry)
+    end
+
+    def no_processes
+      processes
+    end
+
+    # A pid with no /proc entry: `watching_process?` errs toward reporting it,
+    # which is the behavior under test.
+    def processes(*pids)
+      runner = FakeCommandRunner.new
+      runner.stub "pgrep", stdout: pids.join("\n")
+      runner
+    end
+
+    def capture_stderr
+      original, $stderr = $stderr, StringIO.new
+      yield
+      $stderr.string
+    ensure
+      $stderr = original
+    end
+
+    def capture_stdout
+      original, $stdout = $stdout, StringIO.new
+      yield
+      $stdout.string
+    ensure
+      $stdout = original
+    end
     def parse(*argv)
       BasecampAgentConnector::Connector.parse_options(argv)
     end

--- a/test/run_registry_test.rb
+++ b/test/run_registry_test.rb
@@ -1,0 +1,124 @@
+require "test_helper"
+require "tmpdir"
+
+class RunRegistryTest < Minitest::Test
+  def test_records_and_lists_this_run
+    in_registry do |registry|
+      registry.record(**run_attributes)
+
+      assert_equal [ Process.pid ], registry.live.map(&:pid)
+      assert_equal [ "/bc5/mine" ], registry.live.first.paths
+    end
+  end
+
+  def test_forgetting_removes_the_run
+    in_registry do |registry|
+      registry.record(**run_attributes)
+      registry.forget
+
+      assert_empty registry.live
+    end
+  end
+
+  def test_a_run_whose_process_is_gone_is_not_live
+    in_registry do |registry, directory|
+      write_run directory, pid: dead_pid, agent: "clawdito"
+
+      assert_empty registry.live
+    end
+  end
+
+  # The SIGKILL case: no teardown ran, so the file and its paths are all that
+  # says those webhooks were ever ours.
+  def test_pruning_removes_dead_runs_and_returns_what_they_owned
+    in_registry do |registry, directory|
+      write_run directory, pid: dead_pid, agent: "clawdito", paths: [ "/bc5/orphan" ]
+      registry.record(**run_attributes)
+
+      pruned = registry.prune
+
+      assert_equal [ "/bc5/orphan" ], pruned.flat_map(&:paths)
+      assert_equal [ Process.pid ], registry.live.map(&:pid)
+      assert_equal 1, Dir.glob(File.join(directory, "*.json")).length
+    end
+  end
+
+  def test_a_live_run_is_never_pruned
+    in_registry do |registry|
+      registry.record(**run_attributes)
+
+      assert_empty registry.prune
+      assert_equal [ Process.pid ], registry.live.map(&:pid)
+    end
+  end
+
+  def test_duplicates_need_the_same_agent_and_an_overlapping_project
+    in_registry do |registry|
+      registry.record(**run_attributes(agent: "clawdito", projects: [ "Queenbee", "On Call" ]))
+
+      assert_equal [ Process.pid ], registry.duplicates_of(agent: "clawdito", projects: [ "on call" ], repos: []).map(&:pid)
+      assert_empty registry.duplicates_of(agent: "clawdito", projects: [ "BC5.1" ], repos: [])
+      assert_empty registry.duplicates_of(agent: "chef", projects: [ "Queenbee" ], repos: [])
+    end
+  end
+
+  def test_an_overlapping_repo_is_a_duplicate_too
+    in_registry do |registry|
+      registry.record(**run_attributes(projects: [], repos: [ "basecamp/bc3" ]))
+
+      assert_equal [ Process.pid ], registry.duplicates_of(agent: "clawdito", projects: [], repos: [ "basecamp/bc3" ]).map(&:pid)
+    end
+  end
+
+  def test_same_agent_elsewhere_reports_the_non_overlapping_run
+    in_registry do |registry|
+      registry.record(**run_attributes(agent: "clawdito", projects: [ "Queenbee" ]))
+
+      assert_equal [ Process.pid ], registry.same_agent_elsewhere(agent: "clawdito", projects: [ "BC5.1" ], repos: []).map(&:pid)
+      assert_empty registry.same_agent_elsewhere(agent: "clawdito", projects: [ "Queenbee" ], repos: [])
+    end
+  end
+
+  # Deleting a half-written file could drop a live run's paths, so it is
+  # skipped rather than reaped.
+  def test_an_unreadable_entry_is_skipped_not_deleted
+    in_registry do |registry, directory|
+      File.write File.join(directory, "999999.json"), "{not json"
+
+      assert_empty registry.live
+      assert_empty registry.prune
+      assert_path_exists File.join(directory, "999999.json")
+    end
+  end
+
+  def test_an_unwritable_directory_does_not_raise
+    logs = StringIO.new
+    registry = BasecampAgentConnector::RunRegistry.new(directory: "/proc/nope/runs", logger: logs)
+
+    registry.record(**run_attributes)
+
+    assert_match(/could not record this run/, logs.string)
+  end
+
+  private
+    def in_registry
+      Dir.mktmpdir do |directory|
+        yield BasecampAgentConnector::RunRegistry.new(directory: directory, logger: StringIO.new), directory
+      end
+    end
+
+    def run_attributes(agent: "clawdito", projects: [ "Queenbee" ], repos: [], paths: [ "/bc5/mine" ], boosts: true)
+      { agent: agent, operator: "jorge", projects: projects, repos: repos, paths: paths, boosts: boosts }
+    end
+
+    def write_run(directory, pid:, agent:, paths: [])
+      File.write File.join(directory, "#{pid}.json"), JSON.generate(
+        pid: pid, started_at: "2026-09-01T00:00:00Z", agent: agent, operator: "jorge",
+        projects: [ "Queenbee" ], repos: [], paths: paths, boosts: true)
+    end
+
+    # A pid nothing can be running under: the kernel's max is well below this.
+    def dead_pid
+      4_194_303
+    end
+end

--- a/test/webhooks_test.rb
+++ b/test/webhooks_test.rb
@@ -70,6 +70,40 @@ class WebhooksTest < Minitest::Test
     assert_match(/failed to delete webhook 555/, logs.string)
   end
 
+  def test_deletes_only_the_webhooks_whose_path_a_dead_run_recorded
+    runner = FakeCommandRunner.new
+    runner.stub "webhooks list", stdout: envelope([
+      { "id" => 111, "payload_url" => "https://host.ts.net/bc5/dead" },
+      { "id" => 222, "payload_url" => "https://host.ts.net/bc5/alive" },
+      { "id" => 333, "payload_url" => "https://host.ts.net/hook/someone-elses-build" } ])
+    runner.stub "webhooks delete", stdout: envelope({})
+
+    webhooks(runner).delete_orphans(projects: [ 7 ], paths: [ "/bc5/dead" ])
+
+    deletions = runner.commands_matching(/webhooks delete/)
+    assert_equal 1, deletions.length
+    assert_includes deletions.first, "111"
+  end
+
+  def test_sweeps_nothing_when_no_dead_run_left_a_path
+    runner = FakeCommandRunner.new
+
+    webhooks(runner).delete_orphans(projects: [ 7 ], paths: [])
+
+    assert_empty runner.commands
+  end
+
+  def test_a_listing_failure_leaves_the_project_alone
+    runner = FakeCommandRunner.new
+    runner.stub "webhooks list", exit_status: 1, stderr: "nope"
+    logs = StringIO.new
+
+    webhooks(runner, logs).delete_orphans(projects: [ 7 ], paths: [ "/bc5/dead" ])
+
+    assert_empty runner.commands_matching(/webhooks delete/)
+    assert_match(/could not list webhooks for project 7/, logs.string)
+  end
+
   private
     def webhooks(runner, logs = StringIO.new)
       BasecampAgentConnector::Basecamp::Webhooks.new(basecamp_cli: build_cli(runner), logger: logs, wait: ->(_seconds) { })


### PR DESCRIPTION
Two things went wrong in one session, and they compound.

A connector was already running on this machine — 12 projects, `@Chef`, started
earlier. Nothing said so. A second one started, and from that moment Basecamp
delivered every event to both: one mention, two dispatched agents, two replies.
Nothing in either process's output hints at it.

Then, cleaning up, the newer session saw ten webhooks registered under
`/hook/<secret>` — an older build's path prefix — assumed they were leftovers
from a run it had just killed, and deleted them. They belonged to the live
connector. Eleven of its registrations went, and it is now deaf to Basecamp
while still polling chat and still receiving GitHub reviews. No error surfaced
anywhere, because from the process's point of view nothing failed.

The deletion wasn't careless. There was genuinely no way to tell whose webhook
that was. Ownership existed only in a `@secret` ivar inside a running Ruby
process.

So make it a fact on disk. Each run writes one file naming its pid, what it
watches, and the funnel paths it owns, and removes it at teardown. Liveness is
a pid probe paired with the process start time from `/proc`, so a recycled pid
can't pass as alive — reading a live run as dead is the expensive direction,
since the sweep would delete its webhooks.

That buys three things:

**Duplicates are refused.** Same agent, overlapping project or repo, and
startup aborts naming the other run's pid. `--allow-duplicate` for when it's
deliberate. Same agent with no detected overlap only warns — project names and
ids don't compare, so an undetected overlap is possible, and the
received-boosts feed is per-agent, so two boost pollers double every boost
whatever the projects.

**`bin/connect --status` answers the question that used to be a guess.** Every
live run and the paths it owns. A `payload_url` ending in one of those belongs
to something running. It also consults the process table, because the registry
only knows runs that started with it — a connector from an older build records
nothing and would otherwise read as "nothing running." Run against the live
`@Chef` process, it says:

```
No connector recorded as running on this machine.

1 connector process(es) running but NOT recorded: 2468517.
Their funnel paths are unknown, so their webhooks cannot be attributed — do not delete a
registration you cannot account for. Inspect with: ps -fp 2468517
```

**Real orphans clean themselves up.** A `SIGKILL`ed run leaves its entry
behind; the next start prunes it and deletes exactly the webhooks pointing at
the paths it recorded. A path nobody recorded is never touched — it may be
another machine's, another tool's, or an older build's.

The skill gets the behavioral half. Its cleanup section said to "delete the
leftover webhook(s) manually," with nothing to distinguish a leftover from a
live one — the instruction that caused this. It now checks `--status` before
starting, attributes before deleting, prefers restarting the connector over any
manual delete, and asks the user about anything it can't account for.