### PR TITLE
Consult ps where /proc is absent, so --status is right on darwin

### DIFF
--- a/lib/basecamp_agent_connector/connector.rb
+++ b/lib/basecamp_agent_connector/connector.rb
@@ -68,21 +68,36 @@ class BasecampAgentConnector::Connector
 
   def self.running_connector_pids(command_runner)
     result = command_runner.run("pgrep", "-f", "bin/connect")
-    result.stdout.split.map(&:to_i).reject(&:zero?).select { |pid| watching_process?(pid) }
+    result.stdout.split.map(&:to_i).reject(&:zero?).select { |pid| watching_process?(pid, command_runner) }
   rescue SystemCallError, Errno::ENOENT
     []
   end
 
   # `pgrep -f` matches the whole command line, so it also catches the shell that
   # launched a connector (bin/connect buried inside its `-c` string) and this
-  # very `--status` run. A real watcher has `bin/connect` as an argument of its
-  # own and no `--status` among them. An unreadable cmdline errs toward
-  # reporting: an unattributable connector is worth one false positive.
-  def self.watching_process?(pid)
-    arguments = File.read("/proc/#{pid}/cmdline").split("\u0000")
-    arguments.any? { |argument| argument.end_with?("bin/connect") } && !arguments.include?("--status")
+  # very `--status` run. A real watcher has `bin/connect` as the executable or
+  # as the script an interpreter was handed — before any flag, which is what
+  # rules the shell's `-c` string out once `ps` has joined argv into one line —
+  # and no `--status` among its arguments. An unreadable command line errs
+  # toward reporting: an unattributable connector is worth one false positive.
+  def self.watching_process?(pid, command_runner)
+    arguments = process_arguments(pid, command_runner)
+    arguments.nil? || \
+      (arguments.take_while { |argument| !argument.start_with?("-") }.any? { |argument| argument.end_with?("bin/connect") } && \
+        !arguments.include?("--status"))
+  end
+
+  # Exact argv from /proc where it exists; `ps` elsewhere (darwin has no
+  # /proc), which hands back one space-joined line, split on whitespace.
+  def self.process_arguments(pid, command_runner)
+    if BasecampAgentConnector::RunRegistry.procfs?
+      File.read("/proc/#{pid}/cmdline").split("\u0000")
+    else
+      result = command_runner.run("ps", "-o", "command=", "-p", pid.to_s)
+      result.stdout.split if result.success?
+    end
   rescue SystemCallError
-    true
+    nil
   end
 
   def self.parse_options(argv)

--- a/lib/basecamp_agent_connector/run_registry.rb
+++ b/lib/basecamp_agent_connector/run_registry.rb
@@ -1,5 +1,6 @@
 require "json"
 require "fileutils"
+require "open3"
 require "time"
 
 # Which connectors are running on this machine, and which funnel paths each one
@@ -24,15 +25,33 @@ require "time"
 class BasecampAgentConnector::RunRegistry
   DEFAULT_DIRECTORY = File.expand_path("~/.config/basecamp-connect/runs")
 
-  # The process start time, in clock ticks since boot, from /proc/<pid>/stat
-  # field 22. Recorded alongside the pid because a pid alone is ambiguous once
-  # it is recycled, and reading a live run as dead is the expensive direction:
-  # the sweep would delete its webhooks. `comm` may itself contain spaces and
-  # parens, so the fields are counted from the last ')'.
+  # The process start time. Recorded alongside the pid because a pid alone is
+  # ambiguous once it is recycled, and reading a live run as dead is the
+  # expensive direction: the sweep would delete its webhooks. Clock ticks since
+  # boot from /proc/<pid>/stat field 22 where /proc exists (`comm` may itself
+  # contain spaces and parens, so the fields are counted from the last ')');
+  # `ps -o lstart=` elsewhere, darwin having no /proc.
   def self.process_start(pid)
