### PR TITLE
Reactivate webhooks Basecamp deactivated after failed deliveries

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,19 @@ you’re done** — stopping deletes every webhook and unmounts its funnel paths
 automatically. In Claude Code, ending the skill does this; from a terminal, press
 **Ctrl-C**. Nothing is left running or exposed.
 
+While it runs, it also keeps those registrations alive. Basecamp **deactivates
+a webhook after 10 failed deliveries** (`Webhook::DeliveryJob` in bc3: about
+four to five hours of backoff), and says nothing — the registration stays listed, but
+nothing is delivered to it again. A laptop asleep overnight, a Tailscale funnel
+path that dropped, or a run whose every delivery answered `503` all end that
+way, and the chat and boost pollers keep working through it, so the connector
+looks healthy while every mention goes unheard. Every `--webhook-check` seconds
+(default 300) the connector re-reads each webhook it registered and reactivates
+any Basecamp switched off (or re-registers one deleted out from under it),
+remounts any of its funnel paths the funnel has lost, and reports both loudly on
+STDERR. The events of the gap itself are gone — bc3 does not redeliver past a
+deactivation — so a `DEACTIVATED` line in the log is worth reading.
+
 ---
 
 ## How it works
@@ -429,6 +442,7 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
 | `--chat-poll` | Campfire poll interval, in seconds. | `15` |
 | `--boost-poll` | Received-boosts poll interval, in seconds. Boosts have no webhooks, so the connector polls the agent's own received-boosts feed for them. | `60` |
 | `--no-boosts` | Don't poll the agent's received-boosts feed (no boost trigger). | polling on |
+| `--webhook-check` | How often, in seconds, to re-check that each registered webhook is still active and its funnel path still mounted, putting back whichever isn't. Basecamp deactivates a webhook after 10 failed deliveries. | `300` |
 | `--port` | Local port for the webhook server. | an unused high port |
 
 **What it does, in order:**
@@ -474,10 +488,11 @@ bin/connect @Clawdito --project Queenbee --operator jorge --port 4567
    anything it never classified, the keyring race included — leaves the list
    in force. A delivery that stays unanswerable for all of bc3's 10 attempts
    (~4.3h — a revoked credential looks just like the race) makes bc3
