### PR TITLE
Refuse to start when the operator is the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,8 @@ What `bin/connect` has in place, at a glance:
   explicit guard on email and Person id), so replies posted as the agent can't
   re-trigger the connector even under `domain`/`project` trust where the agent
   shares the domain or is a project member; in operator mode they also simply
-  fail the author check. Startup warns if the agent and operator resolve to the
-  same user.
+  fail the author check. Startup refuses to run if the agent and operator
+  resolve to the same user.
 - **Ephemeral exposure** — the funnel and per-project webhooks exist only while
   the process runs and are torn down on exit.
 
@@ -331,9 +331,12 @@ operator. The agent's own identity **never authorizes, in any mode** — an
 explicit guard, matched by email and Person id, refuses agent-authored events
 before any mode is consulted. So even under `--trust domain` (where the agent's
 email may share the domain) or `--trust project` (where the agent is a member),
-its own replies can never re-trigger the connector. (`bin/connect` warns at
-startup if the agent and operator resolve to the same Basecamp user — a
-configuration in which nothing can trigger.)
+its own replies can never re-trigger the connector. (`bin/connect` refuses to
+start if the agent and operator resolve to the same Basecamp user — a
+configuration in which nothing can trigger. The usual cause is `BASECAMP_PROFILE`
+pinned to the agent's profile with no `--operator`: the CLI resolves an
+unflagged call through that variable before the default profile, so the
+operator becomes the agent.)
 
 ### Trust modes
 
@@ -418,7 +421,7 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
 |-----------------|---------|---------|
 | `@AGENT` | Agent user / local `basecamp` profile to watch for and reply as. Leading `@` optional; lowercased to the profile name. **Required**, validated at startup. | — |
 | `--project` | Basecamp project name, URL, or ID. **Required**, repeatable. | — |
-| `--operator` | Profile whose user is allowed to trigger. | CLI default profile |
+| `--operator` | Profile whose user is allowed to trigger. Also the profile every call not made as the agent runs under — corroborating fetches, chat polling, webhook registration. | CLI default profile |
 | `--gh-operator` | GitHub login whose PR approvals are actionable (with `--repo`). Any other reviewer's `approved` review is dropped; `changes_requested` and `commented` pass from anyone. | the login `gh` is authenticated as |
 | `--trust` | Trust mode: `operator`, `allowlist`, `project`, or `domain`. Usually inferred from the value flags below. | `operator` |
 | `--allow` | Author email to trust (repeatable or comma-separated). Implies `--trust allowlist`. | — |
@@ -533,6 +536,9 @@ basecamp comment <recording-url> "…" --profile <agent> # post as the agent
   --profile <agent>`).
 - **Operator** — the user allowed to trigger; defaults to the CLI default
   profile, override with `--operator <profile>`. Must differ from the agent.
+  Every call not made as the agent is made under this profile, so
+  `--operator` also decides whose credentials corroborate events and register
+  webhooks — a `BASECAMP_PROFILE` in the environment does not.
 - **Trust mode** — who beyond the operator may trigger; defaults to nobody.
   See [Trust modes](#trust-modes).
 - **Project → repo mapping** — [`config/project_repos.toml`](config/project_repos.toml)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -49,7 +49,7 @@ The connector distinguishes **two** Basecamp users:
 The agent must be a **different** user than the operator. Because replies are
 posted as the agent, and the trust filter requires the *operator* to be the
 author, agent replies are never re-ingested — this is the structural fix for the
-reply feedback loop. The connector warns at startup if the two resolve to the
+reply feedback loop. The connector refuses to start if the two resolve to the
 same user.
 
 The author match is keyed on **email address or account Person id** — either
@@ -172,8 +172,8 @@ bin/connect @AGENT --project <project>... [--operator <profile>] [--types <types
    profile (`basecamp me --profile <agent>`); if not, exit with guidance to run
    `basecamp auth login --profile <agent>`. Resolve the operator identity
    (default profile, or `--operator`). If a token is expired, attempt `basecamp
-   auth refresh` once before failing (no `login` attempted automatically). Warn
-   if agent and operator resolve to the same user (reply-loop risk).
+   auth refresh` once before failing (no `login` attempted automatically). Exit
+   if agent and operator resolve to the same user (nothing could trigger).
 2. **Resolve projects** — the explicit `--project` list (required). Names/URLs
    are resolved to IDs by the `basecamp` CLI when registering. This is the
    project set to subscribe.

