### PR TITLE
Refuse to start without an account Person id

### DIFF
--- a/lib/basecamp_agent_connector/basecamp/identity.rb
+++ b/lib/basecamp_agent_connector/basecamp/identity.rb
@@ -21,8 +21,14 @@ class BasecampAgentConnector::Basecamp::Identity
 
   # `me` returns the global identity id, but a webhook mention encodes the
   # account-scoped Person id; resolve that here so mentions match on a stable id.
+  # Every trigger keys on it and every consumer tolerates nil by matching
+  # nothing, so an answer without one would start a connector that is deaf
+  # with no symptom: refuse it here, where the profile can still be named.
   def self.account_person_id(basecamp_cli, profile)
-    basecamp_cli.person(profile: profile)["id"]
+    person = basecamp_cli.person(profile: profile)
+    (person["id"] if person.is_a?(Hash)) || \
+      raise(BasecampAgentConnector::Basecamp::Client::Error,
+        "`basecamp people show me#{" --profile #{profile}" if profile}` returned no account Person id; is that user a member of the account?")
   end
   private_class_method :account_person_id
 

--- a/test/identity_test.rb
+++ b/test/identity_test.rb
@@ -48,6 +48,30 @@ class IdentityTest < Minitest::Test
     end
   end
 
+  # A connector that resolves without a Person id runs and never matches a
+  # mention, an assignment, or a subscription: refused at startup instead.
+  def test_refuses_a_person_without_an_id
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp me", stdout: identity_envelope("id" => 123)
+    runner.stub "people show me", stdout: envelope("name" => "Clawdito")
+
+    error = assert_raises BasecampAgentConnector::Basecamp::Client::Error do
+      BasecampAgentConnector::Basecamp::Identity.resolve(basecamp_cli: build_cli(runner), profile: "clawdito")
+    end
+
+    assert_match(/people show me --profile clawdito.*no account Person id/, error.message)
+  end
+
+  def test_refuses_a_person_answer_with_no_data
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp me", stdout: identity_envelope("id" => 123)
+    runner.stub "people show me", stdout: empty_envelope
+
+    assert_raises BasecampAgentConnector::Basecamp::Client::Error do
+      BasecampAgentConnector::Basecamp::Identity.resolve(basecamp_cli: build_cli(runner))
+    end
+  end
+
   private
     def identity_envelope(identity)
       envelope("identity" => identity)


### PR DESCRIPTION
Fixes #35.

`Identity.resolve` accepted a nil account Person id from `basecamp people show me`. Every trigger keys on that id and every consumer (`Event#mentions?`/`#assigns?`, the verifier's assignment and subscription checks, the authorizer's agent-self exclusion) tolerates nil by matching nothing, so the connector started, registered its webhooks, and dropped every mention with no symptom.

`account_person_id` now raises a `Basecamp::Client::Error` naming the profile and the command that answered when the id is missing (or when the envelope carries no `data` at all, which previously surfaced as a bare `NoMethodError`). `Connector#resolve_agent` / `#resolve_operator` already rescue that class and abort with the `basecamp auth login --profile …` remedy, so the failure lands at startup with the profile named.

Tests: one for a person answer without an id, one for an answer without data.

```
330 runs, 1042 assertions, 0 failures, 0 errors, 0 skips
48 files inspected, no offenses detected
```