-   deactivate the webhook: fix
-   the CLI's credentials (`basecamp auth status --profile <agent>`) and
-   restart `bin/connect`, which re-registers it. The connector logs that
-   remedy with every `503`.
+   deactivate the webhook. The webhook check (`--webhook-check`, see
+   [Stopping](#stopping-and-why-it-matters)) reactivates it within one
+   interval, but a credential still broken just fails the next ten deliveries
+   too: fix it (`basecamp auth status --profile <agent>`). The connector logs
+   that remedy with every `503`.
 
 **Emitted event (STDOUT, one JSON object per line):**
 
@@ -547,6 +562,9 @@ basecamp comment <recording-url> "…" --profile <agent> # post as the agent
   connector polls the agent's own received-boosts feed — an account-wide,
   agent-scoped surface (a boost triggers wherever the agent's boosted work
   lives, not only in watched projects).
+- **Webhook check** — `--webhook-check` interval in seconds (default 300):
+  how often each registered webhook is re-read and reactivated if Basecamp
+  deactivated it, and the funnel paths remounted if lost.
 - **Port** — `--port` (default: an unused high port).
 
 ---

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -141,7 +141,7 @@ behavior in Component 2. Discovery follows the standard Claude Code mechanism
 ### Invocation
 
 ```
-bin/connect @AGENT --project <project>... [--operator <profile>] [--types <types>] [--boost-poll <seconds>|--no-boosts] [--port <port>]
+bin/connect @AGENT --project <project>... [--operator <profile>] [--types <types>] [--boost-poll <seconds>|--no-boosts] [--webhook-check <seconds>] [--port <port>]
 ```
 
 - `@AGENT` — the agent user / local profile name (e.g. `@Clawdito` or
@@ -164,6 +164,10 @@ bin/connect @AGENT --project <project>... [--operator <profile>] [--types <types
   Recording and creates no Event in bc3), so the bridge polls the **agent's own
   received-boosts feed** (`/my/boosts.json`) for them on this interval (default
   60s); `--no-boosts` disables the boost trigger.
+- `--webhook-check` — how often (default 300s) each registered webhook is
+  re-read and reactivated if bc3 deactivated it (which it does, silently,
+  after 10 failed deliveries — `Webhook::DeliveryJob`), and the run's funnel
+  paths remounted if the funnel lost them.
 - `--port` — local port for the Ruby server (default: an unused high port).
 
 ### Startup sequence

--- a/lib/basecamp_agent_connector/basecamp/bridge.rb
+++ b/lib/basecamp_agent_connector/basecamp/bridge.rb
@@ -19,7 +19,8 @@ class BasecampAgentConnector::Basecamp::Bridge
 
   def initialize(authorizer:, agent:, projects:, types:, basecamp_cli:, emitter:, logger: $stderr,
     chat_poll_interval: BasecampAgentConnector::Basecamp::ChatPoller::DEFAULT_INTERVAL,
-    boost_poll_interval: BasecampAgentConnector::Basecamp::BoostPoller::DEFAULT_INTERVAL)
+    boost_poll_interval: BasecampAgentConnector::Basecamp::BoostPoller::DEFAULT_INTERVAL,
+    webhook_check_interval: BasecampAgentConnector::Basecamp::WebhookMonitor::DEFAULT_INTERVAL)
     @authorizer = authorizer
     @agent = agent
     @projects = projects
@@ -29,6 +30,7 @@ class BasecampAgentConnector::Basecamp::Bridge
     @logger = logger
     @chat_poll_interval = chat_poll_interval
     @boost_poll_interval = boost_poll_interval
+    @webhook_check_interval = webhook_check_interval
     @secret = SecureRandom.hex(16)
     @webhooks = BasecampAgentConnector::Basecamp::Webhooks.new(basecamp_cli: basecamp_cli)
   end
@@ -46,7 +48,9 @@ class BasecampAgentConnector::Basecamp::Bridge
     [ path ].compact
   end
 
-  def register(base_url:, orphan_paths: [])
+  # `tunnel` is the funnel the webhooks deliver through, for the monitor to
+  # keep mounted; nil when the caller has none to check.
+  def register(base_url:, orphan_paths: [], tunnel: nil)
     # Chat first: webhook registration opens deliveries toward a server that
     # isn't listening yet, so don't widen that window by discovering chats
     # after it. The poller emits nothing until its thread's first interval
@@ -64,8 +68,17 @@ class BasecampAgentConnector::Basecamp::Bridge
       @webhooks.delete_orphans(projects: @projects, paths: orphan_paths)
 
       url = "#{base_url}#{path}"
-      @webhooks.register_all(projects: @projects, url: url, types: @webhook_types.join(","))
+      types = @webhook_types.join(",")
+      @webhooks.register_all(projects: @projects, url: url, types: types)
       log "Listening for mentions of @#{agent_name} on #{@projects.length} project(s) at #{url}"
+
+      # Started before readiness is reported, but its first check is one
+      # interval away, so nothing here races the funnel consumer.
+      if @webhook_check_interval
+        start_webhook_monitor(url: url, types: types, tunnel: tunnel)
+        log "Re-checking those webhooks every #{@webhook_check_interval}s " \
+          "(Basecamp deactivates a webhook after 10 failed deliveries, silently)"
+      end
     end
 
     # The boost poller fetches nothing until its thread's first interval pass,
@@ -93,11 +106,12 @@ class BasecampAgentConnector::Basecamp::Bridge
   #
   # A failure that stays transient through all 10 attempts (~4.3h: a
   # revoked credential reports auth_required on every call, exactly like the
-  # keyring race) ends with bc3 deactivating the webhook, silently; the 503
-  # log line names that and the remedy — fix the CLI's credentials and
-  # restart bin/connect, which re-registers. Which call could not be
-  # answered — the recording fetch, or the subscriber lookup after it — is
-  # in the error's message, which names the failed command.
+  # keyring race) ends with bc3 deactivating the webhook, silently. The
+  # WebhookMonitor reactivates it on its next check, but a credential still
+  # broken just fails the next ten deliveries too, so the 503 log line names
+  # the remedy — fix the CLI's credentials. Which call could not be answered
+  # — the recording fetch, or the subscriber lookup after it — is in the
+  # error's message, which names the failed command.
   #
   # Because the work is on the request thread, shutdown (WEBrick joins its
   # request threads before `start` returns) waits for in-flight deliveries
@@ -125,7 +139,7 @@ class BasecampAgentConnector::Basecamp::Bridge
     rescue BasecampAgentConnector::Basecamp::Client::TransientError => error
       log "could not corroborate event #{event.id}: #{error.message}; answered 503 so Basecamp redelivers " \
         "(bc3 deactivates the webhook after 10 failed deliveries: if this repeats, check `basecamp auth status " \
-        "--profile #{@agent.profile}` and restart bin/connect to re-register)"
+        "--profile #{@agent.profile}` — the webhook check reactivates the webhook, but not the credentials)"
       503
     rescue JSON::ParserError => error
       log "ignored malformed payload: #{error.message}"
@@ -139,6 +153,7 @@ class BasecampAgentConnector::Basecamp::Bridge
   def teardown
     @chat_poller&.stop
     @boost_poller&.stop
+    @webhook_monitor&.stop
     @webhooks.delete_all
   end
 
@@ -171,6 +186,17 @@ class BasecampAgentConnector::Basecamp::Bridge
         agent: @agent,
         interval: @boost_poll_interval,
         logger: @logger
+    end
+
+    def start_webhook_monitor(url:, types:, tunnel:)
+      @webhook_monitor = BasecampAgentConnector::Basecamp::WebhookMonitor.new \
+        webhooks: @webhooks,
+        url: url,
+        types: types,
+        tunnel: tunnel,
+        interval: @webhook_check_interval,
+        logger: @logger
+      @webhook_monitor.start
     end
 
     def build_pipeline

--- a/lib/basecamp_agent_connector/basecamp/bridge.rb
+++ b/lib/basecamp_agent_connector/basecamp/bridge.rb
@@ -48,9 +48,7 @@ class BasecampAgentConnector::Basecamp::Bridge
     [ path ].compact
   end
 
-  # `tunnel` is the funnel the webhooks deliver through, for the monitor to
-  # keep mounted; nil when the caller has none to check.
-  def register(base_url:, orphan_paths: [], tunnel: nil)
+  def register(base_url:, orphan_paths: [])
     # Chat first: webhook registration opens deliveries toward a server that
     # isn't listening yet, so don't widen that window by discovering chats
     # after it. The poller emits nothing until its thread's first interval
@@ -75,7 +73,7 @@ class BasecampAgentConnector::Basecamp::Bridge
       # Started before readiness is reported, but its first check is one
       # interval away, so nothing here races the funnel consumer.
       if @webhook_check_interval
-        start_webhook_monitor(url: url, types: types, tunnel: tunnel)
+        start_webhook_monitor(url: url, types: types)
         log "Re-checking those webhooks every #{@webhook_check_interval}s " \
           "(Basecamp deactivates a webhook after 10 failed deliveries, silently)"
       end
@@ -188,12 +186,11 @@ class BasecampAgentConnector::Basecamp::Bridge
         logger: @logger
     end
 
-    def start_webhook_monitor(url:, types:, tunnel:)
+    def start_webhook_monitor(url:, types:)
       @webhook_monitor = BasecampAgentConnector::Basecamp::WebhookMonitor.new \
         webhooks: @webhooks,
         url: url,
         types: types,
-        tunnel: tunnel,
         interval: @webhook_check_interval,
         logger: @logger
       @webhook_monitor.start

--- a/lib/basecamp_agent_connector/basecamp/client.rb
+++ b/lib/basecamp_agent_connector/basecamp/client.rb
@@ -153,6 +153,16 @@ class BasecampAgentConnector::Basecamp::Client
     Array json("webhooks", "list", "--project", project.to_s)
   end
 
+  def webhook(id:, project:)
+    json "webhooks", "show", id.to_s, "--project", project.to_s
+  end
+
+  # Idempotent, unlike create: an answer lost after the flag landed is
+  # re-applied unchanged by the next attempt, so the reads' retries are safe.
+  def activate_webhook(id:, project:)
+    json "webhooks", "update", id.to_s, "--project", project.to_s, "--active"
+  end
+
   private
     # A command either answers (its envelope is handed back), is refused
     # (Error, at once — Basecamp's verdict doesn't improve with repetition),

--- a/lib/basecamp_agent_connector/basecamp/webhook_monitor.rb
+++ b/lib/basecamp_agent_connector/basecamp/webhook_monitor.rb
@@ -1,0 +1,79 @@
+# Keeps the webhook registrations deliverable for the life of the run. A
+# registration is made once at startup, but Basecamp deactivates a webhook
+# after 10 failed deliveries (bc3 Webhook::DeliveryJob), and the funnel path
+# those deliveries need can drop out from under the run — and neither says so.
+# The pollers keep working through both, so the connector looks healthy while
+# every mention goes unheard. On an interval, the funnel's paths are checked
+# and remounted, then each registration is re-read and restored (see
+# Webhooks#restore), and anything found wrong is logged loudly.
+class BasecampAgentConnector::Basecamp::WebhookMonitor
+  DEFAULT_INTERVAL = 300
+
+  def initialize(webhooks:, url:, types:, tunnel: nil, interval: DEFAULT_INTERVAL, logger: $stderr,
+    wait: ->(seconds) { sleep seconds })
+    @webhooks = webhooks
+    @url = url
+    @types = types
+    @tunnel = tunnel
+    @interval = interval
+    @logger = logger
+    @wait = wait
+    @stopping = false
+  end
+
+  def start
+    @thread = Thread.new { check_loop }
+  end
+
+  def stop
+    @stopping = true
+
+    if @thread
+      @thread.kill
+      # Bounded, not guaranteed: a kill lands between CLI calls instantly, but
+      # a thread mid-subprocess dies only when the child returns. The process
+      # is tearing down anyway, so make any residue visible rather than block.
+      log "webhook check thread did not stop within 5s" if @thread.join(5).nil?
+      @thread = nil
+    end
+  end
+
+  # Funnel first: a webhook reactivated toward an unmounted path only earns
+  # its next ten failures.
+  def check
+    unless @stopping
+      remount_funnel
+      @webhooks.restore(url: @url, types: @types)
+    end
+  end
+
+  private
+    # An exception escaping a check must cost one tick, not the rest of the
+    # session's coverage.
+    def check_loop
+      until @stopping
+        @wait.call(@interval)
+
+        begin
+          check
+        rescue => error
+          log "webhook check failed: #{error.message}"
+        end
+      end
+    end
+
+    # A funnel that can't be asked is logged and the webhooks still checked:
+    # a reactivation is worth doing even when the funnel's state is unknown.
+    def remount_funnel
+      Array(@tunnel&.remount_missing).each do |path|
+        log "funnel path #{path} was no longer mounted (a `tailscale funnel reset`, or tailscaled lost its serve " \
+          "config); remounted it — deliveries in between failed, and bc3 deactivates a webhook after 10 of those"
+      end
+    rescue BasecampAgentConnector::Tunnel::Error => error
+      log "funnel check failed: #{error.message}"
+    end
+
+    def log(message)
+      @logger.puts message
+    end
+end

--- a/lib/basecamp_agent_connector/basecamp/webhook_monitor.rb
+++ b/lib/basecamp_agent_connector/basecamp/webhook_monitor.rb
@@ -1,49 +1,48 @@
-# Keeps the webhook registrations deliverable for the life of the run. A
+# Keeps the webhook registrations alive for the life of the run. A
 # registration is made once at startup, but Basecamp deactivates a webhook
-# after 10 failed deliveries (bc3 Webhook::DeliveryJob), and the funnel path
-# those deliveries need can drop out from under the run — and neither says so.
-# The pollers keep working through both, so the connector looks healthy while
-# every mention goes unheard. On an interval, the funnel's paths are checked
-# and remounted, then each registration is re-read and restored (see
-# Webhooks#restore), and anything found wrong is logged loudly.
+# after 10 failed deliveries (bc3 Webhook::DeliveryJob) and says nothing, and
+# the pollers keep working through it, so the connector looks healthy while
+# every mention goes unheard. On an interval each registration is re-read and
+# restored (see Webhooks#restore), and anything found wrong is logged loudly.
+# The funnel those deliveries need is the FunnelMonitor's to keep mounted.
 class BasecampAgentConnector::Basecamp::WebhookMonitor
   DEFAULT_INTERVAL = 300
 
-  def initialize(webhooks:, url:, types:, tunnel: nil, interval: DEFAULT_INTERVAL, logger: $stderr,
+  def initialize(webhooks:, url:, types:, interval: DEFAULT_INTERVAL, logger: $stderr,
     wait: ->(seconds) { sleep seconds })
     @webhooks = webhooks
     @url = url
     @types = types
-    @tunnel = tunnel
     @interval = interval
     @logger = logger
     @wait = wait
     @stopping = false
+    @checking = Mutex.new
   end
 
   def start
     @thread = Thread.new { check_loop }
   end
 
+  # A check in flight is let finish before the thread is killed: killing it
+  # mid-restore would leave a replacement webhook Basecamp created but the
+  # registrations never recorded, for teardown to miss. Taking the lock
+  # waits for that, so the kill only ever lands in the interval's sleep;
+  # the wait is bounded by the CLI's own timeouts, like an in-flight
+  # delivery's.
   def stop
     @stopping = true
 
     if @thread
-      @thread.kill
-      # Bounded, not guaranteed: a kill lands between CLI calls instantly, but
-      # a thread mid-subprocess dies only when the child returns. The process
-      # is tearing down anyway, so make any residue visible rather than block.
+      @checking.synchronize { @thread.kill }
       log "webhook check thread did not stop within 5s" if @thread.join(5).nil?
       @thread = nil
     end
   end
 
-  # Funnel first: a webhook reactivated toward an unmounted path only earns
-  # its next ten failures.
   def check
-    unless @stopping
-      remount_funnel
-      @webhooks.restore(url: @url, types: @types)
+    @checking.synchronize do
+      @webhooks.restore(url: @url, types: @types) unless @stopping
     end
   end
 
@@ -60,17 +59,6 @@ class BasecampAgentConnector::Basecamp::WebhookMonitor
           log "webhook check failed: #{error.message}"
         end
       end
-    end
-
-    # A funnel that can't be asked is logged and the webhooks still checked:
-    # a reactivation is worth doing even when the funnel's state is unknown.
-    def remount_funnel
-      Array(@tunnel&.remount_missing).each do |path|
-        log "funnel path #{path} was no longer mounted (a `tailscale funnel reset`, or tailscaled lost its serve " \
-          "config); remounted it — deliveries in between failed, and bc3 deactivates a webhook after 10 of those"
-      end
-    rescue BasecampAgentConnector::Tunnel::Error => error
-      log "funnel check failed: #{error.message}"
     end
 
     def log(message)

--- a/lib/basecamp_agent_connector/basecamp/webhooks.rb
+++ b/lib/basecamp_agent_connector/basecamp/webhooks.rb
@@ -39,6 +39,29 @@ class BasecampAgentConnector::Basecamp::Webhooks
     end
   end
 
+  # Basecamp switches a webhook off after 10 failed deliveries
+  # (bc3 Webhook::DeliveryJob: polynomially_longer backoff, ~4-5h in all) and
+  # says nothing: the registration stays listed, `active: false`, and no event
+  # reaches this connector again until something turns it back on. From bc3's
+  # side that is what a laptop asleep overnight, a funnel path that dropped, or
+  # a delivery answered 503 every time all look like. Every registration is
+  # re-read and put back: reactivated in place when Basecamp still has it (a
+  # deactivation is one flag, and the PUT keeps the id the run recorded),
+  # re-registered under a new id when someone deleted it by hand. Returns the
+  # registrations that were restored; one that could not be is left as it was
+  # and logged, so the next check tries again.
+  def restore(url:, types:)
+    restored = []
+
+    @registrations.map! do |registration|
+      live = restore_registration(registration, url: url, types: types)
+      restored << live if live
+      live || registration
+    end
+
+    restored
+  end
+
   private
     def orphans_in(project, paths)
       @basecamp_cli.webhooks(project: project).filter_map do |webhook|
@@ -67,6 +90,55 @@ class BasecampAgentConnector::Basecamp::Webhooks
       end
 
       raise last_error
+    end
+
+    # The live registration when it needed restoring and was; nil when it was
+    # fine, or when the attempt failed (logged, retried on the next check).
+    def restore_registration(registration, url:, types:)
+      case check(registration)
+      when :inactive then reactivate(registration)
+      when :missing then reregister(registration, url: url, types: types)
+      end
+    end
+
+    def check(registration)
+      webhook = @basecamp_cli.webhook(id: registration.id, project: registration.project)
+      webhook["active"] ? :active : :inactive
+    rescue BasecampAgentConnector::Basecamp::Client::Error => error
+      if error.code == "not_found"
+        :missing
+      else
+        log "could not check webhook #{registration.id} on project #{registration.project}: #{error.message}"
+        nil
+      end
+    end
+
+    def reactivate(registration)
+      @basecamp_cli.activate_webhook(id: registration.id, project: registration.project)
+      log "#{deactivation_notice(registration)} Reactivated it in place."
+      registration
+    rescue BasecampAgentConnector::Basecamp::Client::Error => error
+      log "#{deactivation_notice(registration)} Failed to reactivate it: #{error.message}; retrying on the next check."
+      nil
+    end
+
+    def reregister(registration, url:, types:)
+      webhook = create_with_retries(project: registration.project, url: url, types: types)
+      Registration.new(project: registration.project, id: webhook.fetch("id")).tap do |replacement|
+        log "webhook #{registration.id} on project #{registration.project} is gone (deleted outside this connector); " \
+          "re-registered it as #{replacement.id}"
+      end
+    rescue BasecampAgentConnector::Basecamp::Client::Error => error
+      log "webhook #{registration.id} on project #{registration.project} is gone (deleted outside this connector) " \
+        "and re-registering failed after #{@attempts} attempts: #{error.message}; retrying on the next check"
+      nil
+    end
+
+    def deactivation_notice(registration)
+      "webhook #{registration.id} on project #{registration.project} was DEACTIVATED by Basecamp: bc3 switches a " \
+        "webhook off after 10 failed deliveries (~4-5h of retries), which is what an unreachable funnel looks like " \
+        "from its side — this machine asleep, the Tailscale funnel path dropped, or every delivery answered 503 " \
+        "(check `basecamp auth status`). Nothing has been delivered since it was switched off."
     end
 
     def delete(registration)

--- a/lib/basecamp_agent_connector/connector.rb
+++ b/lib/basecamp_agent_connector/connector.rb
@@ -16,7 +16,8 @@ class BasecampAgentConnector::Connector
   TRUST_MODES = %w[operator allowlist project domain]
 
   Options = Data.define(:agent, :operator, :projects, :types, :repos, :events, :gh_operator, :port,
-    :trust, :allowed_emails, :allowed_domains, :allow_assignments, :chat_poll, :boost_poll, :allow_duplicate)
+    :trust, :allowed_emails, :allowed_domains, :allow_assignments, :chat_poll, :boost_poll, :webhook_check,
+    :allow_duplicate)
 
   def self.start(argv)
     return print_status if argv.include?("--status")
@@ -102,11 +103,13 @@ class BasecampAgentConnector::Connector
     allow_duplicate = false
     chat_poll = BasecampAgentConnector::Basecamp::ChatPoller::DEFAULT_INTERVAL
     boost_poll = BasecampAgentConnector::Basecamp::BoostPoller::DEFAULT_INTERVAL
+    webhook_check = BasecampAgentConnector::Basecamp::WebhookMonitor::DEFAULT_INTERVAL
 
     OptionParser.new do |parser|
       parser.banner = "Usage: connect [@AGENT] [--project PROJECT]... [--repo OWNER/REPO]... [--operator PROFILE] [--gh-operator LOGIN] " \
         "[--trust MODE] [--allow EMAIL]... [--allow-domain DOMAIN]... [--allow-project] " \
-        "[--allow-assignments-from-authorized] [--types TYPES] [--chat-poll SECONDS] [--boost-poll SECONDS] [--no-boosts] [--events EVENTS] [--port PORT]"
+        "[--allow-assignments-from-authorized] [--types TYPES] [--chat-poll SECONDS] [--boost-poll SECONDS] [--no-boosts] " \
+        "[--webhook-check SECONDS] [--events EVENTS] [--port PORT]"
       parser.on("--project PROJECT", "Basecamp project name, URL, or ID (repeatable)") { |value| projects << value }
       parser.on("--repo OWNER/REPO", "GitHub repo to watch for reviews (repeatable)") { |value| repos << value }
       parser.on("--operator PROFILE", "Profile whose user is allowed to trigger (default: CLI default profile)") { |value| operator = value }
@@ -144,6 +147,13 @@ class BasecampAgentConnector::Connector
         boost_poll = value
       end
       parser.on("--no-boosts", "Don't poll the agent's received-boosts feed") { boost_poll = nil }
+      parser.on("--webhook-check SECONDS", Integer, "How often to re-check that each registered webhook is still active " \
+        "and its funnel path still mounted, restoring either (default: " \
+        "#{BasecampAgentConnector::Basecamp::WebhookMonitor::DEFAULT_INTERVAL}s; Basecamp deactivates a webhook after 10 failed deliveries)") do |value|
+        raise ArgumentError, "--webhook-check must be a positive number of seconds" unless value.positive?
+
+        webhook_check = value
+      end
       parser.on("--allow-duplicate", "Start even though another connector is already watching this agent " \
         "on these projects (default: refuse — every event would dispatch twice)") { allow_duplicate = true }
       parser.on("--status", "List the connectors running on this machine and the funnel paths they own, then exit") { }
@@ -162,7 +172,7 @@ class BasecampAgentConnector::Connector
     Options.new(agent: normalize_agent(agent), operator: operator, projects: projects, types: types, repos: repos, events: events_list(events),
       gh_operator: gh_operator, port: port,
       trust: trust, allowed_emails: allowed_emails, allowed_domains: allowed_domains, allow_assignments: allow_assignments,
-      chat_poll: chat_poll, boost_poll: boost_poll, allow_duplicate: allow_duplicate)
+      chat_poll: chat_poll, boost_poll: boost_poll, webhook_check: webhook_check, allow_duplicate: allow_duplicate)
   end
 
   # `--trust MODE` picks the mode explicitly; otherwise the value flags imply
@@ -221,7 +231,7 @@ class BasecampAgentConnector::Connector
         @tunnel = BasecampAgentConnector::Tunnel.new(port: port, paths: paths, command_runner: command_runner)
         @tunnel.start
       end
-    @bridges.each { |bridge| bridge.register(base_url: base_url, orphan_paths: orphan_paths) }
+    @bridges.each { |bridge| bridge.register(base_url: base_url, orphan_paths: orphan_paths, tunnel: @tunnel) }
 
     @server = BasecampAgentConnector::Server.new(port: port, routes: routes)
     install_signal_handlers
@@ -247,6 +257,7 @@ class BasecampAgentConnector::Connector
         authorizer: authorizer(operator, agent), agent: agent,
         projects: @options.projects, types: @options.types,
         chat_poll_interval: @options.chat_poll, boost_poll_interval: @options.boost_poll,
+        webhook_check_interval: @options.webhook_check,
         basecamp_cli: basecamp_cli, emitter: emitter
     end
 

--- a/lib/basecamp_agent_connector/connector.rb
+++ b/lib/basecamp_agent_connector/connector.rb
@@ -231,7 +231,8 @@ class BasecampAgentConnector::Connector
         @tunnel = BasecampAgentConnector::Tunnel.new(port: port, paths: paths, command_runner: command_runner)
         @tunnel.start
       end
-    @bridges.each { |bridge| bridge.register(base_url: base_url, orphan_paths: orphan_paths, tunnel: @tunnel) }
+    @bridges.each { |bridge| bridge.register(base_url: base_url, orphan_paths: orphan_paths) }
+    start_funnel_monitor if @tunnel
 
     @server = BasecampAgentConnector::Server.new(port: port, routes: routes)
     install_signal_handlers
@@ -322,6 +323,7 @@ class BasecampAgentConnector::Connector
     def teardown
       @server&.stop
       @bridges&.each(&:teardown)
+      @funnel_monitor&.stop
       @tunnel&.stop
       @registry.forget
     end
@@ -364,6 +366,13 @@ class BasecampAgentConnector::Connector
         paths: @bridges.flat_map(&:paths), boosts: !@options.boost_poll.nil?
     end
 
+
+    # Every transport's path rides the one funnel, so the funnel is kept
+    # mounted here, on the webhook check's cadence, not per bridge.
+    def start_funnel_monitor
+      @funnel_monitor = BasecampAgentConnector::FunnelMonitor.new(tunnel: @tunnel, interval: @options.webhook_check)
+      @funnel_monitor.start
+    end
 
     def free_port
       socket = TCPServer.new("127.0.0.1", 0)

--- a/lib/basecamp_agent_connector/funnel_monitor.rb
+++ b/lib/basecamp_agent_connector/funnel_monitor.rb
@@ -1,0 +1,63 @@
+# Keeps the run's funnel paths mounted for as long as it runs. A path is
+# mounted once at startup, but a `tailscale funnel reset` by another tool, or
+# a serve config that didn't survive tailscaled, takes it down without a word:
+# the local server keeps listening and nothing reaches it. Basecamp deliveries
+# then fail toward the webhook's deactivation, and GitHub's — which are never
+# redelivered — are simply lost. On an interval the funnel is asked what it
+# serves and any of this run's paths it has lost is remounted, loudly.
+class BasecampAgentConnector::FunnelMonitor
+  def initialize(tunnel:, interval:, logger: $stderr, wait: ->(seconds) { sleep seconds })
+    @tunnel = tunnel
+    @interval = interval
+    @logger = logger
+    @wait = wait
+    @stopping = false
+    @checking = Mutex.new
+  end
+
+  def start
+    @thread = Thread.new { check_loop }
+  end
+
+  # A check in flight finishes before the kill, which then lands in the
+  # interval's sleep — a remount half done at teardown would be undone by
+  # the tunnel's own stop a moment later anyway, but not a remount that
+  # lands after it.
+  def stop
+    @stopping = true
+
+    if @thread
+      @checking.synchronize { @thread.kill }
+      log "funnel check thread did not stop within 5s" if @thread.join(5).nil?
+      @thread = nil
+    end
+  end
+
+  def check
+    @checking.synchronize do
+      unless @stopping
+        @tunnel.remount_missing.each do |path|
+          log "funnel path #{path} was no longer mounted (a `tailscale funnel reset`, or tailscaled lost its serve " \
+            "config); remounted it — deliveries in between failed, and Basecamp deactivates a webhook after 10 of those"
+        end
+      end
+    end
+  end
+
+  private
+    def check_loop
+      until @stopping
+        @wait.call(@interval)
+
+        begin
+          check
+        rescue => error
+          log "funnel check failed: #{error.message}"
+        end
+      end
+    end
+
+    def log(message)
+      @logger.puts message
+    end
+end

--- a/lib/basecamp_agent_connector/github/bridge.rb
+++ b/lib/basecamp_agent_connector/github/bridge.rb
@@ -32,7 +32,10 @@ class BasecampAgentConnector::GitHub::Bridge
     [ path ].compact
   end
 
-  def register(base_url:, orphan_paths: [])
+  # `tunnel` is accepted for parity with the Basecamp bridge and unused:
+  # GitHub never deactivates a hook on its own, so there is nothing to
+  # keep alive here.
+  def register(base_url:, orphan_paths: [], tunnel: nil)
     @webhooks.delete_orphans(repos: @repos, paths: orphan_paths)
 
     endpoint = "#{base_url}#{path}"

--- a/lib/basecamp_agent_connector/github/bridge.rb
+++ b/lib/basecamp_agent_connector/github/bridge.rb
@@ -32,10 +32,7 @@ class BasecampAgentConnector::GitHub::Bridge
     [ path ].compact
   end
 
-  # `tunnel` is accepted for parity with the Basecamp bridge and unused:
-  # GitHub never deactivates a hook on its own, so there is nothing to
-  # keep alive here.
-  def register(base_url:, orphan_paths: [], tunnel: nil)
+  def register(base_url:, orphan_paths: [])
     @webhooks.delete_orphans(repos: @repos, paths: orphan_paths)
 
     endpoint = "#{base_url}#{path}"

--- a/lib/basecamp_agent_connector/tunnel.rb
+++ b/lib/basecamp_agent_connector/tunnel.rb
@@ -21,7 +21,38 @@ class BasecampAgentConnector::Tunnel
     @paths.each { |path| run("funnel", "--set-path", path, "off") }
   end
 
+  # Puts back any of this run's paths the funnel has lost — a `tailscale funnel
+  # reset` by another tool, or a serve config that didn't survive tailscaled —
+  # and returns the paths it remounted. A path still mounted is left alone.
+  def remount_missing
+    missing = @paths - mounted_paths
+    missing.each { |path| mount(path) }
+    missing
+  end
+
   private
+    def mounted_paths
+      result = run("funnel", "status", "--json")
+      raise Error, "`tailscale funnel status` failed: #{result.stderr.strip}" unless result.success?
+
+      handler_paths(result.stdout)
+    end
+
+    # The status lists each served host:port under "Web" with its "Handlers"
+    # keyed by mount path, and under "AllowFunnel" whether that host is on the
+    # public internet at all — a handler still served to the tailnet only is
+    # as deaf to Basecamp as no handler, so it counts as unmounted. A status
+    # that doesn't parse (nothing configured, or a wording change) reads as
+    # nothing mounted: remounting a path that is there is harmless, and not
+    # remounting one that isn't is the outage this exists to end.
+    def handler_paths(status_json)
+      status = JSON.parse(status_json)
+      funneled = Hash(status["Web"]).select { |site, _config| Hash(status["AllowFunnel"])[site] }
+      funneled.values.flat_map { |config| Hash(config["Handlers"]).keys }
+    rescue JSON::ParserError
+      []
+    end
+
     # The funnel strips the mount prefix before proxying, so the target has to
     # carry the path or the local server sees every delivery at "/".
     def mount(path)

--- a/test/basecamp_bridge_test.rb
+++ b/test/basecamp_bridge_test.rb
@@ -132,7 +132,7 @@ class BasecampBridgeTest < Minitest::Test
 
     assert_empty output.string
     assert_match(/could not corroborate event 99001: `basecamp show .*` failed on all 3 attempts.*; answered 503 so Basecamp redelivers/, logs.string)
-    assert_match(/deactivates the webhook after 10 failed deliveries.*basecamp auth status --profile clawdito.*restart/, logs.string)
+    assert_match(/deactivates the webhook after 10 failed deliveries.*basecamp auth status --profile clawdito.*reactivates the webhook/, logs.string)
     refute_match(/not corroborated/, logs.string)
   end
 
@@ -219,6 +219,52 @@ class BasecampBridgeTest < Minitest::Test
     refute_match(/received-boosts feed/, logs.string)
   end
 
+  def test_register_starts_the_webhook_monitor_and_logs_after_the_readiness_line
+    runner = FakeCommandRunner.new
+    runner.stub "webhooks create", stdout: envelope("id" => 555)
+    runner.stub "webhooks delete", exit_status: 0
+    logs = StringIO.new
+    bridge = bridge(runner, logger: logs, webhook_check_interval: 300)
+
+    bridge.register(base_url: "https://host.ts.net")
+
+    listening = logs.string.index("Listening for mentions")
+    checking = logs.string.index("Re-checking those webhooks every 300s")
+    refute_nil checking
+    assert_operator listening, :<, checking
+    # The first check is an interval away, so registration is settled before
+    # anything re-reads it.
+    assert_empty runner.commands_matching(/webhooks show/)
+  ensure
+    bridge.teardown
+  end
+
+  def test_a_nil_webhook_check_interval_disables_the_monitor
+    runner = FakeCommandRunner.new
+    runner.stub "webhooks create", stdout: envelope("id" => 555)
+    runner.stub "webhooks delete", exit_status: 0
+    logs = StringIO.new
+    bridge = bridge(runner, logger: logs, webhook_check_interval: nil)
+
+    bridge.register(base_url: "https://host.ts.net")
+    bridge.teardown
+
+    refute_match(/Re-checking/, logs.string)
+  end
+
+  # No registrations, nothing to keep alive.
+  def test_a_chat_only_bridge_starts_no_webhook_monitor
+    runner = FakeCommandRunner.new
+    runner.stub "chat list", stdout: envelope([ chat_hash ])
+    logs = StringIO.new
+    bridge = bridge(runner, types: "Chat::Line", logger: logs, webhook_check_interval: 300)
+
+    bridge.register(base_url: "https://host.ts.net")
+    bridge.teardown
+
+    refute_match(/Re-checking/, logs.string)
+  end
+
   def test_handler_refuses_boost_kind_webhook_payloads
     runner = FakeCommandRunner.new
     output = StringIO.new
@@ -238,7 +284,7 @@ class BasecampBridgeTest < Minitest::Test
     end
 
     def bridge(runner, projects: [ "A" ], types: "Comment", logger: StringIO.new, output: StringIO.new,
-      boost_poll_interval: nil)
+      boost_poll_interval: nil, webhook_check_interval: nil)
       BasecampAgentConnector::Basecamp::Bridge.new \
         authorizer: authorizer,
         agent: agent_identity,