--- a/lib/basecamp_agent_connector/basecamp/client.rb
+++ b/lib/basecamp_agent_connector/basecamp/client.rb
@@ -88,10 +88,14 @@ class BasecampAgentConnector::Basecamp::Client
   TRANSIENT_CODES = %w[auth_required network rate_limit]
   TRANSIENT_API_ERROR = /token refresh|request failed after \d+ attempts?|server error \(500\)|gateway error \(50\d\)|\bAPI error: 5\d\d\b|service temporarily unavailable|rate limit/i
 
+  # `profile` is the default for every command that doesn't name one: the
+  # CLI otherwise resolves BASECAMP_PROFILE ahead of its configured default,
+  # so an unflagged call runs as whatever the environment happens to pin.
   def initialize(command_runner: BasecampAgentConnector::CommandRunner.new, executable: "basecamp",
-    wait: ->(seconds) { sleep seconds })
+    profile: nil, wait: ->(seconds) { sleep seconds })
     @command_runner = command_runner
     @executable = executable
+    @profile = profile
     @wait = wait
   end
 
@@ -254,6 +258,7 @@ class BasecampAgentConnector::Basecamp::Client
     end
 
     def run(*arguments)
+      arguments += [ "--profile", @profile ] unless @profile.nil? || arguments.include?("--profile")
       @command_runner.run(@executable, *arguments)
     end
 end

--- a/lib/basecamp_agent_connector/basecamp/identity.rb
+++ b/lib/basecamp_agent_connector/basecamp/identity.rb
@@ -34,7 +34,9 @@ class BasecampAgentConnector::Basecamp::Identity
     @person_id = person_id
   end
 
+  # Keyed on the identity id, which `me` always carries; an email can be
+  # absent on both sides and would then compare as different users.
   def same_user_as?(other)
-    !email.nil? && !other.email.nil? && email.casecmp?(other.email)
+    id == other.id
   end
 end

--- a/lib/basecamp_agent_connector/connector.rb
+++ b/lib/basecamp_agent_connector/connector.rb
@@ -202,10 +202,6 @@ class BasecampAgentConnector::Connector
   end
 
   def start
-    # Runs that died without tearing down are pruned first: their files would
-    # otherwise read as live connectors and refuse this one, and the paths they
-    # leave behind are exactly what the orphan sweep needs.
-    orphan_paths = @registry.prune.flat_map(&:paths)
     refuse_duplicate_run
     warn_of_same_agent_elsewhere
 
@@ -221,6 +217,13 @@ class BasecampAgentConnector::Connector
         @tunnel = BasecampAgentConnector::Tunnel.new(port: port, paths: paths, command_runner: command_runner)
         @tunnel.start
       end
+    # Runs that died without tearing down are pruned only now, once every
+    # startup refusal is behind us: their files are the sole record of the
+    # paths they owned, and registration is what sweeps those. Pruned any
+    # earlier, a refused start would take that record with it and leave the
+    # webhooks unattributable for good. Liveness, not the file, is what the
+    # duplicate check reads, so a dead entry never refuses anyone.
+    orphan_paths = @registry.prune.flat_map(&:paths)
     @bridges.each { |bridge| bridge.register(base_url: base_url, orphan_paths: orphan_paths) }
 
     @server = BasecampAgentConnector::Server.new(port: port, routes: routes)
@@ -241,7 +244,7 @@ class BasecampAgentConnector::Connector
     def basecamp_bridge
       operator = resolve_operator
       agent = resolve_agent
-      warn_if_same_user(agent, operator)
+      refuse_same_user(agent, operator)
 
       BasecampAgentConnector::Basecamp::Bridge.new \
         authorizer: authorizer(operator, agent), agent: agent,
@@ -295,10 +298,26 @@ class BasecampAgentConnector::Connector
       abort "Could not resolve the operator's GitHub login: #{error.message}\nRun `gh auth login`, or pass --gh-operator LOGIN, and try again."
     end
 
-    def warn_if_same_user(agent, operator)
+    # The agent's own identity never authorizes, so an operator who *is* the
+    # agent can trigger nothing — and every corroborating fetch would run as
+    # the agent. The usual way in is BASECAMP_PROFILE pinned to the agent's
+    # profile with no --operator, since the CLI resolves an unflagged call
+    # through that variable before the default profile.
+    def refuse_same_user(agent, operator)
       if agent.same_user_as?(operator)
