### PR TITLE
The trust modes are invisible in the README, and two of them can't fire

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ default and can be said in passing.
 /basecamp-connect @Clawdito — projects BC5.1, On Call, and 20361308
 /basecamp-connect use @Clawdito to watch https://3.basecamp.com/2914079/projects/41746046
 /basecamp-connect @Clawdito on Queenbee, with jorge as the operator
+/basecamp-connect @Clawdito on On Call, and let anyone on the project trigger it
+/basecamp-connect @Clawdito on BC5.1, and let marie@37signals.com trigger it too
 /basecamp-connect @Clawdito on BC5.1 plus PR reviews on basecamp/bc3
 /basecamp-connect @Clawdito on On Call, poll chat every 30s, skip boosts
 /basecamp-connect watch PR reviews on basecamp/bc3
@@ -117,10 +119,14 @@ A few things worth knowing about what you can ask for:
 - **Several projects, one connector.** One webhook per project, all multiplexed
   onto a single funnel path, so the same `@agent` watches every project you named
   at once. Add as many as you like.
-- **Only you can trigger it.** That's the default and it's the one to stay on —
-  the agent acts with your full machine authority, so widening the trust set
-  hands that authority to someone else. It *can* be widened; read
-  [Trust modes](#trust-modes) first, including the email-redaction limit.
+- **You alone can trigger it, unless you say otherwise.** The agent acts with
+  your full machine authority, so widening the trust set hands that authority to
+  more people — deliberate, never incidental. Four modes exist; ask for one in
+  the same sentence ("let anyone on the project trigger it", "let Marie trigger
+  it too"). **One caveat that decides which to pick:** unless you're a Basecamp
+  account admin, the API hands you colleagues' email addresses masked, so the
+  two email-keyed modes match nobody. Read [Trust modes](#trust-modes) before
+  relying on any of them.
 - **GitHub PR reviews ride the same server.** Ask for a repo ("plus PR reviews on
   basecamp/bc3") and review events arrive on the same funnel. Only **your**
   approvals (the login `gh` is signed in as) reach the agent as `approved`;
@@ -325,12 +331,34 @@ operator's full machine authority, so broadening trust means handing that
 authority to more people — the startup log prints the active mode and the
 concrete allowed set so it is never implicit.
 
-| Mode | Who triggers | CLI |
-|------|--------------|-----|
-| `operator` *(default)* | You only. No flags = exactly this. | — |
-| `allowlist` | You + the named emails. | `--allow marie@37signals.com` (repeatable or comma-separated; implies the mode, or `--trust allowlist`) |
-| `domain` | Any author whose email is at a listed domain. | `--allow-domain 37signals.com` (repeatable), or bare `--trust domain` for the 37signals.com default |
-| `project` | Any corroborated non-client author of a recording the operator's account can read (client users excluded, fail-closed). | `--allow-project` or `--trust project` |
+| Mode | Who triggers | CLI | Keyed on |
+|------|--------------|-----|----------|
+| `operator` *(default)* | You only. No flags = exactly this. | — | your email **or** Person id |
+| `allowlist` | You + the named emails. | `--allow marie@37signals.com` (repeatable or comma-separated; implies the mode, or `--trust allowlist`) | the author's email |
+| `domain` | Any author whose email is at a listed domain. | `--allow-domain 37signals.com` (repeatable), or bare `--trust domain` for the 37signals.com default | the author's email |
+| `project` | Any corroborated non-client author of a recording the operator's account can read (client users excluded, fail-closed). | `--allow-project` or `--trust project` | the author's Person id |
+
+**The `Keyed on` column decides whether a mode can fire at all.** Basecamp shows
+a person's real email address only to themselves and to account admins —
+`Person::Ability#can_see_email_address_of?` is `self == person || admin?`. Every
+trust decision is re-made on the recording the verifier re-fetches with *your*
+CLI profile, so unless you are an admin on that account, a colleague's address
+arrives masked:
+
+```
+$ basecamp show <a colleague's message> --json | jq .data.creator
+{ "id": 51659243, "name": "Rob Zolkos", "email_address": "r••••••••@•••.•••", "client": false }
+```
+
+`allowlist` compares that string against the email you listed and never matches.
+`domain` parses `•••.•••` out of it as the domain and never matches. Both fail
+closed and silently — the event is simply dropped as unauthorized, with no hint
+that a masked address is why. As an account admin you see real addresses and both
+modes work as written.
+
+`project` is keyed on the Person id, which every viewer can see, so it works
+regardless of admin status. It is also the loosest of the three — read the limit
+below before choosing it.
 
 Every mode implicitly includes the operator and excludes the agent itself. In
 `project` mode, membership is proven by corroboration: only project members can

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -123,7 +123,13 @@ guidance if not.
 **Who may trigger** defaults to the operator alone. Broaden it deliberately with
 the trust flags — `--allow <email>`, `--allow-domain <domain>`, `--allow-project`,
 or explicit `--trust <mode>` — and pass them straight through to `bin/connect`;
-the bridge enforces them and logs the active set. See the connector README's
+the bridge enforces them and logs the active set. **`--allow` and `--allow-domain`
+only work when the operator is a Basecamp account admin**: both key on the
+author's email, and Basecamp masks other people's addresses from non-admins
+(`r••••••••@•••.•••`), so the comparison silently matches nobody and every event
+is dropped as unauthorized. `--allow-project` keys on the Person id instead and
+works either way. When a user asks for email-based trust, say which of the two
+they're in rather than letting them find out from an agent that never answers. See the connector README's
 "Trust modes" for the full semantics and the agent-self / assignments-operator-only
 safeguards.
 


### PR DESCRIPTION
[Make the trust gate configurable: operator, allowlist, project, and domain modes](https://github.com/basecamp/basecamp-local-agent-connector/pull/9)
shipped four ways to widen who may drive an agent. The "Using it" examples
showed none of them, so unless you read as far as the Trust modes table you'd
never know the capability was there. Two examples now ask for it in the
phrasing you'd actually use.

Working out which example to write turned up the more useful half of this.

Basecamp shows a person's real email address only to themselves and to account
admins — `Person::Ability#can_see_email_address_of?` is
`self == person || admin?`. Every trust decision is re-made on the recording
the verifier re-fetches with the *operator's* CLI profile. So for a non-admin
operator, that fetch returns:

```
$ basecamp show <a colleague's message> --json | jq .data.creator
{ "id": 51659243, "name": "Rob Zolkos", "email_address": "r••••••••@•••.•••", "client": false }
```

`Authorizer::Allowlist` casecmps that against the address you listed. Never
matches. `Authorizer::Domain` runs `/@([^@\s]+)\z/` over it, gets `•••.•••`,
and compares that to `37signals.com`. Never matches. Both fail closed and
silently: the event is dropped as unauthorized, and nothing anywhere says a
masked address was the reason. As an account admin you see real addresses and
both modes behave exactly as documented.

`Authorizer::Project` is keyed on `creator_id` plus `creator["client"] == false`
and never reads an email, so it works whatever your admin status. That's the
one the new example uses.

Nothing changes in the gate itself — the code is right, and the boost path
already solved this once by falling back to Person id (`Event#authored_by?`
carries the comment explaining why). This is the documentation catching up:
the modes table now names what each mode keys on, shows the masked payload,
and says plainly which two need an admin operator. The skill gets the same,
so it can tell a user which case they're in rather than letting them find out
from an agent that never answers.

Whether to wire the Person-id fallback into `allowlist` is a separate question
and deliberately not in this PR.