@@ -247,6 +293,7 @@ class BasecampBridgeTest < Minitest::Test
         basecamp_cli: build_cli(runner),
         emitter: BasecampAgentConnector::Emitter.new(output: output),
         logger: logger,
-        boost_poll_interval: boost_poll_interval
+        boost_poll_interval: boost_poll_interval,
+        webhook_check_interval: webhook_check_interval
     end
 end

--- a/test/connector_test.rb
+++ b/test/connector_test.rb
@@ -79,6 +79,17 @@ class ConnectorTest < Minitest::Test
     end
   end
 
+  def test_parses_the_webhook_check_interval
+    assert_equal 300, parse("@clawdito", "--project", "A").webhook_check
+    assert_equal 60, parse("@clawdito", "--project", "A", "--webhook-check", "60").webhook_check
+  end
+
+  def test_refuses_a_non_positive_webhook_check_interval
+    assert_raises ArgumentError do
+      parse "@clawdito", "--project", "A", "--webhook-check", "0"
+    end
+  end
+
   def test_refuses_value_flags_that_imply_different_trust_modes
     assert_raises ArgumentError do
       parse "@clawdito", "--project", "A", "--allow", "marie@example.com", "--allow-domain", "example.com"

--- a/test/funnel_monitor_test.rb
+++ b/test/funnel_monitor_test.rb
@@ -1,0 +1,78 @@
+require "test_helper"
+
+class FunnelMonitorTest < Minitest::Test
+  def setup
+    @logs = StringIO.new
+  end
+
+  def test_check_remounts_a_lost_path_and_says_so
+    runner = FakeCommandRunner.new
+    runner.stub "funnel status --json", stdout: "{}"
+    runner.stub "--set-path", exit_status: 0
+
+    monitor(runner).check
+
+    assert_equal [ [ "tailscale", "funnel", "--bg", "--set-path", "/bc5/abc", "http://127.0.0.1:4567/bc5/abc" ] ],
+      runner.commands_matching(/set-path/)
+    assert_match(%r{funnel path /bc5/abc was no longer mounted.*remounted it}, @logs.string)
+  end
+
+  def test_check_is_quiet_when_the_funnel_is_healthy
+    runner = FakeCommandRunner.new
+    runner.stub "funnel status --json", stdout: funnel_status("/bc5/abc")
+
+    monitor(runner).check
+
+    assert_empty @logs.string
+    assert_empty runner.commands_matching(/set-path/)
+  end
+
+  def test_start_checks_nothing_before_the_first_interval_and_stop_ends_the_thread
+    runner = FakeCommandRunner.new
+    runner.stub "funnel status --json", stdout: funnel_status("/bc5/abc")
+    ticks = Queue.new
+    monitor = monitor(runner, wait: ->(_seconds) { ticks.pop })
+
+    monitor.start
+    assert_empty runner.commands
+
+    2.times { ticks << true }
+    deadline = Time.now + 2
+    sleep 0.01 while runner.commands_matching(/funnel status/).empty? && Time.now < deadline
+    refute_empty runner.commands_matching(/funnel status/)
+
+    monitor.stop
+    refute monitor.instance_variable_get(:@thread)
+  end
+
+  def test_the_check_thread_survives_a_funnel_that_cannot_be_asked
+    runner = FakeCommandRunner.new
+    runner.stub "funnel status --json", exit_status: 1, stderr: "tailscaled is not running", once: true
+    runner.stub "funnel status --json", stdout: funnel_status("/bc5/abc")
+    ticks = Queue.new
+    monitor = monitor(runner, wait: ->(_seconds) { ticks.pop })
+
+    monitor.start
+    2.times { ticks << true }
+    deadline = Time.now + 2
+    sleep 0.01 while runner.commands_matching(/funnel status/).length < 2 && Time.now < deadline
+
+    assert_equal 2, runner.commands_matching(/funnel status/).length
+    assert_match(/funnel check failed: `tailscale funnel status` failed: tailscaled is not running/, @logs.string)
+    assert_predicate monitor.instance_variable_get(:@thread), :alive?
+  ensure
+    monitor&.stop
+  end
+
+  private
+    def monitor(runner, wait: ->(_seconds) { })
+      tunnel = BasecampAgentConnector::Tunnel.new(port: 4567, paths: [ "/bc5/abc" ], command_runner: runner)
+      BasecampAgentConnector::FunnelMonitor.new(tunnel: tunnel, interval: 300, logger: @logs, wait: wait)
+    end
+
+    def funnel_status(*paths)
+      handlers = paths.to_h { |path| [ path, { "Proxy" => "http://127.0.0.1:4567#{path}" } ] }
+      JSON.generate("Web" => { "host.example.ts.net:443" => { "Handlers" => handlers } },
+        "AllowFunnel" => { "host.example.ts.net:443" => true })
+    end
+end