-        warn "Warning: agent '#{agent.profile}' and the operator are the same Basecamp user (#{agent.email}). " \
-          "The agent's own identity never authorizes, so nothing will trigger — authenticate the agent profile as a distinct bot user."
+        abort "Agent '#{agent.profile}' and the operator#{operator_label} are the same Basecamp user (#{agent.email || agent.id}). " \
+          "The agent's own identity never authorizes, so nothing could trigger. #{same_user_remedy}"
+      end
+    end
+
+    def same_user_remedy
+      pinned = ENV["BASECAMP_PROFILE"]
+      if @options.operator.nil? && !pinned.to_s.empty?
+        "BASECAMP_PROFILE=#{pinned} is set and --operator is not, so the operator — and every call made on the operator's " \
+          "behalf — resolved through that profile. Unset it (env -u BASECAMP_PROFILE bin/connect …), " \
+          "or pass --operator <your profile>, which pins those calls to that profile instead."
+      else
+        "Authenticate the agent profile as a distinct bot user, or pass --operator <your profile>."
       end
     end
 
@@ -365,8 +384,13 @@ class BasecampAgentConnector::Connector
       @command_runner ||= BasecampAgentConnector::CommandRunner.new
     end
 
+    # Every call not made as the agent is made as the operator, so the
+    # operator profile is the client's default: --operator then governs the
+    # corroborating fetches and webhook registrations too, not just whose
+    # identity authorizes, and a BASECAMP_PROFILE in the environment cannot
+    # quietly substitute another principal for them.
     def basecamp_cli
-      @basecamp_cli ||= BasecampAgentConnector::Basecamp::Client.new(command_runner: command_runner)
+      @basecamp_cli ||= BasecampAgentConnector::Basecamp::Client.new(command_runner: command_runner, profile: @options.operator)
     end
 
     def github_cli

--- a/skills/basecamp-connect/SKILL.md
+++ b/skills/basecamp-connect/SKILL.md
@@ -234,8 +234,10 @@ problem and must not be answered with `auth login` — see
 If the agent profile resolves to the **same** user as the operator, **nothing
 will trigger**: the connector refuses the agent's own identity in every trust
 mode, so if the agent *is* the operator, the operator's own mentions are dropped
-too. `bin/connect` warns about this at startup. Use a distinct bot account for
-the agent.
+too. `bin/connect` refuses to start in that state and says why; the usual
+cause is `BASECAMP_PROFILE` pinned to the agent's profile with no `--operator`,
+which resolves the operator through the agent's profile. Use a distinct bot
+account for the agent, and pass `--operator` when the variable is set.
 
 ## Procedure
 

--- a/test/basecamp_client_test.rb
+++ b/test/basecamp_client_test.rb
@@ -17,6 +17,32 @@ class BasecampClientTest < Minitest::Test
     assert_includes runner.commands.last.join(" "), "--profile clawdito"
   end
 
+  # The CLI resolves BASECAMP_PROFILE ahead of its configured default, so a
+  # command with no --profile runs as whatever the environment pins; the
+  # client's default profile makes the operator explicit on each of them.
+  def test_unflagged_commands_run_under_the_default_profile
+    runner = FakeCommandRunner.new
+    runner.stub "chat list", stdout: envelope([])
+    runner.stub "webhooks delete", exit_status: 0
+
+    cli = BasecampAgentConnector::Basecamp::Client.new(command_runner: runner, profile: "jorge", wait: ->(_seconds) { })
+    cli.chats(project: 222)
+    cli.delete_webhook(id: 555, project: 222)
+
+    assert_equal 2, runner.commands.length
+    runner.commands.each { |command| assert_includes command.join(" "), "--profile jorge" }
+  end
+
+  def test_an_explicit_profile_is_not_overridden_by_the_default
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp me", stdout: envelope("id" => 200)
+
+    BasecampAgentConnector::Basecamp::Client.new(command_runner: runner, profile: "jorge", wait: ->(_seconds) { }).me(profile: "clawdito")
+
+    assert_equal 1, runner.commands.last.count("--profile")
+    assert_includes runner.commands.last.join(" "), "--profile clawdito"
+  end
+
   def test_malformed_json_from_a_successful_command_is_a_transient_error
     runner = FakeCommandRunner.new
     runner.stub "chat list", stdout: '{"data": [{"id": 333, "tit'