+    procfs? ? proc_start(pid) : ps_start(pid)
+  end
+
+  def self.procfs?
+    File.exist?("/proc/self")
+  end
+
+  def self.proc_start(pid)
     stat = File.read("/proc/#{pid}/stat")
     stat[(stat.rindex(")") + 2)..].split[19]
   rescue SystemCallError, NoMethodError, TypeError
+    nil
+  end
+
+  # `lstart` is rendered in the caller's locale and zone, and the value is
+  # compared as text across processes that may not share them; pin both.
+  def self.ps_start(pid)
+    start, _stderr, status = Open3.capture3({ "LC_ALL" => "C", "TZ" => "UTC" }, "ps", "-o", "lstart=", "-p", pid.to_s)
+    start.strip if status.success? && !start.strip.empty?
+  rescue SystemCallError
     nil
   end
 

--- a/test/connector_test.rb
+++ b/test/connector_test.rb
@@ -315,6 +315,31 @@ class ConnectorTest < Minitest::Test
     end
   end
 
+  # Claude Code launches a connector as `bash -c '… bin/connect @agent …'` and
+  # that shell stays alive as the parent, so `pgrep -f` hands back two pids per
+  # connector; only the ruby process is one.
+  def test_status_does_not_count_the_shell_that_launched_a_connector
+    with_registry do |registry|
+      runner = processes(
+        4_194_301 => "/opt/homebrew/bin/bash -c source snapshot.sh && eval 'cd connector && bin/connect @clawdito --project \"App Security\"'",
+        4_194_302 => "ruby bin/connect @clawdito --project App Security")
+
+      output = without_procfs { capture_stdout { BasecampAgentConnector::Connector.print_status(registry: registry, command_runner: runner) } }
+
+      assert_match(/NOT recorded: 4194302\./, output)
+    end
+  end
+
+  def test_status_does_not_count_another_status_run
+    with_registry do |registry|
+      runner = processes(4_194_302 => "ruby bin/connect --status")
+
+      output = without_procfs { capture_stdout { BasecampAgentConnector::Connector.print_status(registry: registry, command_runner: runner) } }
+
+      refute_match(/NOT recorded/, output)
+    end
+  end
+
   def test_status_does_not_report_a_recorded_run_as_unrecorded
     with_registry do |registry|
       registry.record(agent: "clawdito", operator: "jorge", projects: [ "Queenbee" ], repos: [], paths: [], boosts: true)
@@ -342,12 +367,21 @@ class ConnectorTest < Minitest::Test
       processes
     end
 
-    # A pid with no /proc entry: `watching_process?` errs toward reporting it,
-    # which is the behavior under test.
+    # Pids beyond any kernel's range, so /proc never has them: on Linux
+    # `watching_process?` errs toward reporting each one, which is the behavior
+    # under test; elsewhere it asks `ps`, whose answer is stubbed per pid — a
+    # connector's command line unless the caller gives one.
     def processes(*pids)
+      commands = pids.flat_map { |pid| pid.is_a?(Hash) ? pid.to_a : [ [ pid, "ruby bin/connect @clawdito --project A" ] ] }
       runner = FakeCommandRunner.new
-      runner.stub "pgrep", stdout: pids.join("\n")
+      runner.stub "pgrep", stdout: commands.map(&:first).join("\n")
+      commands.each { |pid, command| runner.stub "ps -o command= -p #{pid}", stdout: "#{command}\n" }
       runner
+    end
+
+    # The `ps` path, whichever platform the tests run on.
+    def without_procfs(&block)
+      BasecampAgentConnector::RunRegistry.stub(:procfs?, false, &block)
     end
 
     def capture_stderr

--- a/test/run_registry_test.rb
+++ b/test/run_registry_test.rb
@@ -91,6 +91,23 @@ class RunRegistryTest < Minitest::Test
     end
   end
 
