### PR TITLE
Force UTF-8 encoding on command output

### DIFF
--- a/lib/basecamp_agent_connector/command_runner.rb
+++ b/lib/basecamp_agent_connector/command_runner.rb
@@ -9,6 +9,6 @@ class BasecampAgentConnector::CommandRunner
 
   def run(*command)
     stdout, stderr, status = Open3.capture3(*command)
-    Result.new(stdout: stdout, stderr: stderr, exit_status: status.exitstatus)
+    Result.new(stdout: stdout.force_encoding(Encoding::UTF_8), stderr: stderr.force_encoding(Encoding::UTF_8), exit_status: status.exitstatus)
   end
 end

--- a/test/command_runner_test.rb
+++ b/test/command_runner_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class CommandRunnerTest < Minitest::Test
+  def test_reads_utf_8_output_when_the_locale_is_ascii
+    result = BasecampAgentConnector::CommandRunner.new.run(
+      { "LC_ALL" => "C" }, Gem.ruby, "-e", 'STDOUT.write("{\"name\":\"Kim\xC3\xA9\"}")'
+    )
+
+    assert_equal Encoding::UTF_8, result.stdout.encoding
+    assert_equal "Kimé", JSON.parse(result.stdout).fetch("name")
+  end
+end


### PR DESCRIPTION
## Bug
`Open3.capture3` returns `ASCII-8BIT` strings when the child emits non-ASCII bytes. Any later regex/interpolation on them raises `Encoding::CompatibilityError`.

## Fix
Coerce `stdout`/`stderr` to UTF-8 in `CommandRunner#run` — the one place all callers route through.

## Test
`test/command_runner_test.rb` asserts non-ASCII output comes back as UTF-8.