--- a/test/connector_test.rb
+++ b/test/connector_test.rb
@@ -228,6 +228,72 @@ class ConnectorTest < Minitest::Test
     assert_match(/Polling 0 Campfire\(s\)/, err)
   end
 
+  # The failure this prevents: `BASECAMP_PROFILE` pinned to the agent's profile
+  # and no --operator, so the unflagged `basecamp me` answers as the agent and
+  # the connector runs with nobody able to trigger it.
+  def test_start_refuses_an_operator_who_is_the_agent
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp me", stdout: JSON.generate("ok" => true, "data" => { "identity" => { "id" => 1, "email_address" => "clawdito@example.com", "first_name" => "Clawdito" } })
+    runner.stub "people show me", stdout: JSON.generate("ok" => true, "data" => { "id" => 52007412 })
+
+    _out, err = with_env("BASECAMP_PROFILE" => "clawdito") do
+      start_connector [ "@clawdito", "--project", "123", "--types", "Chat::Line", "--port", "4567" ], runner, expect_exit: true
+    end
+
+    assert_match(/same Basecamp user \(clawdito@example.com\)/, err)
+    assert_match(/BASECAMP_PROFILE=clawdito is set and --operator is not/, err)
+    assert_empty runner.commands_matching(/chat list/)
+  end
+
+  # No email on either side: the match is on the identity id, and the id is
+  # what the message can name.
+  def test_start_refuses_an_operator_who_is_the_agent_without_blaming_the_environment
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp me", stdout: JSON.generate("ok" => true, "data" => { "identity" => { "id" => 28142355 } })
+    runner.stub "people show me", stdout: JSON.generate("ok" => true, "data" => { "id" => 52007412 })
+
+    _out, err = with_env("BASECAMP_PROFILE" => nil) do
+      start_connector [ "@clawdito", "--project", "123", "--types", "Chat::Line", "--operator", "clawdito" ], runner, expect_exit: true
+    end
+
+    assert_match(/operator \(profile clawdito\) are the same Basecamp user \(28142355\)/, err)
+    assert_match(/distinct bot user/, err)
+    refute_match(/BASECAMP_PROFILE/, err)
+  end
+
+  # A run killed without teardown leaves its file as the only record of the
+  # paths it owned; a start that is refused must not be the one to consume it.
+  def test_a_refused_start_leaves_dead_run_records_for_the_next_one_to_sweep
+    with_registry do |registry, directory|
+      orphan = File.join(directory, "4194303.json")
+      File.write orphan, JSON.generate(pid: 4_194_303, started_at: "2026-09-01T00:00:00Z", agent: "clawdito", operator: "jorge",
+        projects: [ "123" ], repos: [], paths: [ "/bc5/orphan" ], boosts: true)
+      runner = FakeCommandRunner.new
+      runner.stub "basecamp me", stdout: JSON.generate("ok" => true, "data" => { "identity" => { "id" => 1, "email_address" => "clawdito@example.com" } })
+      runner.stub "people show me", stdout: JSON.generate("ok" => true, "data" => { "id" => 52007412 })
+
+      with_env("BASECAMP_PROFILE" => nil) do
+        start_connector [ "@clawdito", "--project", "123", "--types", "Chat::Line", "--operator", "clawdito" ], runner, registry: registry, expect_exit: true
+      end
+
+      assert_path_exists orphan
+    end
+  end
+
+  def test_start_makes_every_operator_side_call_under_the_operator_profile
+    runner = FakeCommandRunner.new
+    runner.stub "basecamp me --profile clawdito", stdout: JSON.generate("ok" => true, "data" => { "identity" => { "id" => 1, "email_address" => "clawdito@example.com", "first_name" => "Clawdito" } })
+    runner.stub "basecamp me", stdout: JSON.generate("ok" => true, "data" => { "identity" => { "id" => 2, "email_address" => "jorge@example.com", "first_name" => "Jorge" } })
+    runner.stub "people show me", stdout: JSON.generate("ok" => true, "data" => { "id" => 52007412 })
+    runner.stub "chat list", stdout: "[]"
+
+    start_connector [ "@clawdito", "--project", "123", "--types", "Chat::Line", "--operator", "jorge", "--port", "4567" ], runner
+
+    assert_equal 1, runner.commands_matching(/\Abasecamp me --profile jorge -j\z/).length
+    assert_equal 1, runner.commands_matching(/chat list/).length
+    assert_match(/--profile jorge/, runner.commands_matching(/chat list/).first.join(" "))
+  end
+
   def test_parses_the_duplicate_opt_in
     refute parse("@clawdito", "--project", "A").allow_duplicate
     assert parse("@clawdito", "--project", "A", "--allow-duplicate").allow_duplicate