+  # Both platforms answer for a live pid; a pid nothing runs under has no
+  # start time anywhere.
+  def test_process_start_is_known_for_a_live_pid_and_nil_for_a_dead_one
+    refute_nil BasecampAgentConnector::RunRegistry.process_start(Process.pid)
+    assert_nil BasecampAgentConnector::RunRegistry.process_start(dead_pid)
+  end
+
+  # The recorded value is compared as text by a later process, which may run
+  # under another locale or zone; the `ps` answer must not depend on either.
+  def test_ps_start_does_not_vary_with_the_callers_locale_or_zone
+    in_c = with_env("TZ" => "UTC", "LC_ALL" => "C") { BasecampAgentConnector::RunRegistry.ps_start(Process.pid) }
+    elsewhere = with_env("TZ" => "Asia/Tokyo", "LC_ALL" => "fr_FR.UTF-8") { BasecampAgentConnector::RunRegistry.ps_start(Process.pid) }
+
+    refute_nil in_c
+    assert_equal in_c, elsewhere
+  end
+
   def test_an_unwritable_directory_does_not_raise
     logs = StringIO.new
     registry = BasecampAgentConnector::RunRegistry.new(directory: "/proc/nope/runs", logger: logs)
@@ -115,6 +132,14 @@ class RunRegistryTest < Minitest::Test
       File.write File.join(directory, "#{pid}.json"), JSON.generate(
         pid: pid, started_at: "2026-09-01T00:00:00Z", agent: agent, operator: "jorge",
         projects: [ "Queenbee" ], repos: [], paths: paths, boosts: true)
+    end
+
+    def with_env(variables)
+      saved = variables.to_h { |name, _value| [ name, ENV[name] ] }
+      variables.each { |name, value| ENV[name] = value }
+      yield
+    ensure
+      saved.each { |name, value| ENV[name] = value }
     end
 
     # A pid nothing can be running under: the kernel's max is well below this.


### PR DESCRIPTION
Fixes #37.

`RunRegistry.process_start` and `Connector.watching_process?` both read `/proc`, which darwin does not have. The start time came back nil, so `Run#same_process?` could never detect a recycled pid — a SIGKILLed run whose pid came back keeps its entry, its orphaned webhooks are never swept, and a new connector on the same agent and project is refused as a duplicate. The command line came back unreadable, so every `pgrep -f bin/connect` hit was reported, including the `bash -c '… bin/connect …'` that launched each connector and stays alive as its parent: on a machine with six connectors, `--status` reported ten unrecorded processes.

- `process_start` keeps the `/proc/<pid>/stat` read where `/proc` exists and falls back to `ps -o lstart=` elsewhere, run under `LC_ALL=C TZ=UTC` since the value is compared as text by a later process that may not share the recorder's locale or zone. Entries recorded before this change carry `process_start: null` and still resolve on the bare pid probe, as before.
- `watching_process?` keeps the exact argv from `/proc/<pid>/cmdline` where it exists and falls back to `ps -o command=` (one space-joined line, split on whitespace). A process counts when a `bin/connect` token appears before any flag — the executable, or the script an interpreter was handed — and no `--status` token is present; the wrapper's copy sits after `-c`, so it is out. Linux behaviour is unchanged except that an interpreter invoked with a flag ahead of the script (`ruby -W0 bin/connect`) would no longer count, a shape nothing here launches.

On this machine, before and after:

```
10 connector process(es) running but NOT recorded: 18931, 38778, 49731, 49735, 60410, 60414, 74306, 74312, 79478, 79485.
 4 connector process(es) running but NOT recorded: 49735, 60414, 74312, 79485.
```

The four that remain are ruby connectors started before #28 landed, which is the case the report exists for.

Tests: the shell wrapper is not counted while its child is, and another `--status` run is not counted — both forced onto the `ps` path via `RunRegistry.procfs?` so they exercise the darwin filter on Linux too; `process_start` answers for the live pid and is nil for a dead one; `ps_start` returns the same string under two different `TZ`/`LC_ALL` settings.

```
332 runs, 1046 assertions, 0 failures, 0 errors, 0 skips   (darwin and Linux)
48 files inspected, no offenses detected
```