--- a/test/tunnel_test.rb
+++ b/test/tunnel_test.rb
@@ -24,6 +24,55 @@ class TunnelTest < Minitest::Test
     end
   end
 
+  def test_remount_missing_remounts_only_the_paths_the_funnel_lost
+    runner = FakeCommandRunner.new
+    runner.stub "funnel status --json", stdout: funnel_status("/bc5/abc", "/someone/elses")
+    runner.stub "--set-path", exit_status: 0
+
+    remounted = tunnel(runner, paths: [ "/bc5/abc", "/gh/def" ]).remount_missing
+
+    assert_equal [ "/gh/def" ], remounted
+    assert_equal [ [ "tailscale", "funnel", "--bg", "--set-path", "/gh/def", "http://127.0.0.1:4567/gh/def" ] ],
+      runner.commands_matching(/set-path/)
+  end
+
+  def test_remount_missing_leaves_a_healthy_funnel_alone
+    runner = FakeCommandRunner.new
+    runner.stub "funnel status --json", stdout: funnel_status("/bc5/abc")
+
+    assert_empty tunnel(runner, paths: [ "/bc5/abc" ]).remount_missing
+    assert_empty runner.commands_matching(/set-path/)
+  end
+
+  # A status that isn't the JSON document (no serve config at all, say) can't
+  # prove anything is mounted, and remounting a mounted path is harmless.
+  # `tailscale funnel reset` leaves nothing; `tailscale serve` keeps the
+  # handler but takes it off the internet. Both are outages here.
+  def test_remount_missing_treats_a_path_served_without_funnel_as_lost
+    runner = FakeCommandRunner.new
+    runner.stub "funnel status --json", stdout: funnel_status("/bc5/abc", allow_funnel: false)
+    runner.stub "--set-path", exit_status: 0
+
+    assert_equal [ "/bc5/abc" ], tunnel(runner, paths: [ "/bc5/abc" ]).remount_missing
+  end
+
+  def test_remount_missing_reads_an_unparseable_status_as_nothing_mounted
+    runner = FakeCommandRunner.new
+    runner.stub "funnel status --json", stdout: "No serve config\n"
+    runner.stub "--set-path", exit_status: 0
+
+    assert_equal [ "/bc5/abc" ], tunnel(runner, paths: [ "/bc5/abc" ]).remount_missing
+  end
+
+  def test_remount_missing_raises_when_status_cannot_be_read
+    runner = FakeCommandRunner.new
+    runner.stub "funnel status --json", exit_status: 1, stderr: "tailscaled is not running"
+
+    assert_raises BasecampAgentConnector::Tunnel::Error do
+      tunnel(runner, paths: [ "/bc5/abc" ]).remount_missing
+    end
+  end
+
   def test_stop_unmounts_each_path_and_never_resets_the_funnel
     runner = FakeCommandRunner.new
     runner.stub "tailscale funnel", exit_status: 0
