### PR TITLE
Nothing tells a reader this connector is unofficial

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 > funnel on your own machine. Proper first-class support is being built; expect
 > this to be replaced by it, not to grow into it.
 
-Drive local Claude Code agents from Basecamp. **@mention an agent user** (e.g.
+Drive local coding agents from Basecamp. **@mention an agent user** (e.g.
 `@Clawdito fix the calendar bug`) in any Basecamp comment, message, or card — and
-a Claude agent on **your** machine picks it up, gathers the surrounding context
+an agent on **your** machine picks it up, gathers the surrounding context
 from Basecamp, does the work in the right repo, and **replies as that agent
 user**, right where you asked.
 
@@ -203,7 +203,7 @@ automatically. In Claude Code, ending the skill does this; from a terminal, pres
                           /basecamp-connect  (the driver, a Claude skill)
                                      • boosts the recording `On it!` as the agent (the ack)
                                      • resolves the local repo from the project
-                                     • dispatches a background Claude agent in that repo
+                                     • dispatches a background agent in that repo
                                        (which gathers context via the `basecamp` CLI)
                                      • replies on the card as the agent (--profile)
 ```
@@ -220,6 +220,12 @@ Two halves, deliberately separated:
 
 The bridge is dumb-and-safe; the driver is smart-and-contextual. You can run
 `bin/connect` on its own to see exactly what would be dispatched.
+
+**The bridge doesn't know or care what reads it.** It writes one trusted event
+per line to STDOUT and stops there, so any agent that can run a process and read
+its output can be the driver — the `basecamp` CLI does the replying, and it takes
+a `--profile`, not an agent. The driver shipped here is a Claude Code skill
+because that's what it was built against, not because the protocol needs one.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # basecamp-local-agent-connector
 
+> **Experimental.** This drives agents from Basecamp using the pieces that
+> already exist: webhooks, the `basecamp` CLI, a funnel on your own machine.
+> Proper first-class support is being built; expect this to be replaced by it,
+> not to grow into it.
+
 Drive local Claude Code agents from Basecamp. **@mention an agent user** (e.g.
 `@Clawdito fix the calendar bug`) in any Basecamp comment, message, or card — and
 a Claude agent on **your** machine picks it up, gathers the surrounding context

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # basecamp-local-agent-connector
 
 > **Experimental.** This drives agents from Basecamp using the pieces that
-> already exist: webhooks, the `basecamp` CLI, a funnel on your own machine.
-> Proper first-class support is being built; expect this to be replaced by it,
-> not to grow into it.
+> already exist: webhooks, the [`basecamp` CLI](https://basecamp.com/cli), a
+> funnel on your own machine. Proper first-class support is being built; expect
+> this to be replaced by it, not to grow into it.
 
 Drive local Claude Code agents from Basecamp. **@mention an agent user** (e.g.
 `@Clawdito fix the calendar bug`) in any Basecamp comment, message, or card — and
@@ -67,7 +67,7 @@ You need three things in place:
 
 3. **An agent user + its local profile.** The agent is a *real Basecamp user*
    (e.g. a bot account named “Clawdito”) that you can @mention. The connector
-   talks to Basecamp through the [`basecamp` CLI](https://github.com/basecamp),
+   talks to Basecamp through the [`basecamp` CLI](https://basecamp.com/cli),
    which supports named **profiles** — and the agent name you pass must match a
    local profile authenticated **as that agent user**:
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # basecamp-local-agent-connector
 
+> [!WARNING]
 > **Experimental.** This drives agents from Basecamp using the pieces that
 > already exist: webhooks, the [`basecamp` CLI](https://basecamp.com/cli), a
 > funnel on your own machine. Proper first-class support is being built; expect

--- a/basecamp_agent_connector.gemspec
+++ b/basecamp_agent_connector.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |spec|
   spec.name = "basecamp_agent_connector"
   spec.version = BasecampAgentConnector::VERSION
   spec.authors = [ "Jorge Manrubia" ]
-  spec.summary = "Bridge Basecamp webhooks to local Claude Code agents"
+  spec.summary = "Bridge Basecamp webhooks to local coding agents"
   spec.description = "Exposes a local webhook endpoint via Tailscale Funnel, registers it as a " \
     "Basecamp webhook, and emits trusted, self-authored, trigger-matched events for a local agent to act on."
   spec.homepage = "https://github.com/basecamp/basecamp-local-agent-connector"

--- a/docs/built-in-support.md
+++ b/docs/built-in-support.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 The connector in this repo proved the idea: you @mention an agent user in
-Basecamp, a Claude agent on your machine picks it up, works with full Basecamp
+Basecamp, an agent on your machine picks it up, works with full Basecamp
 context, and replies in place. It works — but every piece of it is a
 workaround for something Basecamp doesn't provide. This document proposes what
 Basecamp (BC5) should build so the approach is native, with all of today's

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2,10 +2,10 @@
 
 ## Purpose
 
-Manage local Claude Code agents from Basecamp. This project bridges Basecamp
-webhooks to local Claude agents: you write a comment / message / card in
+Manage local coding agents from Basecamp. This project bridges Basecamp
+webhooks to local agents: you write a comment / message / card in
 Basecamp that @mentions a real agent user (e.g. `@Clawdito`), and a background
-Claude agent running on your machine picks it up, gathers context from Basecamp,
+agent running on your machine picks it up, gathers context from Basecamp,
 acts on it, and replies as that agent user.
 
 The bridge has two halves:
@@ -24,7 +24,7 @@ The bridge has two halves:
 
 Basecamp is an excellent place to *capture context* — a comment lives inside a
 card, inside a project, with a creator, a thread, and linked recordings. Rather
-than re-typing context into Claude, you write where the work already lives and
+than re-typing context into an agent, you write where the work already lives and
 let the agent pull the surrounding context from Basecamp. The webhook payload is
 treated as a *notification + pointer*, not as a source of truth (see Security).
 


### PR DESCRIPTION
The README opens with a working pitch and a complete setup guide. Nothing on it
says this isn't a supported way to drive agents from Basecamp, so a reader has
no reason to think otherwise — and someone building a habit on it now is going
to be surprised later.

A blockquote at the very top, above the pitch, names it as experimental, says
what it's made of, and says what happens to it: proper support is being built,
and it will replace this rather than grow out of it. Listing the three pieces
it's glued from — webhooks, the `basecamp` CLI, a funnel on your own machine —
does double duty. It's why this can exist today, and it's why it's rough.