@@ -330,7 +396,7 @@ class ConnectorTest < Minitest::Test
   private
     def with_registry
       Dir.mktmpdir do |directory|
-        yield BasecampAgentConnector::RunRegistry.new(directory: directory, logger: StringIO.new)
+        yield BasecampAgentConnector::RunRegistry.new(directory: directory, logger: StringIO.new), directory
       end
     end
 
@@ -380,10 +446,26 @@ class ConnectorTest < Minitest::Test
       runner
     end
 
-    def start_connector(argv, runner)
-      connector = BasecampAgentConnector::Connector.new(BasecampAgentConnector::Connector.parse_options(argv))
+    def start_connector(argv, runner, registry: BasecampAgentConnector::RunRegistry.new, expect_exit: false)
+      connector = BasecampAgentConnector::Connector.new(BasecampAgentConnector::Connector.parse_options(argv), registry: registry)
       connector.instance_variable_set(:@command_runner, runner)
 
-      BasecampAgentConnector::Server.stub(:new, FakeServer.new) { capture_io { connector.start } }
+      BasecampAgentConnector::Server.stub(:new, FakeServer.new) do
+        capture_io do
+          if expect_exit
+            refute_equal 0, assert_raises(SystemExit) { connector.start }.status
+          else
+            connector.start
+          end
+        end
+      end
+    end
+
+    def with_env(variables)
+      saved = variables.to_h { |name, _value| [ name, ENV[name] ] }
+      variables.each { |name, value| ENV[name] = value }
+      yield
+    ensure
+      saved.each { |name, value| ENV[name] = value }
     end
 end


### PR DESCRIPTION
Fixes #36.

`warn_if_same_user` printed one stderr line and kept going. With `BASECAMP_PROFILE` pinned to the agent's profile and no `--operator`, the unflagged `basecamp me` the connector runs for the operator answers as the agent (the CLI resolves `--profile` > `BASECAMP_PROFILE` > `default_profile`), so the run started with nobody able to trigger it under `operator` trust, and with no operator at all under `project` trust — assignments dropped, every corroborating fetch and webhook registration made as the agent.

- `Identity#same_user_as?` compares identity ids instead of emails (an email absent on both sides compared as two different users).
- `Connector#refuse_same_user` aborts. When `BASECAMP_PROFILE` is set and `--operator` was not passed, the message says the operator *and every call made on the operator's behalf* resolved through that profile, and names unsetting it first (`env -u BASECAMP_PROFILE bin/connect …`), then `--operator`.
- `--operator` is now correct as a remedy because the operator profile is the `Basecamp::Client`'s default: every command that does not name a profile (`show`, `subscriptions show`, `chat list/messages`, `webhooks create/list/delete`, `auth refresh` for the operator) gets `--profile <operator>` appended, which the CLI resolves ahead of `BASECAMP_PROFILE`. Chosen over "refuse whenever the variable is set", which would also refuse the harmless case of the variable naming the operator's own profile, and over refusing only the `--operator`-present combination, which would leave `--operator` unable to do what its name says. Agent-side calls (`me`/`people show me` for the agent, the boosts feed) already pass the agent profile explicitly and are unchanged.
- Dead-run records are pruned immediately before registration rather than first thing in `start`, so a start refused for any reason (same user, unresolvable identity, duplicate) leaves the pruned run's paths on disk for the next start to sweep. Liveness, not the file, is what the duplicate check reads, so the reorder does not change which runs count as duplicates.
- README, `docs/spec.md`, and the skill's SKILL.md now say "refuses" where they said "warns", and README notes that `--operator` also governs the operator-side calls. The installed skill copy needs `npx skills update -g` after this lands, per AGENTS.md.

Tests: the same-user abort with the variable set (named in the message; no poll ran); the same-user abort with `--operator` naming the agent profile and no emails on either side (id named, variable not blamed); a refused start leaves a dead run's record on disk; a `--operator jorge` start makes the operator `me` and the chat poll under `--profile jorge`; client-level tests for the default profile on unflagged commands and for an explicit profile not being doubled.

```
334 runs, 1069 assertions, 0 failures, 0 errors, 0 skips   (darwin and Linux)
48 files inspected, no offenses detected
```