### PR TITLE
The email-trust caveat says a non-admin run drops every event; it drops only colleagues'

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ default and can be said in passing.
 /basecamp-connect use @Clawdito to watch https://3.basecamp.com/2914079/projects/41746046
 /basecamp-connect @Clawdito on Queenbee, with jorge as the operator
 /basecamp-connect @Clawdito on On Call, and let anyone on the project trigger it
-/basecamp-connect @Clawdito on BC5.1, and let marie@37signals.com trigger it too
+/basecamp-connect @Clawdito on BC5.1, and let marie@37signals.com trigger it too  # admin operators only
 /basecamp-connect @Clawdito on BC5.1 plus PR reviews on basecamp/bc3
 /basecamp-connect @Clawdito on On Call, poll chat every 30s, skip boosts
 /basecamp-connect watch PR reviews on basecamp/bc3
@@ -125,7 +125,7 @@ A few things worth knowing about what you can ask for:
   the same sentence ("let anyone on the project trigger it", "let Marie trigger
   it too"). **One caveat that decides which to pick:** unless you're a Basecamp
   account admin, the API hands you colleagues' email addresses masked, so the
-  two email-keyed modes match nobody. Read [Trust modes](#trust-modes) before
+  two email-keyed modes add nobody. Read [Trust modes](#trust-modes) before
   relying on any of them.
 - **GitHub PR reviews ride the same server.** Ask for a repo ("plus PR reviews on
   basecamp/bc3") and review events arrive on the same funnel. Only **your**

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -124,12 +124,15 @@ guidance if not.
 the trust flags — `--allow <email>`, `--allow-domain <domain>`, `--allow-project`,
 or explicit `--trust <mode>` — and pass them straight through to `bin/connect`;
 the bridge enforces them and logs the active set. **`--allow` and `--allow-domain`
-only work when the operator is a Basecamp account admin**: both key on the
+only widen trust when the operator is a Basecamp account admin**: both key on the
 author's email, and Basecamp masks other people's addresses from non-admins
-(`r••••••••@•••.•••`), so the comparison silently matches nobody and every event
-is dropped as unauthorized. `--allow-project` keys on the Person id instead and
-works either way. When a user asks for email-based trust, say which of the two
-they're in rather than letting them find out from an agent that never answers. See the connector README's
+(`r••••••••@•••.•••`), so the comparison matches nobody. The operator's own
+mentions still run — every mode authorizes the operator first, by email or Person
+id — but colleagues' are silently dropped as unauthorized, so a non-admin run looks
+healthy while ignoring exactly the people the flag was meant to add.
+`--allow-project` keys on the Person id instead and works either way. When a user
+asks for email-based trust, say which of the two they're in rather than letting
+them find out from an agent that never answers. See the connector README's
 "Trust modes" for the full semantics and the agent-self / assignments-operator-only
 safeguards.
 


### PR DESCRIPTION
Two corrections to [#29](https://github.com/basecamp/basecamp-local-agent-connector/pull/29), following [Copilot's review on #29](https://github.com/basecamp/basecamp-local-agent-connector/pull/29#pullrequestreview-5074314148) — it landed after the merge, so this is the follow-up rather than a push to that branch. Both points hold.

**The skill overstated the failure.** It said a non-admin run with `--allow` or `--allow-domain` drops "every event" as unauthorized, which reads as an inert connector. It isn't: `Authorizer#authorizes?` is `operator_authored?(event) || authorized_author?(event)`, and `Event#authored_by?` matches on email **or** account Person id. Basecamp shows you your own real address, and the Person id is visible to everyone, so the operator authorizes in every mode regardless of admin status. What a non-admin actually loses is the extension — `Allowlist` and `Domain` both read `creator_email`, which arrives masked for colleagues, so colleague-authored events are the ones that fail. The warning now says that: the operator's mentions still run, colleagues' are silently dropped, and the run looks healthy while ignoring exactly the people the flag was meant to add. Same one-word scoping in the README bullet — the email-keyed modes *add* nobody rather than *match* nobody.

**The README promised a config that doesn't always work.** The `let marie@37signals.com trigger it too` example sits in the block closed by "All of those work," but it is the allowlist mode, so it broadens nothing unless the operator is an account admin — a non-admin copying it gets a connector that still accepts only them, and learns why several hundred lines later. The example now carries `# admin operators only` inline. The project-mode example beside it is keyed on the Person id and needs no marker.

Documentation only; no behavior change. `bundle exec rake test` is 328 runs / 1038 assertions / 0 failures, `rubocop` clean across 51 files.