@@ -36,4 +85,17 @@ class TunnelTest < Minitest::Test
     ], runner.commands_matching(/funnel/)
     assert_empty runner.commands_matching(/reset/)
   end
+
+  private
+    def tunnel(runner, paths:)
+      BasecampAgentConnector::Tunnel.new(port: 4567, paths: paths, command_runner: runner)
+    end
+
+    # `tailscale funnel status --json`: handlers keyed by mount path under
+    # each served host:port (verified against a live funnel).
+    def funnel_status(*paths, allow_funnel: true)
+      handlers = paths.to_h { |path| [ path, { "Proxy" => "http://127.0.0.1:4567#{path}" } ] }
+      JSON.generate("Web" => { "host.example.ts.net:443" => { "Handlers" => handlers } },
+        "AllowFunnel" => { "host.example.ts.net:443" => allow_funnel })
+    end
 end

--- a/test/webhook_monitor_test.rb
+++ b/test/webhook_monitor_test.rb
@@ -1,0 +1,128 @@
+require "test_helper"
+
+class WebhookMonitorTest < Minitest::Test
+  def setup
+    @logs = StringIO.new
+  end
+
+  def test_check_remounts_the_funnel_and_then_restores_the_webhooks
+    runner = FakeCommandRunner.new
+    runner.stub "funnel status --json", stdout: "{}"
+    runner.stub "--set-path", exit_status: 0
+    runner.stub "webhooks show 555", stdout: envelope("id" => 555, "active" => false)
+    runner.stub "webhooks update 555", stdout: envelope("id" => 555, "active" => true)
+
+    monitor(runner, tunnel: tunnel(runner)).check
+
+    remounted = runner.commands.index { |command| command.include?("--set-path") }
+    reactivated = runner.commands.index { |command| command.include?("update") }
+    assert_operator remounted, :<, reactivated
+    assert_match(%r{funnel path /bc5/abc was no longer mounted.*remounted it}, @logs.string)
+    assert_match(/webhook 555 on project 1 was DEACTIVATED by Basecamp.*Reactivated it in place/, @logs.string)
+  end
+
+  def test_check_is_quiet_when_everything_is_in_place
+    runner = FakeCommandRunner.new
+    runner.stub "funnel status --json", stdout: funnel_status("/bc5/abc")
+    runner.stub "webhooks show 555", stdout: envelope("id" => 555, "active" => true)
+
+    monitor(runner, tunnel: tunnel(runner)).check
+
+    assert_empty @logs.string
+    assert_empty runner.commands_matching(/set-path|webhooks update/)
+  end
+
+  def test_check_still_restores_the_webhooks_when_the_funnel_cannot_be_asked
+    runner = FakeCommandRunner.new
+    runner.stub "funnel status --json", exit_status: 1, stderr: "tailscaled is not running"
+    runner.stub "webhooks show 555", stdout: envelope("id" => 555, "active" => false)
+    runner.stub "webhooks update 555", stdout: envelope("id" => 555, "active" => true)
+
+    monitor(runner, tunnel: tunnel(runner)).check
+
+    assert_match(/funnel check failed: `tailscale funnel status` failed: tailscaled is not running/, @logs.string)
+    assert_equal 1, runner.commands_matching(/webhooks update 555/).length
+  end
+
+  def test_check_without_a_tunnel_only_restores_the_webhooks
+    runner = FakeCommandRunner.new
+    runner.stub "webhooks show 555", stdout: envelope("id" => 555, "active" => true)
+
+    monitor(runner, tunnel: nil).check
+
+    assert_empty runner.commands_matching(/tailscale/)
+    assert_equal 1, runner.commands_matching(/webhooks show 555/).length
+  end
+
+  def test_start_checks_nothing_before_the_first_interval_and_stop_ends_the_thread
+    runner = FakeCommandRunner.new
+    runner.stub "webhooks show 555", stdout: envelope("id" => 555, "active" => true)
+    ticks = Queue.new
+    monitor = monitor(runner, wait: ->(_seconds) { ticks.pop })
+
+    monitor.start
+    assert_empty runner.commands_matching(/webhooks show/)
+
+    2.times { ticks << true }
+    deadline = Time.now + 2
+    sleep 0.01 while runner.commands_matching(/webhooks show/).empty? && Time.now < deadline
+    refute_empty runner.commands_matching(/webhooks show/)
+
+    monitor.stop
+    refute monitor.instance_variable_get(:@thread)
+  end
+
+  def test_the_check_thread_survives_an_exception_escaping_a_check
+    runner = FakeCommandRunner.new
+    runner.stub "webhooks show 555", stdout: envelope("id" => 555, "active" => true)
+    ticks = Queue.new
+    checked = Queue.new
+    monitor = monitor(runner, wait: ->(_seconds) { ticks.pop })
+    attempts = 0
+    monitor.define_singleton_method(:check) do
+      attempts += 1
+      checked << attempts
+      raise "surprise" if attempts == 1
+      super()
+    end
+
+    monitor.start
+    ticks << true
+    ticks << true
+    checked.pop until attempts >= 2
+
+    assert_match(/webhook check failed: surprise/, @logs.string)
+    assert_predicate monitor.instance_variable_get(:@thread), :alive?
+  ensure
+    monitor&.stop
+  end
+
+  private
+    def monitor(runner, tunnel: nil, wait: ->(_seconds) { })
+      BasecampAgentConnector::Basecamp::WebhookMonitor.new \
+        webhooks: registered_webhooks(runner),
+        url: "https://host.example.ts.net/bc5/abc",
+        types: "Comment",
+        tunnel: tunnel,
+        interval: 300,
+        logger: @logs,
+        wait: wait
+    end
+
+    def registered_webhooks(runner)
+      runner.stub "webhooks create", stdout: envelope("id" => 555)
+      BasecampAgentConnector::Basecamp::Webhooks.new(basecamp_cli: build_cli(runner), logger: @logs, wait: ->(_seconds) { }).tap do |webhooks|
+        webhooks.register_all(projects: [ 1 ], url: "https://host.example.ts.net/bc5/abc", types: "Comment")
+      end
+    end
+
+    def tunnel(runner)
+      BasecampAgentConnector::Tunnel.new(port: 4567, paths: [ "/bc5/abc" ], command_runner: runner)
+    end
+
+    def funnel_status(*paths)
+      handlers = paths.to_h { |path| [ path, { "Proxy" => "http://127.0.0.1:4567#{path}" } ] }
+      JSON.generate("Web" => { "host.example.ts.net:443" => { "Handlers" => handlers } },
+        "AllowFunnel" => { "host.example.ts.net:443" => true })
+    end
+end

--- a/test/webhook_monitor_test.rb
+++ b/test/webhook_monitor_test.rb
@@ -5,53 +5,25 @@ class WebhookMonitorTest < Minitest::Test
     @logs = StringIO.new
   end
 
-  def test_check_remounts_the_funnel_and_then_restores_the_webhooks
+  def test_check_restores_the_registrations
     runner = FakeCommandRunner.new
-    runner.stub "funnel status --json", stdout: "{}"
-    runner.stub "--set-path", exit_status: 0
     runner.stub "webhooks show 555", stdout: envelope("id" => 555, "active" => false)
     runner.stub "webhooks update 555", stdout: envelope("id" => 555, "active" => true)
 
-    monitor(runner, tunnel: tunnel(runner)).check
+    monitor(runner).check
 
-    remounted = runner.commands.index { |command| command.include?("--set-path") }
-    reactivated = runner.commands.index { |command| command.include?("update") }
-    assert_operator remounted, :<, reactivated
-    assert_match(%r{funnel path /bc5/abc was no longer mounted.*remounted it}, @logs.string)
+    assert_equal 1, runner.commands_matching(/webhooks update 555/).length
     assert_match(/webhook 555 on project 1 was DEACTIVATED by Basecamp.*Reactivated it in place/, @logs.string)
   end
 
   def test_check_is_quiet_when_everything_is_in_place
     runner = FakeCommandRunner.new
-    runner.stub "funnel status --json", stdout: funnel_status("/bc5/abc")
     runner.stub "webhooks show 555", stdout: envelope("id" => 555, "active" => true)
 
-    monitor(runner, tunnel: tunnel(runner)).check
+    monitor(runner).check
 
     assert_empty @logs.string
-    assert_empty runner.commands_matching(/set-path|webhooks update/)
-  end
-
-  def test_check_still_restores_the_webhooks_when_the_funnel_cannot_be_asked
-    runner = FakeCommandRunner.new
-    runner.stub "funnel status --json", exit_status: 1, stderr: "tailscaled is not running"
-    runner.stub "webhooks show 555", stdout: envelope("id" => 555, "active" => false)
-    runner.stub "webhooks update 555", stdout: envelope("id" => 555, "active" => true)
-
-    monitor(runner, tunnel: tunnel(runner)).check
-
-    assert_match(/funnel check failed: `tailscale funnel status` failed: tailscaled is not running/, @logs.string)
-    assert_equal 1, runner.commands_matching(/webhooks update 555/).length
-  end
-
-  def test_check_without_a_tunnel_only_restores_the_webhooks
-    runner = FakeCommandRunner.new
-    runner.stub "webhooks show 555", stdout: envelope("id" => 555, "active" => true)
-
-    monitor(runner, tunnel: nil).check
-
-    assert_empty runner.commands_matching(/tailscale/)
-    assert_equal 1, runner.commands_matching(/webhooks show 555/).length
+    assert_empty runner.commands_matching(/webhooks update/)
   end
 
   def test_start_checks_nothing_before_the_first_interval_and_stop_ends_the_thread
@@ -70,6 +42,36 @@ class WebhookMonitorTest < Minitest::Test
 
     monitor.stop
     refute monitor.instance_variable_get(:@thread)
+  end
+
+  # Killed mid-restore, the thread would leave a replacement Basecamp created
+  # but the registrations never recorded; stop waits for the check instead,
+  # so teardown deletes the replacement and not the id it replaced.
+  def test_stop_lets_a_check_in_flight_finish_so_teardown_deletes_what_it_registered
+    runner = PausingCommandRunner.new(/webhooks create/)
+    webhooks = registered_webhooks(runner)
+    runner.stub "webhooks create", stdout: envelope("id" => 556)
+    runner.stub "webhooks show 555", stdout: error_envelope("not_found", "Resource not found: webhook 555"), exit_status: 2
+    runner.stub "webhooks delete", exit_status: 0
+    ticks = Queue.new
+    monitor = monitor(runner, webhooks: webhooks, wait: ->(_seconds) { ticks.pop })
+    runner.arm
+
+    monitor.start
+    ticks << true
+    runner.paused.pop
+    stopper = Thread.new { monitor.stop }
+    sleep 0.05
+    assert_predicate stopper, :alive?
+
+    runner.resume << true
+    stopper.join(2)
+    refute_predicate stopper, :alive?
+    webhooks.delete_all
+
+    deletions = runner.commands_matching(/webhooks delete/)
+    assert_equal 1, deletions.length
+    assert_includes deletions.first, "556"
   end
 
   def test_the_check_thread_survives_an_exception_escaping_a_check
@@ -97,32 +99,48 @@ class WebhookMonitorTest < Minitest::Test
     monitor&.stop
   end
 
+  # Once armed, blocks inside the matching command until released, to hold a
+  # check in flight.
+  class PausingCommandRunner < FakeCommandRunner
+    attr_reader :paused, :resume
+
+    def initialize(pattern)
+      super()
+      @pattern = pattern
+      @armed = false
+      @paused = Queue.new
+      @resume = Queue.new
+    end
+
+    def arm
+      @armed = true
+    end
+
+    def run(*command)
+      if @armed && command.join(" ").match?(@pattern)
+        @paused << true
+        @resume.pop
+      end
+
+      super
+    end
+  end
+
   private
-    def monitor(runner, tunnel: nil, wait: ->(_seconds) { })
+    def monitor(runner, webhooks: registered_webhooks(runner), wait: ->(_seconds) { })
       BasecampAgentConnector::Basecamp::WebhookMonitor.new \
-        webhooks: registered_webhooks(runner),
+        webhooks: webhooks,
         url: "https://host.example.ts.net/bc5/abc",
         types: "Comment",
-        tunnel: tunnel,
         interval: 300,
         logger: @logs,
         wait: wait
     end
 
     def registered_webhooks(runner)
-      runner.stub "webhooks create", stdout: envelope("id" => 555)
+      runner.stub "webhooks create", stdout: envelope("id" => 555), once: true
       BasecampAgentConnector::Basecamp::Webhooks.new(basecamp_cli: build_cli(runner), logger: @logs, wait: ->(_seconds) { }).tap do |webhooks|
         webhooks.register_all(projects: [ 1 ], url: "https://host.example.ts.net/bc5/abc", types: "Comment")
       end
-    end
-
-    def tunnel(runner)
-      BasecampAgentConnector::Tunnel.new(port: 4567, paths: [ "/bc5/abc" ], command_runner: runner)
-    end
-
-    def funnel_status(*paths)
-      handlers = paths.to_h { |path| [ path, { "Proxy" => "http://127.0.0.1:4567#{path}" } ] }
-      JSON.generate("Web" => { "host.example.ts.net:443" => { "Handlers" => handlers } },
-        "AllowFunnel" => { "host.example.ts.net:443" => true })
     end
 end

--- a/test/webhooks_test.rb
+++ b/test/webhooks_test.rb
@@ -178,6 +178,25 @@ class WebhooksTest < Minitest::Test
     assert_includes runner.commands_matching(/webhooks delete/).first, "555"
   end
 
+  def test_restore_keeps_a_registration_it_could_not_replace_and_says_so
+    runner = FakeCommandRunner.new
+    runner.stub "webhooks create", stdout: envelope("id" => 555), once: true
+    runner.stub "webhooks create", exit_status: 1, stdout: '{"ok":false,"error":"400 Bad Request"}'
+    runner.stub "webhooks show 555", stdout: error_envelope("not_found", "Resource not found: webhook 555"), exit_status: 2
+    runner.stub "webhooks delete", exit_status: 0
+    logs = StringIO.new
+    webhooks = webhooks(runner, logs)
+    webhooks.register_all(projects: [ 1 ], url: hook_url, types: "Comment")
+
+    restored = webhooks.restore(url: hook_url, types: "Comment")
+    webhooks.delete_all
+
+    assert_empty restored
+    assert_equal 4, runner.commands_matching(/webhooks create/).length
+    assert_match(/webhook 555 on project 1 is gone .* re-registering failed after 3 attempts: .*; retrying on the next check/, logs.string)
+    assert_includes runner.commands_matching(/webhooks delete/).first, "555"
+  end
+
   def test_restore_continues_past_a_webhook_it_could_not_check
     runner = FakeCommandRunner.new
     runner.stub(/webhooks create .*--project 1\b/, stdout: envelope("id" => 555))

--- a/test/webhooks_test.rb
+++ b/test/webhooks_test.rb
@@ -104,6 +104,97 @@ class WebhooksTest < Minitest::Test
     assert_match(/could not list webhooks for project 7/, logs.string)
   end
 
+  def test_restore_reactivates_a_webhook_basecamp_deactivated
+    runner = FakeCommandRunner.new
+    runner.stub "webhooks create", stdout: envelope("id" => 555)
+    runner.stub "webhooks show 555", stdout: envelope("id" => 555, "active" => false)
+    runner.stub "webhooks update 555", stdout: envelope("id" => 555, "active" => true)
+    logs = StringIO.new
+    webhooks = webhooks(runner, logs)
+    webhooks.register_all(projects: [ 1 ], url: hook_url, types: "Comment")
+
+    restored = webhooks.restore(url: hook_url, types: "Comment")
+
+    assert_equal [ 555 ], restored.map(&:id)
+    assert_equal [ [ "basecamp", "webhooks", "update", "555", "--project", "1", "--active", "-j" ] ],
+      runner.commands_matching(/webhooks update/)
+    assert_match(/webhook 555 on project 1 was DEACTIVATED by Basecamp.*10 failed deliveries.*Reactivated it in place/, logs.string)
+  end
+
+  def test_restore_leaves_an_active_webhook_alone
+    runner = FakeCommandRunner.new
+    runner.stub "webhooks create", stdout: envelope("id" => 555)
+    runner.stub "webhooks show 555", stdout: envelope("id" => 555, "active" => true)
+    logs = StringIO.new
+    webhooks = webhooks(runner, logs)
+    webhooks.register_all(projects: [ 1 ], url: hook_url, types: "Comment")
+
+    restored = webhooks.restore(url: hook_url, types: "Comment")
+
+    assert_empty restored
+    assert_empty runner.commands_matching(/webhooks update/)
+    assert_equal 1, runner.commands_matching(/webhooks create/).length
+    assert_empty logs.string
+  end
+
+  # Someone cleaned up by hand (the README's manual-cleanup recipe on the
+  # wrong id, say): Basecamp has nothing to reactivate, so a fresh
+  # registration replaces it, and teardown deletes the replacement.
+  def test_restore_re_registers_a_webhook_deleted_out_from_under_it
+    runner = FakeCommandRunner.new
+    runner.stub "webhooks create", stdout: envelope("id" => 555), once: true
+    runner.stub "webhooks create", stdout: envelope("id" => 556)
+    runner.stub "webhooks show 555", stdout: error_envelope("not_found", "Resource not found: webhook 555"), exit_status: 2
+    runner.stub "webhooks delete", exit_status: 0
+    logs = StringIO.new
+    webhooks = webhooks(runner, logs)
+    webhooks.register_all(projects: [ 1 ], url: hook_url, types: "Comment")
+
+    restored = webhooks.restore(url: hook_url, types: "Comment")
+    webhooks.delete_all
+
+    assert_equal [ 556 ], restored.map(&:id)
+    assert_match(/webhook 555 on project 1 is gone \(deleted outside this connector\); re-registered it as 556/, logs.string)
+    deletions = runner.commands_matching(/webhooks delete/)
+    assert_equal 1, deletions.length
+    assert_includes deletions.first, "556"
+  end
+
+  def test_restore_keeps_a_registration_it_could_not_reactivate_and_says_so
+    runner = FakeCommandRunner.new
+    runner.stub "webhooks create", stdout: envelope("id" => 555)
+    runner.stub "webhooks show 555", stdout: envelope("id" => 555, "active" => false)
+    runner.stub "webhooks update 555", stdout: error_envelope("api_error", "The webhook limit for this project has been reached"), exit_status: 1
+    runner.stub "webhooks delete", exit_status: 0
+    logs = StringIO.new
+    webhooks = webhooks(runner, logs)
+    webhooks.register_all(projects: [ 1 ], url: hook_url, types: "Comment")
+
+    restored = webhooks.restore(url: hook_url, types: "Comment")
+    webhooks.delete_all
+
+    assert_empty restored
+    assert_match(/was DEACTIVATED by Basecamp.*Failed to reactivate it: .*webhook limit.*; retrying on the next check/, logs.string)
+    assert_includes runner.commands_matching(/webhooks delete/).first, "555"
+  end
+
+  def test_restore_continues_past_a_webhook_it_could_not_check
+    runner = FakeCommandRunner.new
+    runner.stub(/webhooks create .*--project 1\b/, stdout: envelope("id" => 555))
+    runner.stub(/webhooks create .*--project 2\b/, stdout: envelope("id" => 556))
+    stub_transient_failure runner, "webhooks show 555"
+    runner.stub "webhooks show 556", stdout: envelope("id" => 556, "active" => false)
+    runner.stub "webhooks update 556", stdout: envelope("id" => 556, "active" => true)
+    logs = StringIO.new
+    webhooks = webhooks(runner, logs)
+    webhooks.register_all(projects: [ 1, 2 ], url: hook_url, types: "Comment")
+
+    restored = webhooks.restore(url: hook_url, types: "Comment")
+
+    assert_equal [ 556 ], restored.map(&:id)
+    assert_match(/could not check webhook 555 on project 1/, logs.string)
+  end
+
   private
     def webhooks(runner, logs = StringIO.new)
       BasecampAgentConnector::Basecamp::Webhooks.new(basecamp_cli: build_cli(runner), logger: logs, wait: ->(_seconds) { })


### PR DESCRIPTION
## The gap

bc3 deactivates a webhook after 10 failed deliveries and never says so. In `app/jobs/webhook/delivery_job.rb`:

```ruby
retry_on(Webhook::Delivery::Error, wait: :polynomially_longer, attempts: 10, queue: :webhook_retries) { |job, error| job.deactivate_webhook }
discard_on(RestrictedHTTP::Violation) do |job, error| ... job.deactivate_webhook end
```

`Webhook#deactivate` is `update_columns active: false`; `Webhook.relay_to_matches_later` only selects `active` webhooks, and `DeliveryJob#perform` skips an inactive one. Ten polynomial waits add up to about four to five hours, after which the registration is still listed but nothing is delivered to it again.

The connector registered one webhook per project at startup and tore it down at exit, but never re-checked it. A laptop asleep overnight, a Tailscale funnel path that dropped, or a run answering `503` to every delivery (revoked credential, keyring race) all ended the same way: deaf to every mention until someone restarted `bin/connect`, while the chat and boost pollers kept it looking healthy. Nothing logged it.

## What this does

Two small keep-alive threads (same shape as the chat/boost pollers), both on the `--webhook-check` cadence, default **300s**:

**`FunnelMonitor`** — owned by the connector, started whenever any path is mounted (so GitHub-only runs are covered too). `tailscale funnel status --json`; any of the run's paths that is missing — or still served but with `AllowFunnel` off — is remounted with the same `funnel --bg --set-path` as startup. Without it, Basecamp deliveries fail toward the deactivation above and GitHub's, which are never redelivered, are simply lost.

**`Basecamp::WebhookMonitor`** — owned by the Basecamp bridge. `basecamp webhooks show <id> --project <p>` for each registration:
- `active: false` → **reactivated in place**: `basecamp webhooks update <id> --active`. bc3's `WebhooksController#webhook_params` permits `:active`, and `payload_url_must_be_secure_and_public` only re-runs when the URL changes, so the PUT keeps the id the run recorded (and the run registry's paths stay true).
- `not_found` (deleted by hand — the README's manual-cleanup recipe on the wrong id, say) → re-registered under a new id, which replaces the recorded one so teardown deletes the right thing.
- Anything else → logged, left alone, tried again next check.

Every finding is logged to STDERR in one loud line naming the likely cause (`was DEACTIVATED by Basecamp: bc3 switches a webhook off after 10 failed deliveries ... this machine asleep, the Tailscale funnel path dropped, or every delivery answered 503`) and what was done. A quiet check logs nothing.

Both monitors let a check in flight finish before their thread is killed at teardown, so a replacement webhook Basecamp created mid-restore is always recorded (and deleted) rather than leaked; the kill only ever lands in the interval's sleep.

Reactivate-in-place was chosen over delete-and-re-register because the deactivation is one flag, the API supports flipping it back, and it keeps the recorded id stable; re-registration is the fallback only for a webhook that no longer exists.

## Verifying

```bash
bin/connect @clawdito --project "<project>" --webhook-check 30
# in another shell, simulate what bc3 does after 10 failures:
basecamp webhooks list --project "<project>" -j          # find the connector's id
basecamp webhooks update <id> --inactive --project "<project>"
# within 30s the connector logs "webhook <id> on project ... was DEACTIVATED by Basecamp ... Reactivated it in place."
basecamp webhooks show <id> --project "<project>" -j     # active: true again
# and for the funnel:
tailscale funnel --set-path /bc5/<secret> off
# within 30s: "funnel path /bc5/<secret> was no longer mounted ... remounted it"
```

Tests cover every branch through `FakeCommandRunner` (no network): 353 runs, up from 328.
